### PR TITLE
Fix org in git string example on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Welcome to the **aleonard.us-api** repository! This project provides a robust an
 1. **Clone the Repository**
 
    ```bash
-   git clone https://github.com/yourusername/aleonard.us-api.git
+   git clone https://github.com/ALeonard9/aleonard.us-api.git
    cd aleonard.us-api
 
 2. **Create Virtual Environment**


### PR DESCRIPTION
Fixes #21

Update the git clone command in the `README.md` file to use the correct organization name `ALeonard9`.

* Change the git clone command from `https://github.com/yourusername/aleonard.us-api.git` to `https://github.com/ALeonard9/aleonard.us-api.git` in the `README.md` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ALeonard9/aleonard.us-api/pull/22?shareId=fa1a2754-d00b-4fe5-9e7b-73e7baa175c0).