### PR TITLE
fix: add xz to apk deps to resolve SNYK-ALPINE323-XZ-16321164

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN apk update && apk add --no-cache \
     python3-dev \
     musl-dev \
     rust \
-    cargo
+    cargo \
+    xz
 
 # Switch to non-root user for pip operations
 USER adam


### PR DESCRIPTION
The python:3.13-alpine base image's bundled xz package has a heap-based buffer overflow (medium severity). Explicitly adding xz to apk add pulls in the latest patched version from Alpine 3.23 repos.