### PR TITLE
Fix Snyk-flagged dependency and code scanning vulnerabilities

### DIFF
--- a/app/auth/oauth2.py
+++ b/app/auth/oauth2.py
@@ -3,6 +3,7 @@ This module creates access tokens and verifys tokens.
 """
 
 import os
+import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
@@ -18,13 +19,15 @@ from app.log.logging_config import logger
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl='v1/auth/token')
 
 # openssl rand -hex 32 to generate new secret key
-# Get secret key from environment with a default for tests
-SECRET_KEY = (
-    os.getenv('JWT_SECRET_KEY')
-    or 'test_secret_key_which_must_be_at_least_32_bytes_long'
-)
-if SECRET_KEY == 'test_secret_key_which_must_be_at_least_32_bytes_long':
-    logger.warning('Using default test secret key for JWT.')
+# Get secret key from environment; if unset, generate a random one so that
+# no fixed, guessable key can ever be used to sign or verify tokens.
+SECRET_KEY = os.getenv('JWT_SECRET_KEY') or secrets.token_hex(32)
+if not os.getenv('JWT_SECRET_KEY'):
+    logger.warning(
+        'JWT_SECRET_KEY not set; using a randomly generated key for this '
+        'process. Tokens will not persist across restarts or be shared '
+        'across workers.'
+    )
 ALGORITHM = 'HS256'
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,14 +1,17 @@
 fastapi==0.137.0
 uvicorn==0.49.0
 h11>=0.16.0 # Pinned to fix HTTP Request Smuggling vulnerability
+starlette>=1.3.1 # not directly required, pinned by Snyk to avoid a vulnerability
 SQLAlchemy==2.0.50
 pydantic==2.13.4
 pwdlib[argon2]
 python-multipart==0.0.32
 email-validator==2.3.0
+idna>=3.15 # not directly required, pinned by Snyk to avoid a vulnerability
 psycopg2-binary==2.9.12
 python-dotenv==1.2.2
 python-logging-loki==0.3.1
+click>=8.3.3 # not directly required, pinned by Snyk to avoid a vulnerability
 PyJWT==2.13.0
 requests>=2.34.2 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=2.7.0 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
## Summary
- Pin `click`, `idna`, and `starlette` (transitive deps) to versions that resolve Snyk SCA findings — Command Injection (click, High), HTTP Request Smuggling/SSRF/ReDoS/unsafe reflection (starlette, High), ReDoS (idna, Medium). `snyk test` now reports 0 vulnerable paths.
- Fix GitHub code scanning alert #34 (SnykCode, `python/HardcodedKey`, error severity): the JWT fallback secret in `app/auth/oauth2.py` was a fixed string literal checked into source, so any deployment that forgot to set `JWT_SECRET_KEY` would sign/verify tokens with a publicly known key. Replaced with a random key generated via `secrets.token_hex(32)` at import time, preserving zero-setup local `pytest` runs without ever using a guessable key.

## Test plan
- [x] `snyk test --file=requirements/base.txt --package-manager=pip --severity-threshold=high` — 0 vulnerable paths
- [x] `snyk code test --severity-threshold=high` — 0 issues
- [x] `pytest --cov=./ ...` — 64 passed
- [x] pre-commit hooks (black, pylint, pytest) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)