### PR TITLE
Games domain: IGDB-backed (Twitch OAuth) trackers with 100% flag

### DIFF
--- a/alembic/versions/32dcf2b915ce_games_detail_fields_tracker_lists.py
+++ b/alembic/versions/32dcf2b915ce_games_detail_fields_tracker_lists.py
@@ -1,0 +1,91 @@
+"""games detail fields + tracker lists
+
+Revision ID: 32dcf2b915ce
+Revises: 5cfe462a0464
+Create Date: 2026-07-12 07:30:13.325690
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '32dcf2b915ce'
+down_revision: Union[str, Sequence[str], None] = '5cfe462a0464'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add IGDB detail columns and Movies-style list flags, then backfill."""
+    with op.batch_alter_table('video_games', schema=None) as batch_op:
+        # IGDB cover URLs overflow the legacy 100-char column.
+        batch_op.alter_column(
+            'poster_url',
+            existing_type=sa.String(length=100),
+            type_=sa.String(length=254),
+            existing_nullable=True,
+        )
+        batch_op.add_column(sa.Column('year', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('genre', sa.String(length=255), nullable=True))
+        batch_op.add_column(
+            sa.Column('platforms', sa.String(length=254), nullable=True)
+        )
+        batch_op.add_column(sa.Column('summary', sa.Text(), nullable=True))
+
+    # Add with a server_default so existing rows are populated, then backfill.
+    with op.batch_alter_table('user_video_games', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                'on_watchlist',
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+        batch_op.add_column(
+            sa.Column(
+                'on_rankings',
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+
+    # Legacy import: completed=1 => played (ranked list, ranks already
+    # 1-based); otherwise the backlog, whose rank column holds a meaningless
+    # 0 sentinel that must not leak into the ranked list.
+    op.execute('UPDATE user_video_games SET on_rankings = TRUE WHERE completed = 1')
+    # "anything but completed=1" — matches orion_import's flag derivation.
+    op.execute(
+        'UPDATE user_video_games SET on_watchlist = TRUE '
+        'WHERE completed != 1 OR completed IS NULL'
+    )
+    op.execute('UPDATE user_video_games SET rank = NULL WHERE on_rankings = FALSE')
+
+    # Drop the server defaults now that existing rows are populated; the app
+    # model supplies the default on insert.
+    with op.batch_alter_table('user_video_games', schema=None) as batch_op:
+        batch_op.alter_column('on_watchlist', server_default=None)
+        batch_op.alter_column('on_rankings', server_default=None)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('user_video_games', schema=None) as batch_op:
+        batch_op.drop_column('on_rankings')
+        batch_op.drop_column('on_watchlist')
+
+    with op.batch_alter_table('video_games', schema=None) as batch_op:
+        batch_op.drop_column('summary')
+        batch_op.drop_column('platforms')
+        batch_op.drop_column('genre')
+        batch_op.drop_column('year')
+        batch_op.alter_column(
+            'poster_url',
+            existing_type=sa.String(length=254),
+            type_=sa.String(length=100),
+            existing_nullable=True,
+        )

--- a/app/config.py
+++ b/app/config.py
@@ -49,6 +49,10 @@ class Settings(BaseSettings):
     omdb_api_key: Optional[str] = None
     tmdb_api_key: Optional[str] = None
 
+    # --- External APIs (games search proxy — IGDB via Twitch OAuth) ---
+    twitch_client_id: Optional[str] = None
+    twitch_client_secret: Optional[str] = None
+
     @property
     def sqlalchemy_database_url(self) -> str:
         """

--- a/app/db/models_sandbox.py
+++ b/app/db/models_sandbox.py
@@ -168,12 +168,17 @@ class DbVideoGame(DBBaseModel):
 
     title = Column(String(255))
     igdb = Column(Integer, unique=True, nullable=True)
-    poster_url = Column(String(100), nullable=True)
+    poster_url = Column(String(254), nullable=True)
     release_date = Column(DateTime, nullable=True)
     rating = Column(Float, nullable=True)
     time_to_beat = Column(Integer, nullable=True)
     igdb_last_update = Column(DateTime, nullable=True)
     slug = Column(String(255), nullable=True)
+    # Rich detail (populated from IGDB) for the detail view + filtering.
+    year = Column(Integer, nullable=True)
+    genre = Column(String(255), nullable=True)
+    platforms = Column(String(254), nullable=True)
+    summary = Column(Text, nullable=True)
 
     user_games = relationship('DbUserVideoGame', back_populates='game')
 
@@ -184,6 +189,11 @@ class DbUserVideoGame(DBBaseModel):
     game_id = Column(Integer, ForeignKey('video_games.pk'), nullable=False)
     user_id = Column(Integer, ForeignKey('users.pk'), nullable=False)
 
+    # Two independent lists, mirroring the Movies tracker: on_watchlist is the
+    # backlog, on_rankings the played-and-ranked list. `completed` is retained
+    # from the legacy import but no longer drives the UI.
+    on_watchlist = Column(Boolean, nullable=False, default=False)
+    on_rankings = Column(Boolean, nullable=False, default=False)
     rank = Column(Integer, nullable=True)
     completed = Column(Integer, nullable=True)
     notes = Column(Text, nullable=True)

--- a/app/migration/enrich_games.py
+++ b/app/migration/enrich_games.py
@@ -1,0 +1,72 @@
+"""
+Backfill IGDB detail (year/genres/platforms/summary/rating/cover) for games
+that were imported without it, keyed on the ``igdb`` id. Requires
+``TWITCH_CLIENT_ID``/``TWITCH_CLIENT_SECRET``. Throttled and **resumable**:
+it only processes games still missing detail, so re-running continues where
+it left off.
+
+Usage::
+
+    TWITCH_CLIENT_ID=... TWITCH_CLIENT_SECRET=... \\
+    DATABASE_URL=... ENV=prod python -m app.migration.enrich_games
+"""
+
+import time
+
+from app.db.database import SessionLocal
+from app.db.models_sandbox import DbVideoGame
+from app.services.game_search import apply_detail_to_game, get_game_detail
+
+# IGDB allows 4 requests/second; stay well under it.
+THROTTLE_SECONDS = 0.5
+# get_game_detail returns None both for genuine misses and rate limiting; a
+# run of consecutive Nones almost certainly means throttling or bad creds.
+STOP_AFTER_CONSECUTIVE_MISSES = 15
+
+
+def run() -> None:
+    """Enrich all games still missing detail."""
+    db = SessionLocal()
+    try:
+        pending = (
+            db.query(DbVideoGame)
+            .filter(
+                DbVideoGame.igdb.isnot(None),
+                DbVideoGame.summary.is_(None),
+                DbVideoGame.genre.is_(None),
+            )
+            .all()
+        )
+        total = len(pending)
+        print(f'{total} games to enrich')
+        enriched = misses = consecutive = processed = 0
+        for game in pending:
+            processed += 1
+            detail = get_game_detail(game.igdb)
+            if detail:
+                apply_detail_to_game(game, detail)
+                db.commit()
+                enriched += 1
+                consecutive = 0
+            else:
+                misses += 1
+                consecutive += 1
+            if processed % 25 == 0:
+                print(f'  {processed}/{total} (enriched {enriched}, misses {misses})')
+            if consecutive >= STOP_AFTER_CONSECUTIVE_MISSES:
+                print(
+                    f'Stopping after {consecutive} consecutive misses '
+                    '(rate limit or missing Twitch creds). Re-run later to resume.'
+                )
+                break
+            time.sleep(THROTTLE_SECONDS)
+        print(
+            f'Done: enriched {enriched}, misses {misses}, '
+            f'remaining ~{total - processed}'
+        )
+    finally:
+        db.close()
+
+
+if __name__ == '__main__':
+    run()

--- a/app/migration/orion_import.py
+++ b/app/migration/orion_import.py
@@ -381,10 +381,14 @@ def run_import(dry_run: bool = False) -> Report:
                         'game_id': game_map.get(r['videogames_id']),
                     },
                     {
-                        'rank': r['rank'],
+                        # Backlog games carry a meaningless rank-0 sentinel;
+                        # only played (completed) games keep their 1-based rank.
+                        'rank': r['rank'] if r['completed'] == 1 else None,
                         'completed': r['completed'],
                         'notes': _decode_blob(r['notes']),
                         'is_100_percent': bool(r['100_percent']),
+                        'on_rankings': r['completed'] == 1,
+                        'on_watchlist': r['completed'] != 1,
                     },
                 ),
                 lambda nf: nf['user_id'] and nf['game_id'],

--- a/app/router/v1/router_games.py
+++ b/app/router/v1/router_games.py
@@ -1,38 +1,67 @@
 # pylint: disable=missing-function-docstring, useless-return
 """
 This module contains the API routes for Video Games.
+
+Mirrors the Movies pattern: admin-only global catalog CRUD, an IGDB search
+proxy (Twitch OAuth; 503 when unconfigured), lazy enrichment on detail view,
+and per-user trackers with independent Watchlist (backlog) / Rankings
+(played) lists plus a 100%-completion flag.
 """
 
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.db.database import get_db
 from app.db.models_sandbox import DbVideoGame, DbUserVideoGame
-from app.auth.oauth2 import get_current_user
+from app.auth.oauth2 import get_current_user, require_admin
 from app.schemas.schemas_sandbox import (
-    VideoGameCreate,
-    VideoGameResponse,
-    VideoGameUpdate,
+    GameRankingReorder,
+    GameSearchResult,
+    RankPlacement,
     UserVideoGameCreate,
     UserVideoGameResponse,
     UserVideoGameUpdate,
+    VideoGameCreate,
+    VideoGameResponse,
+    VideoGameSummary,
+    VideoGameUpdate,
+)
+from app.services.game_search import (
+    apply_detail_to_game,
+    get_game_detail,
+    search_games as igdb_search_games,
 )
 
 router = APIRouter(prefix='/v1', tags=['Video Games'])
 
 
 # Global Entity Endpoints
-@router.get('/games', response_model=List[VideoGameResponse])
+@router.get('/games', response_model=List[VideoGameSummary])
 def get_all_games(db: Session = Depends(get_db)):
     return db.query(DbVideoGame).all()
+
+
+@router.get('/games/search', response_model=List[GameSearchResult])
+def search_games_endpoint(
+    q: str,
+    current_user: list = Depends(get_current_user),
+):
+    del current_user  # any authenticated user may search
+    return igdb_search_games(q)
 
 
 @router.post(
     '/games', response_model=VideoGameResponse, status_code=status.HTTP_201_CREATED
 )
-def create_game(request: VideoGameCreate, db: Session = Depends(get_db)):
+def create_game(
+    request: VideoGameCreate,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(require_admin),
+):
+    del current_user
     if request.igdb:
         existing = (
             db.query(DbVideoGame).filter(DbVideoGame.igdb == request.igdb).first()
@@ -40,23 +69,48 @@ def create_game(request: VideoGameCreate, db: Session = Depends(get_db)):
         if existing:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail='Game IGDB ID already exists',
+                detail='Game igdb id already exists',
             )
 
     new_game = DbVideoGame(**request.model_dump())
+    # Enrich from IGDB on add so detail/filtering work immediately (best effort).
+    detail = get_game_detail(request.igdb)
+    if detail:
+        apply_detail_to_game(new_game, detail)
     db.add(new_game)
     db.commit()
     db.refresh(new_game)
     return new_game
 
 
+@router.get('/games/{game_id}', response_model=VideoGameResponse)
+def get_game(
+    game_id: str,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """Return one game's full detail, enriching from IGDB on first view."""
+    del current_user
+    game = _get_game(db, game_id)
+    # Lazily backfill detail the first time a sparse game is opened.
+    if game.summary is None and game.genre is None:
+        detail = get_game_detail(game.igdb)
+        if detail:
+            apply_detail_to_game(game, detail)
+            db.commit()
+            db.refresh(game)
+    return game
+
+
 @router.put('/games/{game_id}', response_model=VideoGameResponse)
-def update_game(game_id: str, request: VideoGameUpdate, db: Session = Depends(get_db)):
-    game = db.query(DbVideoGame).filter(DbVideoGame.id == game_id).first()
-    if not game:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail='Game not found'
-        )
+def update_game(
+    game_id: str,
+    request: VideoGameUpdate,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(require_admin),
+):
+    del current_user
+    game = _get_game(db, game_id)
 
     update_data = request.model_dump(exclude_unset=True)
     for key, value in update_data.items():
@@ -68,18 +122,50 @@ def update_game(game_id: str, request: VideoGameUpdate, db: Session = Depends(ge
 
 
 @router.delete('/games/{game_id}', status_code=status.HTTP_204_NO_CONTENT)
-def delete_game(game_id: str, db: Session = Depends(get_db)):
-    game = db.query(DbVideoGame).filter(DbVideoGame.id == game_id).first()
-    if not game:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail='Game not found'
-        )
+def delete_game(
+    game_id: str,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(require_admin),
+):
+    del current_user
+    game = _get_game(db, game_id)
     db.delete(game)
     db.commit()
     return None
 
 
 # User Tracker Endpoints
+def _get_game(db: Session, game_id: str) -> DbVideoGame:
+    game = db.query(DbVideoGame).filter(DbVideoGame.id == game_id).first()
+    if not game:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail='Game not found'
+        )
+    return game
+
+
+def _get_tracker(db: Session, user_pk: int, game_pk: int):
+    return (
+        db.query(DbUserVideoGame)
+        .filter(DbUserVideoGame.user_id == user_pk, DbUserVideoGame.game_id == game_pk)
+        .first()
+    )
+
+
+def _placed_count(db: Session, user_pk: int) -> int:
+    """Number of games with an assigned rank position for this user."""
+    return (
+        db.query(func.count())  # pylint: disable=not-callable
+        .select_from(DbUserVideoGame)
+        .filter(
+            DbUserVideoGame.user_id == user_pk,
+            DbUserVideoGame.on_rankings.is_(True),
+            DbUserVideoGame.rank.isnot(None),
+        )
+        .scalar()
+    )
+
+
 @router.get('/users/me/games', response_model=List[UserVideoGameResponse])
 def get_user_games(
     db: Session = Depends(get_db), current_user: list = Depends(get_current_user)
@@ -89,6 +175,104 @@ def get_user_games(
         .filter(DbUserVideoGame.user_id == current_user[0].pk)
         .all()
     )
+
+
+@router.put(
+    '/users/me/games/rankings/order', response_model=List[UserVideoGameResponse]
+)
+def reorder_rankings(
+    request: GameRankingReorder,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """Persist a new ranking order (drag-and-drop). Rank = position in the list."""
+    user_pk = current_user[0].pk
+    for position, game_id in enumerate(request.game_ids, start=1):
+        game = db.query(DbVideoGame).filter(DbVideoGame.id == game_id).first()
+        if not game:
+            continue
+        tracker = _get_tracker(db, user_pk, game.pk)
+        if tracker:
+            tracker.rank = position
+            tracker.on_rankings = True
+    db.commit()
+    return (
+        db.query(DbUserVideoGame)
+        .filter(
+            DbUserVideoGame.user_id == user_pk,
+            DbUserVideoGame.on_rankings.is_(True),
+        )
+        .order_by(DbUserVideoGame.rank)
+        .all()
+    )
+
+
+@router.get('/users/me/games/{game_id}', response_model=UserVideoGameResponse)
+def get_user_game(
+    game_id: str,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """Return the current user's tracker for one game (404 if not tracked)."""
+    game = _get_game(db, game_id)
+    tracker = _get_tracker(db, current_user[0].pk, game.pk)
+    if not tracker:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail='Game not marked'
+        )
+    return tracker
+
+
+@router.put('/users/me/games/{game_id}/rank', response_model=UserVideoGameResponse)
+def set_game_rank(
+    game_id: str,
+    request: RankPlacement,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """
+    Place a game at an exact 1-based position in the ranked list, shifting the
+    games at and below that position down by one. Works for a not-yet-ranked
+    game (jump it in) or an already-ranked one (move it).
+    """
+    user_pk = current_user[0].pk
+    game = _get_game(db, game_id)
+    tracker = _get_tracker(db, user_pk, game.pk)
+    if not tracker:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail='Game not marked'
+        )
+
+    old_rank = tracker.rank
+    tracker.on_rankings = True
+    # Remove from its current slot first so the shift math excludes it.
+    tracker.rank = None
+    db.flush()
+    if old_rank is not None:
+        db.query(DbUserVideoGame).filter(
+            DbUserVideoGame.user_id == user_pk,
+            DbUserVideoGame.on_rankings.is_(True),
+            DbUserVideoGame.rank.isnot(None),
+            DbUserVideoGame.rank > old_rank,
+        ).update(
+            {DbUserVideoGame.rank: DbUserVideoGame.rank - 1},
+            synchronize_session=False,
+        )
+
+    target = max(1, min(request.position, _placed_count(db, user_pk) + 1))
+    db.query(DbUserVideoGame).filter(
+        DbUserVideoGame.user_id == user_pk,
+        DbUserVideoGame.on_rankings.is_(True),
+        DbUserVideoGame.rank.isnot(None),
+        DbUserVideoGame.rank >= target,
+    ).update(
+        {DbUserVideoGame.rank: DbUserVideoGame.rank + 1}, synchronize_session=False
+    )
+
+    tracker.rank = target
+    db.commit()
+    db.refresh(tracker)
+    return tracker
 
 
 @router.post(
@@ -102,32 +286,37 @@ def mark_game(
     db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
 ):
-    game = db.query(DbVideoGame).filter(DbVideoGame.id == game_id).first()
-    if not game:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail='Game not found'
-        )
+    """Add a game to the user's lists (idempotent — merges list membership)."""
+    user_pk = current_user[0].pk
+    game = _get_game(db, game_id)
+    tracker = _get_tracker(db, user_pk, game.pk)
+    data = request.model_dump(exclude_unset=True)
 
-    existing_tracker = (
-        db.query(DbUserVideoGame)
-        .filter(
-            DbUserVideoGame.user_id == current_user[0].pk,
-            DbUserVideoGame.game_id == game.pk,
+    if tracker is None:
+        was_on_rankings = False
+        tracker = DbUserVideoGame(
+            user_id=user_pk,
+            game_id=game.pk,
+            on_watchlist=bool(data.get('on_watchlist', False)),
+            on_rankings=bool(data.get('on_rankings', False)),
+            notes=data.get('notes'),
+            is_100_percent=bool(data.get('is_100_percent', False)),
         )
-        .first()
-    )
-    if existing_tracker:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail='Game already marked'
-        )
+        db.add(tracker)
+    else:
+        was_on_rankings = tracker.on_rankings
+        for key in ('on_watchlist', 'on_rankings', 'notes', 'is_100_percent'):
+            if key in data:
+                setattr(tracker, key, data[key])
 
-    new_tracker = DbUserVideoGame(
-        user_id=current_user[0].pk, game_id=game.pk, **request.model_dump()
-    )
-    db.add(new_tracker)
+    # A game only holds a rank while it's on the ranked list AND was already
+    # placed. Entering Rankings (or leaving it) resets to unplaced so it lands
+    # in the "to rank" bucket rather than at a stale/leftover position.
+    if not tracker.on_rankings or not was_on_rankings:
+        tracker.rank = None
     db.commit()
-    db.refresh(new_tracker)
-    return new_tracker
+    db.refresh(tracker)
+    return tracker
 
 
 @router.put('/users/me/games/{game_id}', response_model=UserVideoGameResponse)
@@ -137,28 +326,30 @@ def update_user_game(
     db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
 ):
-    game = db.query(DbVideoGame).filter(DbVideoGame.id == game_id).first()
-    if not game:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail='Game not found'
-        )
-
-    tracker = (
-        db.query(DbUserVideoGame)
-        .filter(
-            DbUserVideoGame.user_id == current_user[0].pk,
-            DbUserVideoGame.game_id == game.pk,
-        )
-        .first()
-    )
+    """Update list membership, rank, notes, or 100% flag for a tracked game."""
+    user_pk = current_user[0].pk
+    game = _get_game(db, game_id)
+    tracker = _get_tracker(db, user_pk, game.pk)
     if not tracker:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail='Game not marked'
         )
 
-    update_data = request.model_dump(exclude_unset=True)
-    for key, value in update_data.items():
+    was_on_rankings = tracker.on_rankings
+    for key, value in request.model_dump(exclude_unset=True).items():
         setattr(tracker, key, value)
+
+    # Entering Rankings (or leaving it) resets to unplaced so a stale/leftover
+    # rank never places the game automatically; it lands in "to rank" instead.
+    if not tracker.on_rankings or not was_on_rankings:
+        tracker.rank = None
+
+    # If it's on neither list, drop the tracker entirely.
+    if not tracker.on_watchlist and not tracker.on_rankings:
+        response = UserVideoGameResponse.model_validate(tracker)
+        db.delete(tracker)
+        db.commit()
+        return response
 
     db.commit()
     db.refresh(tracker)
@@ -171,25 +362,13 @@ def unmark_game(
     db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
 ):
-    game = db.query(DbVideoGame).filter(DbVideoGame.id == game_id).first()
-    if not game:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail='Game not found'
-        )
-
-    tracker = (
-        db.query(DbUserVideoGame)
-        .filter(
-            DbUserVideoGame.user_id == current_user[0].pk,
-            DbUserVideoGame.game_id == game.pk,
-        )
-        .first()
-    )
+    user_pk = current_user[0].pk
+    game = _get_game(db, game_id)
+    tracker = _get_tracker(db, user_pk, game.pk)
     if not tracker:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail='Game not marked'
         )
-
     db.delete(tracker)
     db.commit()
     return None

--- a/app/schemas/schemas_sandbox.py
+++ b/app/schemas/schemas_sandbox.py
@@ -334,6 +334,10 @@ class VideoGameBase(BaseModel):
     time_to_beat: Optional[int] = None
     igdb_last_update: Optional[datetime] = None
     slug: Optional[str] = None
+    year: Optional[int] = None
+    genre: Optional[str] = None
+    platforms: Optional[str] = None
+    summary: Optional[str] = None
 
 
 class VideoGameCreate(VideoGameBase):
@@ -349,6 +353,10 @@ class VideoGameUpdate(BaseModel):
     time_to_beat: Optional[int] = None
     igdb_last_update: Optional[datetime] = None
     slug: Optional[str] = None
+    year: Optional[int] = None
+    genre: Optional[str] = None
+    platforms: Optional[str] = None
+    summary: Optional[str] = None
 
 
 class VideoGameResponse(VideoGameBase):
@@ -358,11 +366,37 @@ class VideoGameResponse(VideoGameBase):
     model_config = ConfigDict(from_attributes=True)
 
 
+class VideoGameSummary(BaseModel):
+    """Lightweight game for list responses — omits the large ``summary``."""
+
+    id: str
+    title: str
+    igdb: Optional[int] = None
+    poster_url: Optional[str] = None
+    rating: Optional[float] = None
+    time_to_beat: Optional[int] = None
+    slug: Optional[str] = None
+    year: Optional[int] = None
+    genre: Optional[str] = None
+    platforms: Optional[str] = None
+    model_config = ConfigDict(from_attributes=True)
+
+
+class GameSearchResult(BaseModel):
+    igdb: Optional[int] = None
+    title: str
+    year: Optional[str] = None
+    platforms: Optional[str] = None
+    poster_url: Optional[str] = None
+
+
 class UserVideoGameBase(BaseModel):
+    on_watchlist: Optional[bool] = None
+    on_rankings: Optional[bool] = None
     rank: Optional[int] = None
     completed: Optional[int] = None
     notes: Optional[str] = None
-    is_100_percent: Optional[bool] = False
+    is_100_percent: Optional[bool] = None
 
 
 class UserVideoGameCreate(UserVideoGameBase):
@@ -375,10 +409,16 @@ class UserVideoGameUpdate(UserVideoGameBase):
 
 class UserVideoGameResponse(UserVideoGameBase):
     id: str
-    game: VideoGameResponse
+    game: VideoGameSummary
     created_at: datetime
     updated_at: datetime
     model_config = ConfigDict(from_attributes=True)
+
+
+class GameRankingReorder(BaseModel):
+    """Ordered list of game (catalog) ids defining the new ranking order."""
+
+    game_ids: List[str]
 
 
 # --- Books ---

--- a/app/services/game_search.py
+++ b/app/services/game_search.py
@@ -1,0 +1,241 @@
+"""
+Video game search proxy.
+
+Wraps the IGDB API (https://api.igdb.com — authenticated with Twitch OAuth
+client credentials, mirroring the legacy orion games page) so the web and
+MCP frontends can look up games without holding the credentials. Results are
+normalized into the shape the ``/v1/games`` create endpoint expects. IGDB is
+also the enrichment source, keyed on the catalog's ``igdb`` id: release
+year, genres, platforms, summary, rating (0–100), and cover art.
+
+Raises 503 when ``TWITCH_CLIENT_ID``/``TWITCH_CLIENT_SECRET`` are not
+configured (same graceful degradation as the OMDB movie search).
+"""
+
+import time
+from datetime import datetime, timezone
+from typing import List, Optional, Tuple
+
+import requests
+from fastapi import HTTPException, status
+
+from app.config import get_settings
+from app.log.logging_config import logger
+
+TWITCH_OAUTH_URL = 'https://id.twitch.tv/oauth2/token'
+IGDB_URL = 'https://api.igdb.com/v4'
+COVER_URL = 'https://images.igdb.com/igdb/image/upload/t_cover_big'
+REQUEST_TIMEOUT = 10
+
+_DETAIL_FIELDS = (
+    'name,slug,first_release_date,total_rating,genres.name,'
+    'platforms.abbreviation,summary,cover.image_id,updated_at'
+)
+
+# (token, expires_at_epoch) — Twitch app tokens last ~60 days; refresh early.
+_token_cache: Tuple[Optional[str], float] = (None, 0.0)
+
+
+def _credentials() -> Tuple[str, str]:
+    settings = get_settings()
+    if not (settings.twitch_client_id and settings.twitch_client_secret):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail='Game search is not configured '
+            '(TWITCH_CLIENT_ID/TWITCH_CLIENT_SECRET missing)',
+        )
+    return settings.twitch_client_id, settings.twitch_client_secret
+
+
+def _access_token() -> str:
+    """Return a cached Twitch app token, refreshing when near expiry."""
+    global _token_cache  # pylint: disable=global-statement
+    token, expires_at = _token_cache
+    if token and time.time() < expires_at - 300:
+        return token
+
+    client_id, client_secret = _credentials()
+    try:
+        response = requests.post(
+            TWITCH_OAUTH_URL,
+            params={
+                'client_id': client_id,
+                'client_secret': client_secret,
+                'grant_type': 'client_credentials',
+            },
+            timeout=REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except (requests.RequestException, ValueError) as exc:
+        logger.error('Twitch OAuth token request failed: %s', exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Upstream game auth failed',
+        ) from exc
+
+    token = payload['access_token']
+    _token_cache = (token, time.time() + payload.get('expires_in', 3600))
+    return token
+
+
+def _igdb_query(endpoint: str, body: str) -> list:
+    """
+    POST an APIcalypse query to IGDB and return the JSON list.
+
+    On a 401 (token revoked/rotated before its cached expiry) the token
+    cache is evicted and the request retried once with a fresh token.
+    """
+    global _token_cache  # pylint: disable=global-statement
+    client_id, _ = _credentials()
+    for attempt in (1, 2):
+        headers = {
+            'Client-ID': client_id,
+            'Authorization': f'Bearer {_access_token()}',
+        }
+        response = requests.post(
+            f'{IGDB_URL}/{endpoint}',
+            data=body,
+            headers=headers,
+            timeout=REQUEST_TIMEOUT,
+        )
+        if response.status_code == 401 and attempt == 1:
+            _token_cache = (None, 0.0)
+            continue
+        response.raise_for_status()
+        return response.json()
+    return []  # unreachable; keeps the type checker honest
+
+
+def _cover(game: dict) -> Optional[str]:
+    image_id = (game.get('cover') or {}).get('image_id')
+    return f'{COVER_URL}/{image_id}.jpg' if image_id else None
+
+
+def _release(game: dict) -> Optional[datetime]:
+    ts = game.get('first_release_date')
+    if not ts:
+        return None
+    return datetime.fromtimestamp(ts, tz=timezone.utc).replace(tzinfo=None)
+
+
+def _names(game: dict, key: str, name_key: str = 'name') -> Optional[str]:
+    items = game.get(key) or []
+    names = [i.get(name_key) for i in items if i.get(name_key)]
+    return ', '.join(names) if names else None
+
+
+def search_games(query: str) -> List[dict]:
+    """
+    Search IGDB for games matching ``query``.
+
+    Returns a list of normalized dicts (``igdb``, ``title``, ``year``,
+    ``platforms``, ``poster_url``). Raises 400 on an empty query, 503 when
+    unconfigured, and 502 when the upstream call fails.
+    """
+    query = (query or '').strip()
+    if not query:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='Search query must not be empty',
+        )
+
+    # Escape backslashes first, then quotes — otherwise a trailing backslash
+    # (or crafted \" sequence) breaks out of the APIcalypse string literal.
+    escaped = query.replace('\\', '\\\\').replace('"', '\\"')
+    try:
+        payload = _igdb_query(
+            'games',
+            f'search "{escaped}"; fields name,first_release_date,'
+            'platforms.abbreviation,cover.image_id; limit 20;',
+        )
+    except (requests.RequestException, ValueError) as exc:
+        # HTTPExceptions from _igdb_query (503 unconfigured / 502 auth)
+        # propagate untouched — they aren't caught here.
+        logger.error('IGDB search failed for %r: %s', query, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Upstream game search failed',
+        ) from exc
+
+    results = []
+    for game in payload:
+        release = _release(game)
+        results.append(
+            {
+                'igdb': game.get('id'),
+                'title': game.get('name'),
+                'year': str(release.year) if release else None,
+                'platforms': _names(game, 'platforms', 'abbreviation'),
+                'poster_url': _cover(game),
+            }
+        )
+    return results
+
+
+# Max lengths for the bounded catalog columns (see models_sandbox.DbVideoGame).
+_FIELD_LIMITS = {
+    'title': 255,
+    'slug': 255,
+    'poster_url': 254,
+    'genre': 255,
+    'platforms': 254,
+}
+
+
+def apply_detail_to_game(game, detail: dict) -> None:
+    """
+    Copy IGDB detail onto a DbVideoGame, truncating to column limits and
+    skipping None values (never clobber a good value with None).
+    """
+    for key, value in detail.items():
+        if value is None:
+            continue
+        if key in _FIELD_LIMITS and isinstance(value, str):
+            value = value[: _FIELD_LIMITS[key]]
+        setattr(game, key, value)
+
+
+def get_game_detail(igdb_id: Optional[int]) -> Optional[dict]:
+    """
+    Fetch full detail for a game by IGDB id and map it to the fields the
+    catalog stores. Returns None when unavailable/unconfigured so callers
+    can skip enrichment gracefully.
+    """
+    if not igdb_id:
+        return None
+    try:
+        payload = _igdb_query(
+            'games',
+            f'fields {_DETAIL_FIELDS}; where id = {int(igdb_id)};',
+        )
+    except HTTPException:
+        # Unconfigured (503) or upstream auth failure — skip enrichment.
+        return None
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning('IGDB detail failed for %s: %s', igdb_id, exc)
+        return None
+    if not payload:
+        return None
+
+    game = payload[0]
+    release = _release(game)
+    rating = game.get('total_rating')
+    updated = game.get('updated_at')
+    return {
+        'title': game.get('name'),
+        'igdb': game.get('id'),
+        'slug': game.get('slug'),
+        'release_date': release,
+        'year': release.year if release else None,
+        'genre': _names(game, 'genres'),
+        'platforms': _names(game, 'platforms', 'abbreviation'),
+        'summary': game.get('summary'),
+        'rating': round(rating, 1) if rating else None,
+        'poster_url': _cover(game),
+        'igdb_last_update': (
+            datetime.fromtimestamp(updated, tz=timezone.utc).replace(tzinfo=None)
+            if updated
+            else None
+        ),
+    }

--- a/openapi.json
+++ b/openapi.json
@@ -1508,7 +1508,7 @@
               "application/json": {
                 "schema": {
                   "items": {
-                    "$ref": "#/components/schemas/VideoGameResponse"
+                    "$ref": "#/components/schemas/VideoGameSummary"
                   },
                   "type": "array",
                   "title": "Response Get All Games V1 Games Get"
@@ -1555,16 +1555,123 @@
               }
             }
           }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/v1/games/search": {
+      "get": {
+        "tags": [
+          "Video Games"
+        ],
+        "summary": "Search Games Endpoint",
+        "operationId": "search_games_endpoint_v1_games_search_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Q"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GameSearchResult"
+                  },
+                  "title": "Response Search Games Endpoint V1 Games Search Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
         }
       }
     },
     "/v1/games/{game_id}": {
+      "get": {
+        "tags": [
+          "Video Games"
+        ],
+        "summary": "Get Game",
+        "description": "Return one game's full detail, enriching from IGDB on first view.",
+        "operationId": "get_game_v1_games__game_id__get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "game_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Game Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VideoGameResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
       "put": {
         "tags": [
           "Video Games"
         ],
         "summary": "Update Game",
         "operationId": "update_game_v1_games__game_id__put",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "game_id",
@@ -1615,6 +1722,11 @@
         ],
         "summary": "Delete Game",
         "operationId": "delete_game_v1_games__game_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "game_id",
@@ -1673,12 +1785,110 @@
         ]
       }
     },
+    "/v1/users/me/games/rankings/order": {
+      "put": {
+        "tags": [
+          "Video Games"
+        ],
+        "summary": "Reorder Rankings",
+        "description": "Persist a new ranking order (drag-and-drop). Rank = position in the list.",
+        "operationId": "reorder_rankings_v1_users_me_games_rankings_order_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GameRankingReorder"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/UserVideoGameResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Reorder Rankings V1 Users Me Games Rankings Order Put"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
     "/v1/users/me/games/{game_id}": {
+      "get": {
+        "tags": [
+          "Video Games"
+        ],
+        "summary": "Get User Game",
+        "description": "Return the current user's tracker for one game (404 if not tracked).",
+        "operationId": "get_user_game_v1_users_me_games__game_id__get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "game_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Game Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserVideoGameResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
       "post": {
         "tags": [
           "Video Games"
         ],
         "summary": "Mark Game",
+        "description": "Add a game to the user's lists (idempotent \u2014 merges list membership).",
         "operationId": "mark_game_v1_users_me_games__game_id__post",
         "security": [
           {
@@ -1734,6 +1944,7 @@
           "Video Games"
         ],
         "summary": "Update User Game",
+        "description": "Update list membership, rank, notes, or 100% flag for a tracked game.",
         "operationId": "update_user_game_v1_users_me_games__game_id__put",
         "security": [
           {
@@ -1809,6 +2020,64 @@
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/users/me/games/{game_id}/rank": {
+      "put": {
+        "tags": [
+          "Video Games"
+        ],
+        "summary": "Set Game Rank",
+        "description": "Place a game at an exact 1-based position in the ranked list, shifting the\ngames at and below that position down by one. Works for a not-yet-ranked\ngame (jump it in) or an already-ranked one (move it).",
+        "operationId": "set_game_rank_v1_users_me_games__game_id__rank_put",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "game_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Game Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RankPlacement"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserVideoGameResponse"
+                }
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
@@ -4355,6 +4624,80 @@
         },
         "type": "object",
         "title": "CountryUpdate"
+      },
+      "GameRankingReorder": {
+        "properties": {
+          "game_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Game Ids"
+          }
+        },
+        "type": "object",
+        "required": [
+          "game_ids"
+        ],
+        "title": "GameRankingReorder",
+        "description": "Ordered list of game (catalog) ids defining the new ranking order."
+      },
+      "GameSearchResult": {
+        "properties": {
+          "igdb": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Igdb"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "year": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Year"
+          },
+          "platforms": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platforms"
+          },
+          "poster_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Poster Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "title": "GameSearchResult"
       },
       "GoogleAuthRequest": {
         "properties": {
@@ -6982,6 +7325,28 @@
       },
       "UserVideoGameCreate": {
         "properties": {
+          "on_watchlist": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "On Watchlist"
+          },
+          "on_rankings": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "On Rankings"
+          },
           "rank": {
             "anyOf": [
               {
@@ -7024,8 +7389,7 @@
                 "type": "null"
               }
             ],
-            "title": "Is 100 Percent",
-            "default": false
+            "title": "Is 100 Percent"
           }
         },
         "type": "object",
@@ -7033,6 +7397,28 @@
       },
       "UserVideoGameResponse": {
         "properties": {
+          "on_watchlist": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "On Watchlist"
+          },
+          "on_rankings": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "On Rankings"
+          },
           "rank": {
             "anyOf": [
               {
@@ -7075,15 +7461,14 @@
                 "type": "null"
               }
             ],
-            "title": "Is 100 Percent",
-            "default": false
+            "title": "Is 100 Percent"
           },
           "id": {
             "type": "string",
             "title": "Id"
           },
           "game": {
-            "$ref": "#/components/schemas/VideoGameResponse"
+            "$ref": "#/components/schemas/VideoGameSummary"
           },
           "created_at": {
             "type": "string",
@@ -7107,6 +7492,28 @@
       },
       "UserVideoGameUpdate": {
         "properties": {
+          "on_watchlist": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "On Watchlist"
+          },
+          "on_rankings": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "On Rankings"
+          },
           "rank": {
             "anyOf": [
               {
@@ -7149,8 +7556,7 @@
                 "type": "null"
               }
             ],
-            "title": "Is 100 Percent",
-            "default": false
+            "title": "Is 100 Percent"
           }
         },
         "type": "object",
@@ -7280,6 +7686,50 @@
               }
             ],
             "title": "Slug"
+          },
+          "year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Year"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "platforms": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platforms"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Summary"
           }
         },
         "type": "object",
@@ -7373,6 +7823,50 @@
             ],
             "title": "Slug"
           },
+          "year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Year"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "platforms": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platforms"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Summary"
+          },
           "id": {
             "type": "string",
             "title": "Id"
@@ -7396,6 +7890,113 @@
           "updated_at"
         ],
         "title": "VideoGameResponse"
+      },
+      "VideoGameSummary": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "igdb": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Igdb"
+          },
+          "poster_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Poster Url"
+          },
+          "rating": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rating"
+          },
+          "time_to_beat": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Time To Beat"
+          },
+          "slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slug"
+          },
+          "year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Year"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "platforms": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platforms"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title"
+        ],
+        "title": "VideoGameSummary",
+        "description": "Lightweight game for list responses \u2014 omits the large ``summary``."
       },
       "VideoGameUpdate": {
         "properties": {
@@ -7488,6 +8089,50 @@
               }
             ],
             "title": "Slug"
+          },
+          "year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Year"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "platforms": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platforms"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Summary"
           }
         },
         "type": "object",

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -58,6 +58,16 @@ tasks:
     cmds:
       - python -m app.migration.enrich_tv
 
+  enrich:books:
+    desc: "Backfill Google Books detail for existing books (throttled, resumable)"
+    cmds:
+      - python -m app.migration.enrich_books
+
+  enrich:countries:
+    desc: "Seed the full world list + enrich countries from REST Countries"
+    cmds:
+      - python -m app.migration.enrich_countries
+
   import:orion:
     desc: "Import legacy orion (MySQL) data into phoenix. Usage: task import:orion -- --dry-run"
     cmds:

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -64,9 +64,14 @@ tasks:
       - python -m app.migration.enrich_books
 
   enrich:countries:
-    desc: "Seed the full world list + enrich countries from REST Countries"
+    desc: "Seed the full world list + enrich countries from the world dataset"
     cmds:
       - python -m app.migration.enrich_countries
+
+  enrich:games:
+    desc: "Backfill IGDB detail for existing games (needs TWITCH_CLIENT_ID/SECRET)"
+    cmds:
+      - python -m app.migration.enrich_games
 
   import:orion:
     desc: "Import legacy orion (MySQL) data into phoenix. Usage: task import:orion -- --dry-run"

--- a/tests/integration/router_games_test.py
+++ b/tests/integration/router_games_test.py
@@ -1,39 +1,217 @@
 # pylint: disable=missing-module-docstring, missing-function-docstring
+from unittest.mock import patch
+
 from fastapi.testclient import TestClient
 
 
+def _make_game(test_client: TestClient, title='Breath of the Wild', **extra) -> str:
+    headers = {'Authorization': f"Bearer {test_client.admin_user.token}"}
+    resp = test_client.post(
+        '/v1/games', headers=headers, json={'title': title, **extra}
+    )
+    assert resp.status_code == 201
+    return resp.json()['id']
+
+
+# --- Global catalog ---
 def test_create_game(test_client: TestClient):
-    admin_token = test_client.admin_user.token
-    headers = {'Authorization': f"Bearer {admin_token}"}
+    headers = {'Authorization': f"Bearer {test_client.admin_user.token}"}
     response = test_client.post(
-        '/v1/games',
-        headers=headers,
-        json={'title': 'Zelda: Breath of the Wild', 'igdb': 1111},
+        '/v1/games', headers=headers, json={'title': 'Breath of the Wild', 'igdb': 1111}
     )
     assert response.status_code == 201
     data = response.json()
-    assert data['title'] == 'Zelda: Breath of the Wild'
+    assert data['title'] == 'Breath of the Wild'
     assert data['igdb'] == 1111
 
 
-def test_mark_game(test_client: TestClient):
-    admin_token = test_client.admin_user.token
-    headers = {'Authorization': f"Bearer {admin_token}"}
+def test_get_games(test_client: TestClient):
+    _make_game(test_client)
+    response = test_client.get('/v1/games')
+    assert response.status_code == 200
+    assert len(response.json()) > 0
 
-    response = test_client.post(
-        '/v1/games', headers=headers, json={'title': 'Zelda', 'igdb': 1111}
+
+def test_create_game_unauthenticated(test_client: TestClient):
+    response = test_client.post('/v1/games', json={'title': 'Zelda'})
+    assert response.status_code == 401
+
+
+def test_create_game_requires_admin(test_client: TestClient):
+    headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
+    response = test_client.post('/v1/games', headers=headers, json={'title': 'Zelda'})
+    assert response.status_code == 403
+
+
+def test_create_duplicate_igdb_rejected(test_client: TestClient):
+    _make_game(test_client, igdb=1111)
+    headers = {'Authorization': f"Bearer {test_client.admin_user.token}"}
+    dup = test_client.post(
+        '/v1/games', headers=headers, json={'title': 'Zelda again', 'igdb': 1111}
     )
-    game_id = response.json()['id']
+    assert dup.status_code == 400
 
-    user_token = test_client.first_user.token
-    user_headers = {'Authorization': f"Bearer {user_token}"}
 
+@patch('app.router.v1.router_games.get_game_detail')
+def test_get_game_enriches_on_view(mock_detail, test_client: TestClient):
+    game_id = _make_game(test_client)
+    mock_detail.return_value = {
+        'year': 2017,
+        'genre': 'Adventure, RPG',
+        'platforms': 'Switch',
+        'summary': 'Open-air adventure.',
+        'rating': 92.5,
+    }
+    headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
+    resp = test_client.get(f"/v1/games/{game_id}", headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['genre'] == 'Adventure, RPG'
+    assert data['platforms'] == 'Switch'
+    assert data['summary'] == 'Open-air adventure.'
+
+
+# --- Search proxy ---
+def test_search_games_requires_auth(test_client: TestClient):
+    response = test_client.get('/v1/games/search?q=zelda')
+    assert response.status_code == 401
+
+
+def test_search_games_unconfigured_returns_503(test_client: TestClient):
+    # No TWITCH_CLIENT_ID/SECRET in the test environment.
+    headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
+    response = test_client.get('/v1/games/search?q=zelda', headers=headers)
+    assert response.status_code == 503
+
+
+@patch('app.router.v1.router_games.igdb_search_games')
+def test_search_games_returns_results(mock_search, test_client: TestClient):
+    mock_search.return_value = [
+        {
+            'igdb': 1234,
+            'title': 'Breath of the Wild',
+            'year': '2017',
+            'platforms': 'Switch',
+            'poster_url': 'https://images.igdb.com/x/co3p2d.jpg',
+        }
+    ]
+    headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
+    response = test_client.get('/v1/games/search?q=zelda', headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data[0]['igdb'] == 1234
+    assert data[0]['platforms'] == 'Switch'
+
+
+# --- Trackers (Movies-parity lists + 100% flag) ---
+def test_mark_game_to_rankings_is_unplaced(test_client: TestClient):
+    game_id = _make_game(test_client)
+    headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
     response = test_client.post(
         f"/v1/users/me/games/{game_id}",
-        headers=user_headers,
-        json={'rank': 1, 'is_100_percent': True},
+        headers=headers,
+        json={'on_rankings': True, 'notes': 'GOTY'},
     )
     assert response.status_code == 201
     data = response.json()
-    assert data['rank'] == 1
-    assert data['is_100_percent'] is True
+    assert data['on_rankings'] is True
+    assert data['on_watchlist'] is False
+    assert data['rank'] is None
+    assert data['is_100_percent'] is False
+
+
+def test_hundred_percent_flag(test_client: TestClient):
+    game_id = _make_game(test_client)
+    headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
+    test_client.post(
+        f"/v1/users/me/games/{game_id}", headers=headers, json={'on_rankings': True}
+    )
+    r = test_client.put(
+        f"/v1/users/me/games/{game_id}",
+        headers=headers,
+        json={'is_100_percent': True},
+    )
+    assert r.json()['is_100_percent'] is True
+    assert r.json()['on_rankings'] is True
+
+
+def test_lists_are_independent(test_client: TestClient):
+    game_id = _make_game(test_client)
+    headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
+
+    r = test_client.post(
+        f"/v1/users/me/games/{game_id}", headers=headers, json={'on_watchlist': True}
+    )
+    assert r.json()['on_watchlist'] is True
+    assert r.json()['on_rankings'] is False
+
+    r = test_client.post(
+        f"/v1/users/me/games/{game_id}", headers=headers, json={'on_rankings': True}
+    )
+    assert r.json()['on_watchlist'] is True
+    assert r.json()['on_rankings'] is True
+    assert r.json()['rank'] is None
+
+    # Off both lists -> tracker dropped.
+    test_client.put(
+        f"/v1/users/me/games/{game_id}",
+        headers=headers,
+        json={'on_watchlist': False, 'on_rankings': False},
+    )
+    listing = test_client.get('/v1/users/me/games', headers=headers).json()
+    assert all(t['game']['id'] != game_id for t in listing)
+
+
+def test_set_game_rank_inserts_and_shifts(test_client: TestClient):
+    headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
+    ids = []
+    for i in range(3):
+        gid = _make_game(test_client, title=f"Ranked {i}")
+        test_client.post(
+            f"/v1/users/me/games/{gid}", headers=headers, json={'on_rankings': True}
+        )
+        ids.append(gid)
+    test_client.put(
+        '/v1/users/me/games/rankings/order',
+        headers=headers,
+        json={'game_ids': ids},
+    )
+
+    new_id = _make_game(test_client, title='Inserted')
+    test_client.post(
+        f"/v1/users/me/games/{new_id}", headers=headers, json={'on_rankings': True}
+    )
+    resp = test_client.put(
+        f"/v1/users/me/games/{new_id}/rank", headers=headers, json={'position': 2}
+    )
+    assert resp.status_code == 200
+    assert resp.json()['rank'] == 2
+
+    listing = test_client.get('/v1/users/me/games', headers=headers).json()
+    ranked = sorted(
+        [t for t in listing if t['rank'] is not None], key=lambda t: t['rank']
+    )
+    order = [(t['rank'], t['game']['id']) for t in ranked]
+    assert order == [(1, ids[0]), (2, new_id), (3, ids[1]), (4, ids[2])]
+
+
+def test_reorder_rankings(test_client: TestClient):
+    headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
+    ids = []
+    for i in range(3):
+        gid = _make_game(test_client, title=f"Game {i}")
+        test_client.post(
+            f"/v1/users/me/games/{gid}", headers=headers, json={'on_rankings': True}
+        )
+        ids.append(gid)
+
+    reordered = list(reversed(ids))
+    resp = test_client.put(
+        '/v1/users/me/games/rankings/order',
+        headers=headers,
+        json={'game_ids': reordered},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [t['game']['id'] for t in data] == reordered
+    assert [t['rank'] for t in data] == [1, 2, 3]

--- a/tests/unit/game_search_test.py
+++ b/tests/unit/game_search_test.py
@@ -1,0 +1,147 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+# pylint: disable=protected-access, missing-class-docstring
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.config import Settings
+from app.services import game_search
+
+
+def _reset_token_cache():
+    game_search._token_cache = (None, 0.0)
+
+
+def test_helpers():
+    assert game_search._cover({'cover': {'image_id': 'abc'}}) == (
+        'https://images.igdb.com/igdb/image/upload/t_cover_big/abc.jpg'
+    )
+    assert game_search._cover({}) is None
+    assert game_search._release({'first_release_date': 1496275200}).year == 2017
+    assert game_search._release({}) is None
+    assert (
+        game_search._names(
+            {'platforms': [{'abbreviation': 'PS5'}, {'abbreviation': 'PC'}]},
+            'platforms',
+            'abbreviation',
+        )
+        == 'PS5, PC'
+    )
+    assert game_search._names({}, 'genres') is None
+
+
+def test_apply_detail_truncates_and_skips_none():
+    class Game:
+        genre = None
+        platforms = None
+        summary = None
+
+    g = Game()
+    game_search.apply_detail_to_game(
+        g, {'genre': 'x' * 999, 'platforms': 'PC', 'summary': None}
+    )
+    assert len(g.genre) == 255  # truncated to column limit
+    assert g.platforms == 'PC'
+    assert g.summary is None  # None values are skipped
+
+
+@patch('app.services.game_search.get_settings')
+def test_search_unconfigured_returns_503(mock_settings):
+    _reset_token_cache()
+    mock_settings.return_value = Settings(
+        twitch_client_id=None, twitch_client_secret=None, env='github'
+    )
+    with pytest.raises(HTTPException) as exc:
+        game_search.search_games('zelda')
+    assert exc.value.status_code == 503
+
+
+@patch('app.services.game_search.get_settings')
+def test_get_game_detail_unconfigured_returns_none(mock_settings):
+    _reset_token_cache()
+    mock_settings.return_value = Settings(
+        twitch_client_id=None, twitch_client_secret=None, env='github'
+    )
+    assert game_search.get_game_detail(1234) is None
+    assert game_search.get_game_detail(None) is None
+
+
+@patch('app.services.game_search.get_settings')
+@patch('app.services.game_search.requests.post')
+def test_search_games_returns_results(mock_post, mock_settings):
+    _reset_token_cache()
+    mock_settings.return_value = Settings(
+        twitch_client_id='cid', twitch_client_secret='secret', env='github'
+    )
+    token_resp = MagicMock()
+    token_resp.raise_for_status.return_value = None
+    token_resp.json.return_value = {'access_token': 'tok', 'expires_in': 5000000}
+    games_resp = MagicMock()
+    games_resp.raise_for_status.return_value = None
+    games_resp.json.return_value = [
+        {
+            'id': 1234,
+            'name': 'The Legend of Zelda: Breath of the Wild',
+            'first_release_date': 1488499200,
+            'platforms': [{'abbreviation': 'Switch'}, {'abbreviation': 'WiiU'}],
+            'cover': {'image_id': 'co3p2d'},
+        }
+    ]
+    mock_post.side_effect = [token_resp, games_resp]
+
+    results = game_search.search_games('zelda')
+    assert len(results) == 1
+    assert results[0]['igdb'] == 1234
+    assert results[0]['title'].startswith('The Legend of Zelda')
+    assert results[0]['year'] == '2017'
+    assert results[0]['platforms'] == 'Switch, WiiU'
+    assert results[0]['poster_url'].endswith('/co3p2d.jpg')
+    _reset_token_cache()
+
+
+@patch('app.services.game_search.get_settings')
+@patch('app.services.game_search.requests.post')
+def test_get_game_detail_maps_fields_and_caches_token(mock_post, mock_settings):
+    _reset_token_cache()
+    mock_settings.return_value = Settings(
+        twitch_client_id='cid', twitch_client_secret='secret', env='github'
+    )
+    token_resp = MagicMock()
+    token_resp.raise_for_status.return_value = None
+    token_resp.json.return_value = {'access_token': 'tok', 'expires_in': 5000000}
+    detail_resp = MagicMock()
+    detail_resp.raise_for_status.return_value = None
+    detail_resp.json.return_value = [
+        {
+            'id': 1234,
+            'name': 'Breath of the Wild',
+            'slug': 'the-legend-of-zelda-breath-of-the-wild',
+            'first_release_date': 1488499200,
+            'total_rating': 92.456,
+            'genres': [{'name': 'Adventure'}, {'name': 'RPG'}],
+            'platforms': [{'abbreviation': 'Switch'}],
+            'summary': 'Open-air adventure.',
+            'cover': {'image_id': 'co3p2d'},
+            'updated_at': 1600000000,
+        }
+    ]
+    second_detail = MagicMock()
+    second_detail.raise_for_status.return_value = None
+    second_detail.json.return_value = []
+    mock_post.side_effect = [token_resp, detail_resp, second_detail]
+
+    detail = game_search.get_game_detail(1234)
+    assert detail['title'] == 'Breath of the Wild'
+    assert detail['year'] == 2017
+    assert detail['genre'] == 'Adventure, RPG'
+    assert detail['platforms'] == 'Switch'
+    assert detail['rating'] == 92.5
+    assert detail['summary'] == 'Open-air adventure.'
+    assert detail['poster_url'].endswith('/co3p2d.jpg')
+    assert detail['igdb_last_update'].year == 2020
+
+    # Second call reuses the cached token (no extra OAuth POST).
+    assert game_search.get_game_detail(9999) is None
+    assert mock_post.call_count == 3  # 1 token + 2 queries
+    _reset_token_cache()


### PR DESCRIPTION
## What
The fifth and final legacy domain (stacks on the Books+Countries PR):
- IGDB v4 search/enrichment via Twitch client-credentials OAuth: process-cached token (evicted + retried once on 401), APIcalypse query escaping (backslashes before quotes), and **503 with a friendly message when `TWITCH_CLIENT_ID`/`TWITCH_CLIENT_SECRET` are unset** — the same graceful degradation as the OMDB movie search.
- `DbVideoGame` gains year/genre/platforms/summary; `poster_url` widened 100→254 (IGDB cover URLs overflow the legacy column). Tracker gains backlog (Watchlist) / played (Rankings) lists, keeping `is_100_percent`.
- Migration backfill: 156 played games keep their 1-based ranks; 20 backlog rank-0 sentinels cleared. Matches `orion_import`'s flag derivation.
- `enrich_games` backfill + `task enrich:games` (needs the Twitch creds from the legacy prod env).

## Verified
- 151 tests, pylint 10/10, pre-commit green.
- Live against migrated data: catalog, tracker/100%/rank flow; search verified to 503 while unconfigured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)