### PR TITLE
Allow any signed-in user to add catalog entries (fixes add-from-search)

### DIFF
--- a/app/router/v1/router_books.py
+++ b/app/router/v1/router_books.py
@@ -56,8 +56,10 @@ def search_books_endpoint(
 def create_book(
     request: BookCreate,
     db: Session = Depends(get_db),
-    current_user: list = Depends(require_admin),
+    current_user: list = Depends(get_current_user),
 ):
+    # Any signed-in user may add to the shared catalog (the add-from-search
+    # flow); editing and deleting catalog entries stay admin-only.
     del current_user
     # Normalize before the dedupe check — enrichment stores dash-free ISBNs.
     isbn = (request.isbn or '').replace('-', '').strip() or None

--- a/app/router/v1/router_games.py
+++ b/app/router/v1/router_games.py
@@ -59,8 +59,10 @@ def search_games_endpoint(
 def create_game(
     request: VideoGameCreate,
     db: Session = Depends(get_db),
-    current_user: list = Depends(require_admin),
+    current_user: list = Depends(get_current_user),
 ):
+    # Any signed-in user may add to the shared catalog (the add-from-search
+    # flow); editing and deleting catalog entries stay admin-only.
     del current_user
     if request.igdb:
         existing = (

--- a/app/router/v1/router_movies.py
+++ b/app/router/v1/router_movies.py
@@ -53,8 +53,10 @@ def search_movies_endpoint(
 def create_movie(
     request: MovieCreate,
     db: Session = Depends(get_db),
-    current_user: list = Depends(require_admin),
+    current_user: list = Depends(get_current_user),
 ):
+    # Any signed-in user may add to the shared catalog (the add-from-search
+    # flow); editing and deleting catalog entries stay admin-only.
     del current_user
     existing = db.query(DbMovie).filter(DbMovie.imdb == request.imdb).first()
     if existing:

--- a/app/router/v1/router_tv.py
+++ b/app/router/v1/router_tv.py
@@ -67,8 +67,10 @@ def search_tv_shows_endpoint(
 def create_tv_show(
     request: TVShowCreate,
     db: Session = Depends(get_db),
-    current_user: list = Depends(require_admin),
+    current_user: list = Depends(get_current_user),
 ):
+    # Any signed-in user may add to the shared catalog (the add-from-search
+    # flow); editing and deleting catalog entries stay admin-only.
     del current_user
     if request.tvmaze:
         existing = db.query(DbTVShow).filter(DbTVShow.tvmaze == request.tvmaze).first()

--- a/tests/integration/router_books_test.py
+++ b/tests/integration/router_books_test.py
@@ -37,10 +37,11 @@ def test_create_book_unauthenticated(test_client: TestClient):
     assert response.status_code == 401
 
 
-def test_create_book_requires_admin(test_client: TestClient):
+def test_create_book_allowed_for_any_user(test_client: TestClient):
+    """Regular users add to the shared catalog via the add-from-search flow."""
     headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
     response = test_client.post('/v1/books', headers=headers, json={'title': 'Dune'})
-    assert response.status_code == 403
+    assert response.status_code == 201
 
 
 def test_create_duplicate_isbn_rejected(test_client: TestClient):

--- a/tests/integration/router_games_test.py
+++ b/tests/integration/router_games_test.py
@@ -37,10 +37,11 @@ def test_create_game_unauthenticated(test_client: TestClient):
     assert response.status_code == 401
 
 
-def test_create_game_requires_admin(test_client: TestClient):
+def test_create_game_allowed_for_any_user(test_client: TestClient):
+    """Regular users add to the shared catalog via the add-from-search flow."""
     headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
     response = test_client.post('/v1/games', headers=headers, json={'title': 'Zelda'})
-    assert response.status_code == 403
+    assert response.status_code == 201
 
 
 def test_create_duplicate_igdb_rejected(test_client: TestClient):

--- a/tests/integration/router_movies_test.py
+++ b/tests/integration/router_movies_test.py
@@ -236,13 +236,14 @@ def test_create_movie_unauthenticated(test_client: TestClient):
     assert response.status_code == 401
 
 
-def test_create_movie_requires_admin(test_client: TestClient):
+def test_create_movie_allowed_for_any_user(test_client: TestClient):
+    """Regular users add to the shared catalog via the add-from-search flow."""
     user_token = test_client.first_user.token
     headers = {'Authorization': f"Bearer {user_token}"}
     response = test_client.post(
         '/v1/movies', headers=headers, json={'title': 'Inception', 'imdb': 'tt1375666'}
     )
-    assert response.status_code == 403
+    assert response.status_code == 201
 
 
 def test_update_movie_requires_admin(test_client: TestClient):

--- a/tests/integration/router_tv_test.py
+++ b/tests/integration/router_tv_test.py
@@ -61,12 +61,13 @@ def test_create_tv_show_unauthenticated(test_client: TestClient):
     assert response.status_code == 401
 
 
-def test_create_tv_show_requires_admin(test_client: TestClient):
+def test_create_tv_show_allowed_for_any_user(test_client: TestClient):
+    """Regular users add to the shared catalog via the add-from-search flow."""
     headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
     response = test_client.post(
         '/v1/tv-shows', headers=headers, json={'title': 'Breaking Bad'}
     )
-    assert response.status_code == 403
+    assert response.status_code == 201
 
 
 def test_create_duplicate_tvmaze_rejected(test_client: TestClient):


### PR DESCRIPTION
## Summary
Google sign-in creates accounts in the `user` group, and every add-from-search flow first creates the shared catalog entry — which was admin-only. Result: regular users couldn't add anything from search, in any domain.

- Catalog **create** for movies / tv-shows / games / books now requires authentication only, matching the legacy product model of a shared, user-built catalog (entries are enriched from OMDB/TVMaze/IGDB/Open Library on create, so quality is bounded)
- **Edit, delete, and episode sync remain admin-only**
- Flipped the four `create_*_requires_admin` tests to assert 201 for a regular user; unauthenticated create still 401s

## Test plan
- [x] 178 pytest
- [x] Live verification with a fresh non-admin account: direct catalog create 201 (was 403), full add-from-search through the web BFF 201, catalog delete still 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)