### PR TITLE
Search: retry with spell-corrected query on empty results

### DIFF
--- a/app/router/v1/router_books.py
+++ b/app/router/v1/router_books.py
@@ -33,6 +33,7 @@ from app.services.book_search import (
     get_book_detail,
     search_books as openlibrary_search_books,
 )
+from app.services.search_correction import correct_query
 
 router = APIRouter(prefix='/v1', tags=['Books'])
 
@@ -49,7 +50,12 @@ def search_books_endpoint(
     current_user: list = Depends(get_current_user),
 ):
     del current_user  # any authenticated user may search
-    return openlibrary_search_books(q)
+    results = openlibrary_search_books(q)
+    if not results:
+        corrected = correct_query(q)
+        if corrected:
+            results = openlibrary_search_books(corrected)
+    return results
 
 
 @router.post('/books', response_model=BookResponse, status_code=status.HTTP_201_CREATED)

--- a/app/router/v1/router_games.py
+++ b/app/router/v1/router_games.py
@@ -34,6 +34,7 @@ from app.services.game_search import (
     get_game_detail,
     search_games as igdb_search_games,
 )
+from app.services.search_correction import correct_query
 
 router = APIRouter(prefix='/v1', tags=['Video Games'])
 
@@ -50,7 +51,12 @@ def search_games_endpoint(
     current_user: list = Depends(get_current_user),
 ):
     del current_user  # any authenticated user may search
-    return igdb_search_games(q)
+    results = igdb_search_games(q)
+    if not results:
+        corrected = correct_query(q)
+        if corrected:
+            results = igdb_search_games(corrected)
+    return results
 
 
 @router.post(

--- a/app/router/v1/router_movies.py
+++ b/app/router/v1/router_movies.py
@@ -28,6 +28,7 @@ from app.services.movie_search import (
     get_movie_detail,
     search_movies as omdb_search_movies,
 )
+from app.services.search_correction import correct_query
 
 router = APIRouter(prefix='/v1', tags=['Movies'])
 
@@ -44,7 +45,12 @@ def search_movies_endpoint(
     current_user: list = Depends(get_current_user),
 ):
     del current_user  # any authenticated user may search
-    return omdb_search_movies(q)
+    results = omdb_search_movies(q)
+    if not results:
+        corrected = correct_query(q)
+        if corrected:
+            results = omdb_search_movies(corrected)
+    return results
 
 
 @router.post(

--- a/app/router/v1/router_tv.py
+++ b/app/router/v1/router_tv.py
@@ -42,6 +42,7 @@ from app.services.tv_search import (
     search_tv_shows as tvmaze_search_shows,
     sync_episodes,
 )
+from app.services.search_correction import correct_query
 
 router = APIRouter(prefix='/v1', tags=['TV'])
 
@@ -58,7 +59,12 @@ def search_tv_shows_endpoint(
     current_user: list = Depends(get_current_user),
 ):
     del current_user  # any authenticated user may search
-    return tvmaze_search_shows(q)
+    results = tvmaze_search_shows(q)
+    if not results:
+        corrected = correct_query(q)
+        if corrected:
+            results = tvmaze_search_shows(corrected)
+    return results
 
 
 @router.post(

--- a/app/services/search_correction.py
+++ b/app/services/search_correction.py
@@ -1,0 +1,37 @@
+"""
+Spelling fallback for the search proxies.
+
+The external providers (OMDB especially) do exact-ish matching, so a typo
+like "jurrasic" returns nothing. When a search comes back empty, the routers
+retry once with a spell-corrected query. Correction is per-word against an
+offline English dictionary; words it can't improve pass through unchanged,
+so proper nouns degrade gracefully to the original behavior.
+"""
+
+from typing import Optional
+
+from spellchecker import SpellChecker
+
+_spell: Optional[SpellChecker] = None
+
+
+def correct_query(query: str) -> Optional[str]:
+    """
+    Best-effort respelling of ``query``. Returns the corrected string, or
+    None when correction wouldn't change anything (so callers can skip the
+    retry).
+    """
+    global _spell  # pylint: disable=global-statement
+    if _spell is None:
+        # Lazy: loading the dictionary costs ~0.3s; only pay it on the first
+        # empty search result, not at import time.
+        _spell = SpellChecker()
+
+    words = query.split()
+    if not words:
+        return None
+    corrected = [_spell.correction(word) or word for word in words]
+    result = ' '.join(corrected)
+    if result.lower() == query.lower():
+        return None
+    return result

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,3 +18,4 @@ google-auth==2.55.2
 requests>=2.34.2 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=2.7.0 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=4.1.0 # not directly required, pinned by Snyk to avoid a vulnerability
+pyspellchecker>=0.8.1

--- a/tests/integration/router_movies_test.py
+++ b/tests/integration/router_movies_test.py
@@ -315,3 +315,28 @@ def test_search_movies_returns_results(
     assert data[0]['poster_url'] == 'https://example.com/matrix.jpg'
     # 'N/A' posters are normalized to null.
     assert data[1]['poster_url'] is None
+
+
+@patch('app.router.v1.router_movies.omdb_search_movies')
+def test_search_retries_with_spelling_fix(mock_search, test_client: TestClient):
+    """An empty result retries once with a spell-corrected query."""
+    hit = [{'imdb': 'tt0107290', 'title': 'Jurassic Park', 'year': '1993'}]
+    mock_search.side_effect = [[], hit]
+    headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
+
+    response = test_client.get('/v1/movies/search?q=jurrasic', headers=headers)
+    assert response.status_code == 200
+    assert response.json()[0]['title'] == 'Jurassic Park'
+    assert mock_search.call_count == 2
+    assert mock_search.call_args_list[1].args[0] == 'jurassic'
+
+
+@patch('app.router.v1.router_movies.omdb_search_movies')
+def test_search_no_retry_when_spelling_correct(mock_search, test_client: TestClient):
+    mock_search.return_value = []
+    headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
+
+    response = test_client.get('/v1/movies/search?q=jurassic', headers=headers)
+    assert response.status_code == 200
+    assert response.json() == []
+    assert mock_search.call_count == 1

--- a/tests/unit/search_correction_test.py
+++ b/tests/unit/search_correction_test.py
@@ -1,0 +1,26 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+from app.services.search_correction import correct_query
+
+
+def test_corrects_misspelled_word():
+    assert correct_query('jurrasic') == 'jurassic'
+
+
+def test_corrects_within_phrase():
+    assert correct_query('jurrasic park') == 'jurassic park'
+
+
+def test_returns_none_when_already_correct():
+    assert correct_query('jurassic') is None
+    assert correct_query('the matrix') is None
+
+
+def test_unknown_words_pass_through():
+    # Proper nouns the dictionary can't fix don't block the phrase.
+    result = correct_query('tarantino filmz')
+    assert result is None or 'tarantino' in result
+
+
+def test_empty_query():
+    assert correct_query('') is None
+    assert correct_query('   ') is None


### PR DESCRIPTION
## Summary
"jurrasic" returned nothing — OMDB and friends do exact-ish matching. All four search endpoints (movies/tv/games/books) now retry once with a per-word spelling correction (`pyspellchecker`, offline dictionary, lazily loaded) when the original query returns empty. Words the dictionary can't improve pass through unchanged, so proper-noun queries behave exactly as before.

## Test plan
- [x] 185 pytest (7 new: correction unit tests + retry/no-retry integration)
- [x] Live: `jurrasic` → 10 results (Jurassic Park…), `severence` → Severance

🤖 Generated with [Claude Code](https://claude.com/claude-code)