### PR TITLE
Cloud Run production support: structured JSON logs, PORT env, release deploy workflow

### DIFF
--- a/.github/workflows/deploy_cloud_run.yaml
+++ b/.github/workflows/deploy_cloud_run.yaml
@@ -1,0 +1,57 @@
+name: Deploy to Cloud Run
+
+# Prod deploys are release-driven (see druthers-infra/docs/PROMOTION.md):
+# publishing a vX.Y.Z release builds the image into Artifact Registry,
+# runs alembic migrations against Neon, and rolls the druthers-api service.
+# No-ops until the GCP_* repo variables exist (set by the launch runbook).
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: vars.GCP_WIF_PROVIDER != ''
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      IMAGE: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/druthers/aleonard.us-api:${{ github.event.release.tag_name }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SA }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Build and push image
+        run: |
+          gcloud auth configure-docker ${{ vars.GCP_REGION }}-docker.pkg.dev --quiet
+          docker build -t "$IMAGE" .
+          docker push "$IMAGE"
+
+      - name: Run database migrations
+        env:
+          DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+          ENV: prod
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "NEON_DATABASE_URL secret not set — skipping migrations."
+            exit 0
+          fi
+          pip install -r requirements/base.txt
+          alembic upgrade head
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy druthers-api \
+            --image "$IMAGE" \
+            --region ${{ vars.GCP_REGION }} \
+            --project ${{ vars.GCP_PROJECT_ID }}

--- a/app/log/logging_config.py
+++ b/app/log/logging_config.py
@@ -2,7 +2,9 @@
 Logging configuration for the API
 """
 
+import json
 import logging
+import os
 from logging.handlers import RotatingFileHandler
 from typing import override
 
@@ -45,6 +47,39 @@ class CustomFormatter(logging.Formatter):
         return formatter.format(record)
 
 
+class GcpJsonFormatter(logging.Formatter):
+    """
+    One JSON object per line, in the shape Google Cloud Logging ingests
+    natively from Cloud Run stdout: ``severity`` maps onto log levels and
+    exception tracebacks ride inside ``message`` so Error Reporting can
+    group them.
+    """
+
+    @override
+    def format(self, record):
+        """
+        Serialize the record as a single-line JSON log entry.
+        """
+        message = record.getMessage()
+        if record.exc_info:
+            message = f'{message}\n{self.formatException(record.exc_info)}'
+        entry = {
+            'severity': record.levelname,
+            'message': message,
+            'logger': record.name,
+            'source': f'{record.filename}:{record.lineno}',
+            'env': get_settings().env,
+        }
+        return json.dumps(entry)
+
+
+def running_on_cloud_run() -> bool:
+    """
+    True when executing on Google Cloud Run (which always sets K_SERVICE).
+    """
+    return bool(os.getenv('K_SERVICE'))
+
+
 # Create or retrieve a logger
 logger = logging.getLogger('aleonard_api')
 
@@ -72,13 +107,18 @@ def configure_logger():
     file_log_formatter.datefmt = '%Y-%m-%d %H:%M:%S'
 
     # Used separate formatters as color ASCII threw off the file log formatting
-    ch.setFormatter(CustomFormatter())
+    # On Cloud Run, stdout is the log pipeline: emit structured JSON instead.
+    if running_on_cloud_run():
+        ch.setFormatter(GcpJsonFormatter())
+    else:
+        ch.setFormatter(CustomFormatter())
     logger.addHandler(ch)
 
     logger.debug('API env set to: %s', settings.env)
 
-    # File + Loki handlers are noise in CI; only attach them when deployed/local.
-    if settings.is_ci:
+    # File + Loki handlers are noise in CI, and on Cloud Run the container
+    # filesystem is ephemeral and Cloud Logging already has everything.
+    if settings.is_ci or running_on_cloud_run():
         return
 
     # Mode 'a' appends to the log file across restarts.

--- a/app/run.py
+++ b/app/run.py
@@ -4,6 +4,7 @@ This module contains the main application setup and routing.
 
 import asyncio
 import json
+import os
 
 import uvicorn
 from fastapi import FastAPI
@@ -171,8 +172,8 @@ async def start_server():
     uvicorn.run(
         'app.run:app',
         host='0.0.0.0',
-        port=8000,
-        reload=True,
+        port=int(os.getenv('PORT', '8000')),
+        reload=settings.is_local,
         log_level=settings.log_level.lower(),
     )
 

--- a/app/utils/exceptions.py
+++ b/app/utils/exceptions.py
@@ -10,6 +10,7 @@ from starlette.status import (
     HTTP_500_INTERNAL_SERVER_ERROR,
 )
 
+from app.log.logging_config import logger
 from app.schemas.model_schemas import OutResponseBaseModel
 
 
@@ -37,10 +38,22 @@ async def validation_exception_handler(_: Request, exc: RequestValidationError):
     )
 
 
-async def generic_exception_handler(_: Request, exc: Exception):
+async def generic_exception_handler(request: Request, exc: Exception):
     """
     Custom handler for generic exceptions.
+
+    Logs the full traceback (severity ERROR) before responding — without this
+    a 500 leaves no trace in the logs, so alerting and Error Reporting
+    grouping would never see it.
     """
+    # scope.get keeps the logging path safe even for malformed/partial scopes
+    logger.error(
+        'Unhandled exception on %s %s: %s',
+        request.scope.get('method', '-'),
+        request.scope.get('path', '-'),
+        exc,
+        exc_info=exc,
+    )
     return JSONResponse(
         status_code=HTTP_500_INTERNAL_SERVER_ERROR,
         content=OutResponseBaseModel(

--- a/tests/unit/exceptions_test.py
+++ b/tests/unit/exceptions_test.py
@@ -39,18 +39,22 @@ async def test_http_exception_handler():
 
 
 @pytest.mark.asyncio
-async def test_generic_exception_handler():
+async def test_generic_exception_handler(caplog):
     """
     Test the custom generic exception handler.
     """
-    request = Request(scope={'type': 'http'})
+    request = Request(scope={'type': 'http', 'method': 'GET', 'path': '/boom'})
     exc = Exception('Test exception')
-    response = await generic_exception_handler(request, exc)
+    with caplog.at_level('ERROR', logger='aleonard_api'):
+        response = await generic_exception_handler(request, exc)
     response_body = json.loads(response.body.decode('utf-8'))
     assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
     assert response_body['success'] is False
     assert response_body['message'] == 'Test exception'
     assert response_body['data'] == []
+    # The 500 must leave a traceback in the logs (Error Reporting feeds on it)
+    assert 'Unhandled exception on GET /boom' in caplog.text
+    assert 'Test exception' in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/logging_config_test.py
+++ b/tests/unit/logging_config_test.py
@@ -1,0 +1,63 @@
+"""
+Test the Cloud Run structured-logging pieces of logging_config.
+"""
+
+import json
+import logging
+import sys
+
+from app.log.logging_config import GcpJsonFormatter, running_on_cloud_run
+
+
+def make_record(level, msg, exc_info=None):
+    """
+    Build a bare LogRecord for formatter tests.
+    """
+    return logging.LogRecord(
+        name='aleonard_api',
+        level=level,
+        pathname='somefile.py',
+        lineno=42,
+        msg=msg,
+        args=(),
+        exc_info=exc_info,
+    )
+
+
+def test_gcp_json_formatter_shapes_entry():
+    """
+    Entries are single-line JSON with Cloud Logging's severity field.
+    """
+    out = GcpJsonFormatter().format(make_record(logging.WARNING, 'heads up'))
+    entry = json.loads(out)
+    assert entry['severity'] == 'WARNING'
+    assert entry['message'] == 'heads up'
+    assert entry['logger'] == 'aleonard_api'
+    assert entry['source'] == 'somefile.py:42'
+    assert '\n' not in out
+
+
+def test_gcp_json_formatter_includes_traceback():
+    """
+    Exception tracebacks ride inside message so Error Reporting groups them.
+    """
+    record = None
+    try:
+        raise ValueError('kaboom')
+    except ValueError:
+        record = make_record(logging.ERROR, 'it broke', exc_info=sys.exc_info())
+    entry = json.loads(GcpJsonFormatter().format(record))
+    assert entry['severity'] == 'ERROR'
+    assert 'it broke' in entry['message']
+    assert 'Traceback' in entry['message']
+    assert 'ValueError: kaboom' in entry['message']
+
+
+def test_running_on_cloud_run(monkeypatch):
+    """
+    Detection keys off the K_SERVICE env var Cloud Run always sets.
+    """
+    monkeypatch.delenv('K_SERVICE', raising=False)
+    assert running_on_cloud_run() is False
+    monkeypatch.setenv('K_SERVICE', 'druthers-api')
+    assert running_on_cloud_run() is True


### PR DESCRIPTION
<!-- See SDLC.md for the workflow. -->

## What & why

Production support for the druthers.io Cloud Run launch (ALeonard9/druthers-infra#1, ALeonard9/druthers-infra#2):

- **Structured JSON logging on Cloud Run** — when `K_SERVICE` is present, stdout emits one JSON entry per line (`severity`, `message`, `logger`, `source`, `env`) that Cloud Logging ingests natively; exception tracebacks ride inside `message` so Error Reporting groups them. Local/QA behavior (colored console, file, Loki) is unchanged.
- **Unhandled exceptions now get logged** — `generic_exception_handler` previously returned a 500 without any log line, so alerting/Error Reporting would never have seen crashes. It now logs the traceback at ERROR with method + path.
- **`PORT` env respected** (default 8000) and `reload` only in local — Cloud Run injects `PORT`; hot-reload in a prod container was wasted overhead. Dev containers don't mount source, so nothing loses reload except prod.
- **`deploy_cloud_run.yaml`** — on release publish: build → push to Artifact Registry (keyless via WIF) → `alembic upgrade head` against Neon (`NEON_DATABASE_URL` secret, skips if unset) → deploy `druthers-api`. No-ops until the `GCP_*` repo variables are set by the launch runbook (druthers-infra/docs/LAUNCH-RUNBOOK.md step 4), so merging this is safe pre-launch.

## How verified

- `black --check --skip-string-normalization`, `pylint` 10/10, full suite **198 passed** locally (pre-commit hooks ran the same on commit).
- New tests: `GcpJsonFormatter` shape + traceback embedding, `running_on_cloud_run` detection; `test_generic_exception_handler` extended to assert the ERROR log fires.
- Workflow is inert by design until launch (guarded by `vars.GCP_WIF_PROVIDER`).

## Checklist

- [x] Branch named `feat/…`, `fix/…`, or `chore/…`
- [x] CI green (lint + tests)
- [x] No secrets committed
- [x] Docs/README updated if behavior changed (docs live in druthers-infra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
