### PR TITLE
API keys: mint/list/revoke + drk_ bearer auth for MCP and crons

### DIFF
--- a/alembic/versions/2c4970e2c27f_movie_detail_year_genre_director_actors_.py
+++ b/alembic/versions/2c4970e2c27f_movie_detail_year_genre_director_actors_.py
@@ -11,7 +11,6 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision: str = '2c4970e2c27f'
 down_revision: Union[str, Sequence[str], None] = '56d230517330'

--- a/alembic/versions/56d230517330_movie_tracker_on_watchlist_on_rankings.py
+++ b/alembic/versions/56d230517330_movie_tracker_on_watchlist_on_rankings.py
@@ -11,7 +11,6 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision: str = '56d230517330'
 down_revision: Union[str, Sequence[str], None] = 'a3732379d384'

--- a/alembic/versions/b41f0a7c9e21_api_keys_table.py
+++ b/alembic/versions/b41f0a7c9e21_api_keys_table.py
@@ -1,0 +1,51 @@
+"""api keys table
+
+Revision ID: b41f0a7c9e21
+Revises: cf876ee82d17
+Create Date: 2026-07-18 09:55:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'b41f0a7c9e21'
+down_revision: Union[str, Sequence[str], None] = 'cf876ee82d17'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'api_keys',
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(length=60), nullable=False),
+        sa.Column('key_hash', sa.String(length=64), nullable=False),
+        sa.Column('prefix', sa.String(length=12), nullable=False),
+        sa.Column('last_used_at', sa.DateTime(), nullable=True),
+        sa.Column('pk', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('id', sa.String(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['users.pk']),
+        sa.PrimaryKeyConstraint('pk'),
+    )
+    with op.batch_alter_table('api_keys', schema=None) as batch_op:
+        batch_op.create_index(batch_op.f('ix_api_keys_id'), ['id'], unique=True)
+        batch_op.create_index(batch_op.f('ix_api_keys_pk'), ['pk'], unique=False)
+        batch_op.create_index(
+            batch_op.f('ix_api_keys_key_hash'), ['key_hash'], unique=True
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('api_keys', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_api_keys_key_hash'))
+        batch_op.drop_index(batch_op.f('ix_api_keys_pk'))
+        batch_op.drop_index(batch_op.f('ix_api_keys_id'))
+    op.drop_table('api_keys')

--- a/alembic/versions/cf876ee82d17_notifications_table.py
+++ b/alembic/versions/cf876ee82d17_notifications_table.py
@@ -11,7 +11,6 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision: str = 'cf876ee82d17'
 down_revision: Union[str, Sequence[str], None] = '32dcf2b915ce'

--- a/app/auth/oauth2.py
+++ b/app/auth/oauth2.py
@@ -2,6 +2,7 @@
 This module creates access tokens and verifys tokens.
 """
 
+import hashlib
 import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Optional
@@ -48,6 +49,39 @@ SECRET_KEY = _resolve_secret_key()
 ALGORITHM = 'HS256'
 ACCESS_TOKEN_EXPIRE_MINUTES = settings.access_token_expire_minutes
 
+# API keys ride the same Authorization: Bearer header as JWTs; the prefix is
+# how we tell them apart (and lets secret scanners recognize leaked keys).
+API_KEY_PREFIX = 'drk_'
+
+
+def generate_api_key() -> str:
+    """Mint a new API key secret (returned to the user exactly once)."""
+    return f'{API_KEY_PREFIX}{secrets.token_hex(24)}'
+
+
+def hash_api_key(key: str) -> str:
+    """SHA-256 of the full key — the only form ever stored."""
+    return hashlib.sha256(key.encode()).hexdigest()
+
+
+def _user_from_api_key(token: str, db: Session, credentials_exception):
+    """
+    Resolve a ``drk_`` bearer token to its owner, or raise.
+
+    Returns the same one-element-list shape as the JWT path so routes can't
+    tell the difference.
+    """
+    # Local import: models imports nothing from here, but keeping it out of
+    # module scope avoids widening the auth module's import surface.
+    from app.db.models import DbApiKey  # pylint: disable=import-outside-toplevel
+
+    row = db.query(DbApiKey).filter(DbApiKey.key_hash == hash_api_key(token)).first()
+    if row is None:
+        raise credentials_exception
+    row.last_used_at = datetime.now(timezone.utc)
+    db.commit()
+    return [row.user]
+
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
     """
@@ -74,6 +108,8 @@ def get_current_user(
         detail='Could not validate credentials',
         headers={'WWW-Authenticate': 'Bearer'},
     )
+    if token.startswith(API_KEY_PREFIX):
+        return _user_from_api_key(token, db, credentials_exception)
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
         uuid: str = payload.get('sub')

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -5,7 +5,8 @@ This module defines the database models.
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, DateTime, Integer, String
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
 
 from app.db.database import Base
 
@@ -38,6 +39,25 @@ class DbUser(DBBaseModel):
     display_name = Column(String(length=30))
     user_group = Column(String, default='user')
     password = Column(String)
+
+
+class DbApiKey(DBBaseModel):
+    """
+    Long-lived API key for programmatic access (MCP servers, crons).
+
+    Only the SHA-256 hash of the secret is stored; the plaintext is shown
+    exactly once at creation. ``prefix`` is a short display hint so a user
+    can tell keys apart in a list.
+    """
+
+    __tablename__ = 'api_keys'
+    user_id = Column(Integer, ForeignKey('users.pk'), nullable=False)
+    name = Column(String(length=60), nullable=False)
+    key_hash = Column(String(length=64), unique=True, index=True, nullable=False)
+    prefix = Column(String(length=12), nullable=False)
+    last_used_at = Column(DateTime, nullable=True)
+
+    user = relationship('DbUser', backref='api_keys')
 
 
 # Import sandbox models to ensure they are registered with the Base metadata

--- a/app/router/v1/router_api_keys.py
+++ b/app/router/v1/router_api_keys.py
@@ -1,0 +1,85 @@
+# pylint: disable=missing-function-docstring
+"""
+API-key management: long-lived credentials for programmatic access — the MCP
+server running locally, Proxmox crons, scripts. Keys authenticate through the
+normal ``Authorization: Bearer`` header (see app/auth/oauth2.py).
+"""
+
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.auth import oauth2
+from app.auth.oauth2 import get_current_user
+from app.db.database import get_db
+from app.db.models import DbApiKey
+from app.schemas.model_schemas import (
+    InApiKeyCreate,
+    OutApiKey,
+    OutApiKeyCreated,
+)
+
+router = APIRouter(prefix='/v1/users/me/api-keys', tags=['API keys'])
+
+
+@router.post('', response_model=OutApiKeyCreated, status_code=status.HTTP_201_CREATED)
+def create_api_key(
+    body: InApiKeyCreate,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """
+    Mint a new key. The plaintext secret is in this response and nowhere
+    else — it is never stored or shown again.
+    """
+    secret = oauth2.generate_api_key()
+    row = DbApiKey(
+        user_id=current_user[0].pk,
+        name=body.name.strip(),
+        key_hash=oauth2.hash_api_key(secret),
+        prefix=secret[:12],
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return OutApiKeyCreated(
+        id=row.id,
+        name=row.name,
+        prefix=row.prefix,
+        created_at=row.created_at,
+        key=secret,
+    )
+
+
+@router.get('', response_model=List[OutApiKey])
+def list_api_keys(
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    return (
+        db.query(DbApiKey)
+        .filter(DbApiKey.user_id == current_user[0].pk)
+        .order_by(DbApiKey.created_at)
+        .all()
+    )
+
+
+@router.delete('/{key_id}', status_code=status.HTTP_204_NO_CONTENT)
+def revoke_api_key(
+    key_id: str,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """Revocation is deletion — the hash is gone, the key can never auth again."""
+    row = (
+        db.query(DbApiKey)
+        .filter(DbApiKey.id == key_id, DbApiKey.user_id == current_user[0].pk)
+        .first()
+    )
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail='API key not found'
+        )
+    db.delete(row)
+    db.commit()

--- a/app/run.py
+++ b/app/run.py
@@ -24,6 +24,7 @@ from .log.logging_config import logger
 from .router.v1 import (
     user,
     router_activity,
+    router_api_keys,
     router_countries,
     router_notifications,
     router_search,
@@ -92,6 +93,7 @@ app.include_router(router_tv.router)
 app.include_router(router_activity.router)
 app.include_router(router_notifications.router)
 app.include_router(router_search.router)
+app.include_router(router_api_keys.router)
 
 # Serve static files
 app.mount('/static', StaticFiles(directory='app/static'), name='static')

--- a/app/schemas/model_schemas.py
+++ b/app/schemas/model_schemas.py
@@ -5,7 +5,7 @@ This module defines the Pydantic models (schemas) for the API.
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, EmailStr
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 
 # User data provided as input
@@ -67,3 +67,33 @@ class OutResponseUserModel(OutResponseBaseModel):
         arbitrary_types_allowed=True,
         from_attributes=True,
     )
+
+
+class InApiKeyCreate(BaseModel):
+    """
+    Request body for minting an API key.
+    """
+
+    name: str = Field(min_length=1, max_length=60)
+
+
+class OutApiKey(BaseModel):
+    """
+    An API key as shown in listings — never includes the secret.
+    """
+
+    id: str
+    name: str
+    prefix: str
+    created_at: datetime
+    last_used_at: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class OutApiKeyCreated(OutApiKey):
+    """
+    Creation response: the one and only time the plaintext key appears.
+    """
+
+    key: str

--- a/tests/integration/router_api_keys_test.py
+++ b/tests/integration/router_api_keys_test.py
@@ -1,0 +1,95 @@
+"""
+Test API-key management and key-based authentication.
+"""
+
+from fastapi.testclient import TestClient
+
+
+def _create_key(test_client: TestClient, token: str, name: str = 'laptop mcp'):
+    return test_client.post(
+        '/v1/users/me/api-keys',
+        json={'name': name},
+        headers={'Authorization': f'Bearer {token}'},
+    )
+
+
+def test_create_key_returns_secret_once(test_client: TestClient):
+    '''
+    Creation returns the plaintext once; listings never do.
+    '''
+    response = _create_key(test_client, test_client.first_user.token)
+    assert response.status_code == 201
+    body = response.json()
+    assert body['name'] == 'laptop mcp'
+    assert body['key'].startswith('drk_')
+    assert body['prefix'] == body['key'][:12]
+    # Listings never expose the secret
+    listing = test_client.get(
+        '/v1/users/me/api-keys',
+        headers={'Authorization': f'Bearer {test_client.first_user.token}'},
+    )
+    assert listing.status_code == 200
+    assert len(listing.json()) == 1
+    assert 'key' not in listing.json()[0]
+    assert listing.json()[0]['prefix'] == body['prefix']
+
+
+def test_api_key_authenticates_as_owner(test_client: TestClient):
+    '''
+    A drk_ bearer token resolves to its owner and stamps last_used_at.
+    '''
+    key = _create_key(test_client, test_client.first_user.token).json()['key']
+    response = test_client.get(
+        '/v1/users/me/api-keys', headers={'Authorization': f'Bearer {key}'}
+    )
+    assert response.status_code == 200
+    assert response.json()[0]['name'] == 'laptop mcp'
+    # last_used_at is stamped by the auth path
+    assert response.json()[0]['last_used_at'] is not None
+
+
+def test_bogus_api_key_rejected(test_client: TestClient):
+    '''
+    Unknown keys get a 401.
+    '''
+    response = test_client.get(
+        '/v1/users/me/api-keys',
+        headers={'Authorization': 'Bearer drk_' + '0' * 48},
+    )
+    assert response.status_code == 401
+
+
+def test_revoked_key_stops_working(test_client: TestClient):
+    '''
+    Deleting a key immediately kills its auth.
+    '''
+    token = test_client.first_user.token
+    created = _create_key(test_client, token).json()
+    revoke = test_client.delete(
+        f"/v1/users/me/api-keys/{created['id']}",
+        headers={'Authorization': f'Bearer {token}'},
+    )
+    assert revoke.status_code == 204
+    response = test_client.get(
+        '/v1/users/me/api-keys',
+        headers={'Authorization': f"Bearer {created['key']}"},
+    )
+    assert response.status_code == 401
+
+
+def test_cannot_revoke_another_users_key(test_client: TestClient):
+    '''
+    Users can't see or revoke each other's keys.
+    '''
+    created = _create_key(test_client, test_client.first_user.token).json()
+    response = test_client.delete(
+        f"/v1/users/me/api-keys/{created['id']}",
+        headers={'Authorization': f'Bearer {test_client.second_user.token}'},
+    )
+    assert response.status_code == 404
+    # Still works for the owner
+    listing = test_client.get(
+        '/v1/users/me/api-keys',
+        headers={'Authorization': f"Bearer {created['key']}"},
+    )
+    assert listing.status_code == 200


### PR DESCRIPTION
## What & why

The API half of aleonard.us-mcp#4 — users can request an API key so they can run the MCP server locally against prod without password gymnastics:

- **`DbApiKey`** (`api_keys` table, migration `b41f0a7c9e21`): SHA-256 of the secret only, plus a 12-char display prefix and `last_used_at`. Plaintext appears exactly once, in the creation response.
- **Endpoints** (`/v1/users/me/api-keys`): `POST` mint (named), `GET` list (never the secret), `DELETE` revoke — revocation is deletion, effect is immediate.
- **Auth path**: keys are `drk_…` bearer tokens on the existing `Authorization` header — `get_current_user` branches on the prefix and resolves the owner in the same `[DbUser]` shape, so every route and the MCP server work unchanged (`API_TOKEN=drk_…` is a drop-in). The distinctive prefix also makes leaked keys greppable/secret-scannable.
- Keys never appear in logs (only the hash ever touches the DB layer; no logging of the token).

Companion PR: aleonard.us-mcp#5 (README setup instructions for Claude Desktop/Code).

## How verified

- 5 new integration tests: secret-shown-once + listing redaction, key auth resolves owner + stamps `last_used_at`, bogus key 401, revoked key 401 immediately, cross-user revoke 404.
- Full suite **203 passed**; black/pylint 10/10; `alembic heads` = single head `b41f0a7c9e21`.

## Checklist

- [x] Branch named `feat/…`, `fix/…`, or `chore/…`
- [ ] CI green (lint + tests)
- [x] No secrets committed
- [x] Docs updated (MCP README in companion PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
