### PR TITLE
Data export: full-fidelity JSON + per-domain CSVs

### DIFF
--- a/app/router/v1/router_export.py
+++ b/app/router/v1/router_export.py
@@ -1,0 +1,273 @@
+# pylint: disable=missing-function-docstring
+"""
+Data export: everything a user has tracked, in JSON (full fidelity) or
+per-domain CSV. Your data is never locked in.
+"""
+
+import csv
+import io
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import Response
+from sqlalchemy.orm import Session
+
+from app.auth.oauth2 import get_current_user
+from app.db.database import get_db
+from app.db.models_sandbox import (
+    DbTVEpisode,
+    DbUserBook,
+    DbUserMovie,
+    DbUserTVEpisode,
+    DbUserTVShow,
+    DbUserVideoGame,
+)
+from app.schemas.schemas_sandbox import (
+    UserBookResponse,
+    UserMovieResponse,
+    UserTVEpisodeResponse,
+    UserTVShowResponse,
+    UserVideoGameResponse,
+)
+
+router = APIRouter(prefix='/v1/users/me/export', tags=['Export'])
+
+# Data-source licenses ride along so exports stay attributable
+# (see aleonard.us-web docs/DATA-SOURCES.md).
+LICENSES = {
+    'movies': 'Movie data from the OMDb API, CC BY-NC 4.0',
+    'tv': 'TV data from TVmaze, CC BY-SA 4.0',
+    'books': 'Book data from Open Library',
+    'games': 'Game data from IGDB.com',
+}
+
+
+def _state(tracker) -> str:
+    """One-word list membership, mirroring the Activity page's derivation."""
+    if tracker.on_rankings and tracker.rank is not None:
+        return 'ranked'
+    if tracker.on_rankings:
+        return 'to-rank'
+    if tracker.on_watchlist:
+        return 'watchlist'
+    return 'none'
+
+
+def _movies(db: Session, user_pk: int):
+    return db.query(DbUserMovie).filter(DbUserMovie.user_id == user_pk).all()
+
+
+def _shows(db: Session, user_pk: int):
+    return db.query(DbUserTVShow).filter(DbUserTVShow.user_id == user_pk).all()
+
+
+def _episode_marks(db: Session, user_pk: int):
+    return (
+        db.query(DbUserTVEpisode)
+        .join(DbTVEpisode, DbUserTVEpisode.episode_id == DbTVEpisode.pk)
+        .filter(DbUserTVEpisode.user_id == user_pk)
+        .all()
+    )
+
+
+def _books(db: Session, user_pk: int):
+    return db.query(DbUserBook).filter(DbUserBook.user_id == user_pk).all()
+
+
+def _games(db: Session, user_pk: int):
+    return db.query(DbUserVideoGame).filter(DbUserVideoGame.user_id == user_pk).all()
+
+
+@router.get('')
+def export_json(
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """
+    Full-fidelity JSON export of every domain, using the same schemas the
+    API serves — anything the UI can show is in here.
+    """
+    user = current_user[0]
+    payload = {
+        'exported_at': datetime.now(timezone.utc).isoformat(),
+        'account': {'email': user.email, 'display_name': user.display_name},
+        'licenses': LICENSES,
+        'movies': [
+            UserMovieResponse.model_validate(t).model_dump(mode='json')
+            for t in _movies(db, user.pk)
+        ],
+        'tv_shows': [
+            UserTVShowResponse.model_validate(t).model_dump(mode='json')
+            for t in _shows(db, user.pk)
+        ],
+        'tv_episode_marks': [
+            UserTVEpisodeResponse.model_validate(t).model_dump(mode='json')
+            for t in _episode_marks(db, user.pk)
+        ],
+        'books': [
+            UserBookResponse.model_validate(t).model_dump(mode='json')
+            for t in _books(db, user.pk)
+        ],
+        'games': [
+            UserVideoGameResponse.model_validate(t).model_dump(mode='json')
+            for t in _games(db, user.pk)
+        ],
+    }
+    return payload
+
+
+def _csv_response(filename: str, header: list, rows: list) -> Response:
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(header)
+    writer.writerows(rows)
+    return Response(
+        content=buf.getvalue(),
+        media_type='text/csv; charset=utf-8',
+        headers={'Content-Disposition': f'attachment; filename="{filename}"'},
+    )
+
+
+@router.get('/{domain}.csv')
+def export_csv(
+    domain: str,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """
+    Spreadsheet-friendly CSV for one domain:
+    ``movies`` | ``tv-shows`` | ``tv-episodes`` | ``books`` | ``games``.
+    """
+    user_pk = current_user[0].pk
+
+    if domain == 'movies':
+        rows = [
+            (
+                t.movie.title,
+                t.movie.year,
+                _state(t),
+                t.rank,
+                t.movie.imdb,
+                t.notes,
+                t.created_at,
+                t.updated_at,
+            )
+            for t in _movies(db, user_pk)
+        ]
+        header = [
+            'title',
+            'year',
+            'state',
+            'rank',
+            'imdb_id',
+            'notes',
+            'added_at',
+            'updated_at',
+        ]
+    elif domain == 'tv-shows':
+        rows = [
+            (
+                t.tv_show.title,
+                t.tv_show.year,
+                _state(t),
+                t.rank,
+                t.tv_show.imdb,
+                'yes' if t.freeze else 'no',
+                t.notes,
+                t.created_at,
+                t.updated_at,
+            )
+            for t in _shows(db, user_pk)
+        ]
+        header = [
+            'title',
+            'year',
+            'state',
+            'rank',
+            'imdb_id',
+            'hidden_from_schedule',
+            'notes',
+            'added_at',
+            'updated_at',
+        ]
+    elif domain == 'tv-episodes':
+        rows = [
+            (
+                t.episode.tv_show.title,
+                t.episode.season,
+                t.episode.season_number,
+                t.episode.title,
+                t.episode.airdate,
+                'yes' if t.watched else 'no',
+                t.updated_at,
+            )
+            for t in _episode_marks(db, user_pk)
+        ]
+        header = [
+            'show',
+            'season',
+            'episode',
+            'title',
+            'airdate',
+            'watched',
+            'marked_at',
+        ]
+    elif domain == 'books':
+        rows = [
+            (
+                t.book.title,
+                t.book.authors,
+                t.book.year,
+                _state(t),
+                t.rank,
+                t.book.isbn,
+                t.notes,
+                t.created_at,
+                t.updated_at,
+            )
+            for t in _books(db, user_pk)
+        ]
+        header = [
+            'title',
+            'authors',
+            'year',
+            'state',
+            'rank',
+            'isbn',
+            'notes',
+            'added_at',
+            'updated_at',
+        ]
+    elif domain == 'games':
+        rows = [
+            (
+                t.game.title,
+                t.game.year,
+                _state(t),
+                t.rank,
+                'yes' if t.is_100_percent else 'no',
+                t.game.platforms,
+                t.notes,
+                t.created_at,
+                t.updated_at,
+            )
+            for t in _games(db, user_pk)
+        ]
+        header = [
+            'title',
+            'year',
+            'state',
+            'rank',
+            'completed_100_percent',
+            'platforms',
+            'notes',
+            'added_at',
+            'updated_at',
+        ]
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail='Unknown export domain — use movies, tv-shows, tv-episodes, books, or games',
+        )
+
+    return _csv_response(f'druthers-{domain}.csv', header, rows)

--- a/app/run.py
+++ b/app/run.py
@@ -26,6 +26,7 @@ from .router.v1 import (
     router_activity,
     router_api_keys,
     router_countries,
+    router_export,
     router_notifications,
     router_search,
     router_movies,
@@ -94,6 +95,7 @@ app.include_router(router_activity.router)
 app.include_router(router_notifications.router)
 app.include_router(router_search.router)
 app.include_router(router_api_keys.router)
+app.include_router(router_export.router)
 
 # Serve static files
 app.mount('/static', StaticFiles(directory='app/static'), name='static')

--- a/tests/integration/router_export_test.py
+++ b/tests/integration/router_export_test.py
@@ -1,0 +1,87 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+from fastapi.testclient import TestClient
+
+
+def _auth(token: str) -> dict:
+    return {'Authorization': f'Bearer {token}'}
+
+
+def _seed_movie(test_client: TestClient, rank: bool):
+    admin = _auth(test_client.admin_user.token)
+    movie_id = test_client.post(
+        '/v1/movies',
+        headers=admin,
+        json={'title': 'Inception', 'imdb': 'tt1375666', 'year': 2010},
+    ).json()['id']
+    user = _auth(test_client.first_user.token)
+    test_client.post(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=user,
+        json={'on_rankings': rank, 'on_watchlist': not rank, 'notes': 'good'},
+    )
+    if rank:
+        test_client.put(
+            f'/v1/users/me/movies/{movie_id}/rank',
+            headers=user,
+            json={'position': 1},
+        )
+    return movie_id
+
+
+def test_export_json_covers_domains_and_licenses(test_client: TestClient):
+    _seed_movie(test_client, rank=True)
+    response = test_client.get(
+        '/v1/users/me/export', headers=_auth(test_client.first_user.token)
+    )
+    assert response.status_code == 200
+    body = response.json()
+    for key in (
+        'exported_at',
+        'account',
+        'licenses',
+        'movies',
+        'tv_shows',
+        'tv_episode_marks',
+        'books',
+        'games',
+    ):
+        assert key in body
+    assert body['movies'][0]['movie']['title'] == 'Inception'
+    assert body['movies'][0]['rank'] == 1
+    assert body['movies'][0]['notes'] == 'good'
+    assert 'CC BY-SA' in body['licenses']['tv']
+
+
+def test_export_json_is_scoped_to_the_caller(test_client: TestClient):
+    _seed_movie(test_client, rank=True)
+    response = test_client.get(
+        '/v1/users/me/export', headers=_auth(test_client.second_user.token)
+    )
+    assert response.status_code == 200
+    assert response.json()['movies'] == []
+
+
+def test_export_movies_csv(test_client: TestClient):
+    _seed_movie(test_client, rank=False)
+    response = test_client.get(
+        '/v1/users/me/export/movies.csv',
+        headers=_auth(test_client.first_user.token),
+    )
+    assert response.status_code == 200
+    assert response.headers['content-type'].startswith('text/csv')
+    assert 'druthers-movies.csv' in response.headers['content-disposition']
+    lines = response.text.strip().splitlines()
+    assert lines[0].startswith('title,year,state,rank')
+    assert lines[1].startswith('Inception,2010,watchlist,')
+
+
+def test_export_unknown_domain_404s(test_client: TestClient):
+    response = test_client.get(
+        '/v1/users/me/export/vibes.csv',
+        headers=_auth(test_client.first_user.token),
+    )
+    assert response.status_code == 404
+
+
+def test_export_requires_auth(test_client: TestClient):
+    assert test_client.get('/v1/users/me/export').status_code == 401


### PR DESCRIPTION
## What & why

API side of #138 — your data is never locked in:

- **`GET /v1/users/me/export`** — full-fidelity JSON: all five tracker sets (movies, TV shows, per-episode watch marks, books, games) serialized with the exact response schemas the API already serves, plus `exported_at`, account identity, and a `licenses` block (OMDb CC BY-NC / TVmaze CC BY-SA notes from the DATA-SOURCES audit ride along with the data).
- **`GET /v1/users/me/export/{domain}.csv`** — spreadsheet-friendly per-domain CSVs (`movies`, `tv-shows`, `tv-episodes`, `books`, `games`) with a derived one-word `state` column (ranked / to-rank / watchlist), rank, notes, ids (imdb/isbn), and domain extras (hidden-from-schedule, 100%-completed, airdates). Proper `Content-Disposition` download filenames.
- Everything is scoped to the caller; works with JWTs and the new API keys (#146) alike.

UI entry point (settings page with download links) lands in the aleonard.us-web settings PR.

## How verified

- 5 new integration tests: JSON shape + license notes + rank/notes fidelity, per-user scoping, movies CSV header/row/content-type/filename, unknown domain 404, auth required.
- Full suite **203 passed**; black/pylint clean.

## Checklist

- [x] Branch named `feat/…`, `fix/…`, or `chore/…`
- [ ] CI green (lint + tests)
- [x] No secrets committed
- [x] Docs updated (n/a — OpenAPI self-documents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
