### PR TITLE
Goodreads CSV import for books

### DIFF
--- a/app/router/v1/router_import.py
+++ b/app/router/v1/router_import.py
@@ -1,0 +1,51 @@
+# pylint: disable=missing-function-docstring
+"""
+Data import: bring your library in from other services.
+Currently: Goodreads CSV (books). IMDb CSV (movies/TV) is next.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+from sqlalchemy.orm import Session
+
+from app.auth.oauth2 import get_current_user
+from app.db.database import get_db
+from app.services.goodreads_import import import_goodreads_csv
+
+router = APIRouter(prefix='/v1/users/me/import', tags=['Import'])
+
+MAX_UPLOAD_BYTES = 5 * 1024 * 1024  # a Goodreads export is tens of KB
+
+
+@router.post('/goodreads')
+async def import_goodreads(
+    file: UploadFile,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """
+    Upload the standard Goodreads library export CSV. Idempotent — re-running
+    the same file updates rather than duplicates. Returns counts plus any
+    skipped rows with reasons (nothing is dropped silently).
+    """
+    raw = await file.read()
+    if len(raw) > MAX_UPLOAD_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail='File too large for a Goodreads export',
+        )
+    try:
+        content = raw.decode('utf-8-sig')  # Goodreads ships a BOM sometimes
+    except UnicodeDecodeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail='File is not UTF-8 text — upload the raw Goodreads CSV',
+        ) from exc
+
+    report = import_goodreads_csv(db, current_user[0].pk, content)
+    return {
+        'books_created': report.books_created,
+        'books_matched': report.books_matched,
+        'trackers_created': report.trackers_created,
+        'trackers_updated': report.trackers_updated,
+        'skipped': report.skipped,
+    }

--- a/app/run.py
+++ b/app/run.py
@@ -27,6 +27,7 @@ from .router.v1 import (
     router_api_keys,
     router_countries,
     router_export,
+    router_import,
     router_notifications,
     router_search,
     router_movies,
@@ -96,6 +97,7 @@ app.include_router(router_notifications.router)
 app.include_router(router_search.router)
 app.include_router(router_api_keys.router)
 app.include_router(router_export.router)
+app.include_router(router_import.router)
 
 # Serve static files
 app.mount('/static', StaticFiles(directory='app/static'), name='static')

--- a/app/services/goodreads_import.py
+++ b/app/services/goodreads_import.py
@@ -1,0 +1,156 @@
+"""
+Goodreads CSV import.
+
+Parses the standard Goodreads library export (goodreads.com → My Books →
+Import/Export) and maps each row onto the Books domain:
+
+- ``Exclusive Shelf`` ``read`` → on the rankings list (unplaced, ready to
+  rank); ``to-read``/``currently-reading`` → watchlist.
+- Catalog matching is by ISBN first (Goodreads wraps them in ``="…"``), then
+  case-insensitive title+author; unmatched rows create a catalog entry from
+  the CSV itself — no external API calls, so imports are fast and
+  deterministic.
+- Idempotent: re-uploading the same file updates existing trackers instead
+  of duplicating, and never overwrites notes you've written since.
+"""
+
+import csv
+import io
+from dataclasses import dataclass, field
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.db.models_sandbox import DbBook, DbUserBook
+
+
+@dataclass
+class ImportReport:
+    """Counts + skipped rows for the import response."""
+
+    books_created: int = 0
+    books_matched: int = 0
+    trackers_created: int = 0
+    trackers_updated: int = 0
+    skipped: list = field(default_factory=list)
+
+
+def _clean_isbn(raw: str | None) -> str | None:
+    """Goodreads exports ISBNs as ``="0439023483"`` — unwrap them."""
+    if not raw:
+        return None
+    cleaned = raw.strip().removeprefix('=').strip('"').strip()
+    return cleaned or None
+
+
+def _int_or_none(raw: str | None) -> int | None:
+    try:
+        return int(raw) if raw and raw.strip() else None
+    except ValueError:
+        return None
+
+
+def _notes(row: dict) -> str | None:
+    """Review + rating become the tracker note (only when tracker has none)."""
+    parts = []
+    review = (row.get('My Review') or '').strip()
+    if review:
+        parts.append(review)
+    rating = _int_or_none(row.get('My Rating'))
+    if rating:
+        parts.append(f'Goodreads rating: {rating}/5')
+    return '\n\n'.join(parts) or None
+
+
+def _find_book(db: Session, isbn: str | None, title: str, author: str | None):
+    if isbn:
+        book = db.query(DbBook).filter(DbBook.isbn == isbn).first()
+        if book:
+            return book
+    query = db.query(DbBook).filter(func.lower(DbBook.title) == title.lower())
+    if author:
+        query = query.filter(func.lower(DbBook.authors).contains(author.lower()))
+    return query.first()
+
+
+def import_goodreads_csv(  # pylint: disable=too-many-locals
+    db: Session, user_pk: int, content: str
+) -> ImportReport:
+    """
+    Run the import for one user. Commits once at the end.
+    """
+    report = ImportReport()
+    reader = csv.DictReader(io.StringIO(content))
+    if not reader.fieldnames or 'Title' not in reader.fieldnames:
+        report.skipped.append(
+            {'row': 0, 'reason': 'Not a Goodreads export (no Title column)'}
+        )
+        return report
+
+    for line_no, row in enumerate(reader, start=2):
+        title = (row.get('Title') or '').strip()
+        if not title:
+            report.skipped.append({'row': line_no, 'reason': 'Missing title'})
+            continue
+
+        shelf = (row.get('Exclusive Shelf') or 'read').strip().lower()
+        if shelf not in ('read', 'to-read', 'currently-reading'):
+            report.skipped.append(
+                {'row': line_no, 'reason': f'Unknown shelf "{shelf}"'}
+            )
+            continue
+
+        author = (row.get('Author') or '').strip() or None
+        isbn = _clean_isbn(row.get('ISBN13')) or _clean_isbn(row.get('ISBN'))
+
+        book = _find_book(db, isbn, title, author)
+        if book is None:
+            book = DbBook(
+                title=title,
+                isbn=isbn,
+                authors=author,
+                year=_int_or_none(row.get('Original Publication Year'))
+                or _int_or_none(row.get('Year Published')),
+                page_count=_int_or_none(row.get('Number of Pages')),
+            )
+            db.add(book)
+            db.flush()
+            report.books_created += 1
+        else:
+            report.books_matched += 1
+
+        tracker = (
+            db.query(DbUserBook)
+            .filter(DbUserBook.user_id == user_pk, DbUserBook.book_id == book.pk)
+            .first()
+        )
+        read = shelf == 'read'
+        if tracker is None:
+            db.add(
+                DbUserBook(
+                    user_id=user_pk,
+                    book_id=book.pk,
+                    on_rankings=read,
+                    on_watchlist=not read,
+                    notes=_notes(row),
+                )
+            )
+            report.trackers_created += 1
+        else:
+            # Promote watchlist → read if Goodreads says so; never demote a
+            # ranked book, never clobber existing notes.
+            changed = False
+            if read and not tracker.on_rankings:
+                tracker.on_rankings = True
+                tracker.on_watchlist = False
+                changed = True
+            if not tracker.notes:
+                notes = _notes(row)
+                if notes:
+                    tracker.notes = notes
+                    changed = True
+            if changed:
+                report.trackers_updated += 1
+
+    db.commit()
+    return report

--- a/tests/integration/router_import_test.py
+++ b/tests/integration/router_import_test.py
@@ -1,0 +1,92 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+import io
+
+from fastapi.testclient import TestClient
+
+HEADER = (
+    'Title,Author,ISBN,ISBN13,My Rating,Number of Pages,Year Published,'
+    'Original Publication Year,Exclusive Shelf,My Review\n'
+)
+
+CSV = (
+    HEADER
+    + 'Dune,Frank Herbert,="0441172717",="9780441172719",5,412,1990,1965,read,A classic.\n'
+    + 'Piranesi,Susanna Clarke,="",="9781635575637",0,245,2020,2020,to-read,\n'
+    + ',Nobody,="",="",0,,,,read,\n'
+)
+
+
+def _auth(token: str) -> dict:
+    return {'Authorization': f'Bearer {token}'}
+
+
+def _upload(test_client: TestClient, token: str, content: str = CSV):
+    return test_client.post(
+        '/v1/users/me/import/goodreads',
+        headers=_auth(token),
+        files={'file': ('goodreads.csv', io.BytesIO(content.encode()), 'text/csv')},
+    )
+
+
+def test_goodreads_import_creates_books_and_trackers(test_client: TestClient):
+    token = test_client.first_user.token
+    response = _upload(test_client, token)
+    assert response.status_code == 200
+    body = response.json()
+    assert body['books_created'] == 2
+    assert body['trackers_created'] == 2
+    assert body['skipped'] == [{'row': 4, 'reason': 'Missing title'}]
+
+    books = test_client.get('/v1/users/me/books', headers=_auth(token)).json()
+    by_title = {b['book']['title']: b for b in books}
+    dune = by_title['Dune']
+    assert dune['on_rankings'] is True
+    assert dune['on_watchlist'] is False
+    assert dune['book']['isbn'] == '9780441172719'
+    assert dune['book']['year'] == 1965
+    assert 'A classic.' in dune['notes']
+    assert 'Goodreads rating: 5/5' in dune['notes']
+    piranesi = by_title['Piranesi']
+    assert piranesi['on_watchlist'] is True
+    assert piranesi['on_rankings'] is False
+
+
+def test_goodreads_import_is_idempotent(test_client: TestClient):
+    token = test_client.first_user.token
+    _upload(test_client, token)
+    body = _upload(test_client, token).json()
+    assert body['books_created'] == 0
+    assert body['books_matched'] == 2
+    assert body['trackers_created'] == 0
+    assert body['trackers_updated'] == 0
+    books = test_client.get('/v1/users/me/books', headers=_auth(token)).json()
+    assert len(books) == 2
+
+
+def test_goodreads_import_promotes_but_never_demotes(test_client: TestClient):
+    token = test_client.first_user.token
+    _upload(test_client, token)
+    # Same file with Piranesi now read: watchlist → rankings
+    promoted = CSV.replace('to-read', 'read')
+    body = _upload(test_client, token, promoted).json()
+    assert body['trackers_updated'] == 1
+    books = test_client.get('/v1/users/me/books', headers=_auth(token)).json()
+    piranesi = next(b for b in books if b['book']['title'] == 'Piranesi')
+    assert piranesi['on_rankings'] is True
+    assert piranesi['on_watchlist'] is False
+
+
+def test_goodreads_import_rejects_non_export(test_client: TestClient):
+    body = _upload(
+        test_client, test_client.first_user.token, 'just,some,columns\n1,2,3\n'
+    ).json()
+    assert body['books_created'] == 0
+    assert body['skipped'][0]['reason'].startswith('Not a Goodreads export')
+
+
+def test_goodreads_import_requires_auth(test_client: TestClient):
+    response = test_client.post(
+        '/v1/users/me/import/goodreads',
+        files={'file': ('x.csv', io.BytesIO(b'Title\n'), 'text/csv')},
+    )
+    assert response.status_code == 401


### PR DESCRIPTION
## What & why

API side of #139 — Goodreads CSV import for books. Stacked on #147 (which stacks on #146): **merge order #146 → #147 → this**; GitHub retargets bases automatically as each lands.

- **`POST /v1/users/me/import/goodreads`** (multipart upload, 5 MB cap, BOM-tolerant): parses the standard Goodreads library export.
- **Mapping:** `Exclusive Shelf` `read` → rankings list (unplaced, ready to rank); `to-read`/`currently-reading` → watchlist. `My Review` + `My Rating` become the tracker note.
- **Matching:** ISBN13/ISBN first (unwraps Goodreads' `="…"` quirk), then case-insensitive title+author; a miss **creates the catalog entry from the CSV row itself** (title/author/ISBN/year/pages) — zero external API calls, so imports are instant and deterministic. Unparseable rows come back in a `skipped` list with reasons; nothing drops silently.
- **Idempotent & polite:** re-uploads update instead of duplicate, promote watchlist→read when Goodreads says so, and never demote a book or clobber notes you've written since.

Not in this PR: an upload UI (settings page is the natural home — follow-up), and IMDb import (#140, same importer shape).

## How verified

- 5 integration tests: create books+trackers with shelf/notes/ISBN/year fidelity + skipped-row report, idempotent re-run, promote-never-demote, non-export rejection, auth required.
- Full suite **208 passed** on the stacked branch; black/pylint clean; pre-commit hooks green.

## Checklist

- [x] Branch named `feat/…`, `fix/…`, or `chore/…`
- [ ] CI green (lint + tests)
- [x] No secrets committed
- [x] Docs updated (n/a — OpenAPI self-documents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
