### PR TITLE
Harden Open Library work-key fetch against SSRF (CodeQL 37/38)

### DIFF
--- a/app/services/book_search.py
+++ b/app/services/book_search.py
@@ -11,6 +11,7 @@ description (from the work record), page count, rating, and cover image.
 requires an API key for every request.)
 """
 
+import re
 from typing import List, Optional
 
 import requests
@@ -120,9 +121,14 @@ def apply_detail_to_book(book, detail: dict) -> None:
         setattr(book, key, value)
 
 
+# Open Library work keys look like "/works/OL45883W". Anything else from the
+# search response is discarded before it can reach a URL (SSRF hardening).
+_WORK_KEY_RE = re.compile(r'^/works/OL\d+W$')
+
+
 def _work_description(work_key: Optional[str]) -> Optional[str]:
     """Fetch the work record for its description (best effort)."""
-    if not work_key:
+    if not work_key or not _WORK_KEY_RE.match(work_key):
         return None
     try:
         response = requests.get(


### PR DESCRIPTION
## What & why

Clears CodeQL alerts 37/38 (python/Ssrf, open on main since Jul 13 — they are what flunks the CodeQL check on unrelated PRs like #146). Taint path: user-supplied ISBN → Open Library search → the response's work_key interpolated into the follow-up URL. A hostile or compromised search response could steer that request.

Fix: validate the key against the strict pattern `^/works/OL[0-9]+W$` before it touches a URL; anything else is discarded (enrichment already degrades gracefully to None).

## How verified

- Pattern unit-checked: accepts /works/OL45883W; rejects absolute URLs, traversal, and suffixed paths.
- Full suite 198 passed; black/pylint/pre-commit green.
- CodeQL on this PR should close both alerts — check the Security tab after merge.

## Checklist

- [x] Branch named fix/…
- [ ] CI green (lint + tests)
- [x] No secrets committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
