### PR TITLE
One-home rule: watchlist / to-be-ranked / ranked are mutually exclusive

### DIFF
--- a/alembic/versions/c7d2e91b4f03_exclusive_list_membership.py
+++ b/alembic/versions/c7d2e91b4f03_exclusive_list_membership.py
@@ -1,0 +1,49 @@
+"""exclusive list membership
+
+One-time cleanup for the one-home rule (#145): an item lives on exactly one
+of Watchlist / To-be-ranked / Ranked. For existing overlaps, Rankings wins
+(ranked > to-rank > watchlist). One-way — the overlap isn't recoverable.
+
+Revision ID: c7d2e91b4f03
+Revises: b41f0a7c9e21
+Create Date: 2026-07-18 10:40:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'c7d2e91b4f03'
+down_revision: Union[str, Sequence[str], None] = 'b41f0a7c9e21'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TRACKER_TABLES = (
+    'user_movies',
+    'user_tv_shows',
+    'user_books',
+    'user_video_games',
+    'user_countries',
+)
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    for table_name in TRACKER_TABLES:
+        tracker = sa.table(
+            table_name,
+            sa.column('on_watchlist', sa.Boolean),
+            sa.column('on_rankings', sa.Boolean),
+        )
+        op.execute(
+            tracker.update()
+            .where(tracker.c.on_rankings == sa.true())
+            .values(on_watchlist=sa.false())
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema (data cleanup is one-way; nothing to restore)."""

--- a/app/router/v1/router_books.py
+++ b/app/router/v1/router_books.py
@@ -14,6 +14,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.db.database import get_db
+from app.services.tracker_rules import enforce_single_home
 from app.db.models_sandbox import DbBook, DbUserBook
 from app.auth.oauth2 import get_current_user, require_admin
 from app.schemas.schemas_sandbox import (
@@ -214,6 +215,7 @@ def reorder_rankings(
         if tracker:
             tracker.rank = position
             tracker.on_rankings = True
+            tracker.on_watchlist = False
     db.commit()
     return (
         db.query(DbUserBook)
@@ -261,6 +263,7 @@ def set_book_rank(
 
     old_rank = tracker.rank
     tracker.on_rankings = True
+    tracker.on_watchlist = False
     # Remove from its current slot first so the shift math excludes it.
     tracker.rank = None
     db.flush()
@@ -305,6 +308,7 @@ def mark_book(
 
     if tracker is None:
         was_on_rankings = False
+        old_rank = None
         tracker = DbUserBook(
             user_id=user_pk,
             book_id=book.pk,
@@ -315,6 +319,7 @@ def mark_book(
         db.add(tracker)
     else:
         was_on_rankings = tracker.on_rankings
+        old_rank = tracker.rank
         for key in ('on_watchlist', 'on_rankings', 'notes'):
             if key in data:
                 setattr(tracker, key, data[key])
@@ -322,8 +327,11 @@ def mark_book(
     # A book only holds a rank while it's on the ranked list AND was already
     # placed. Entering Rankings (or leaving it) resets to unplaced so it lands
     # in the "to rank" bucket rather than at a stale/leftover position.
+    enforce_single_home(tracker, data)
     if not tracker.on_rankings or not was_on_rankings:
         tracker.rank = None
+    if old_rank is not None and tracker.rank is None:
+        _close_rank_gap(db, user_pk, old_rank)
     db.commit()
     db.refresh(tracker)
     return tracker
@@ -347,8 +355,10 @@ def update_user_book(
 
     old_rank = tracker.rank
     was_on_rankings = tracker.on_rankings
-    for key, value in request.model_dump(exclude_unset=True).items():
+    data = request.model_dump(exclude_unset=True)
+    for key, value in data.items():
         setattr(tracker, key, value)
+    enforce_single_home(tracker, data)
 
     # Entering Rankings (or leaving it) resets to unplaced so a stale/leftover
     # rank never places the book automatically; it lands in "to rank" instead.

--- a/app/router/v1/router_countries.py
+++ b/app/router/v1/router_countries.py
@@ -16,6 +16,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.db.database import get_db
+from app.services.tracker_rules import enforce_single_home
 from app.db.models_sandbox import DbCountry, DbUserCountry
 from app.auth.oauth2 import get_current_user, require_admin
 from app.schemas.schemas_sandbox import (
@@ -214,6 +215,7 @@ def reorder_rankings(
         if tracker:
             tracker.rank = position
             tracker.on_rankings = True
+            tracker.on_watchlist = False
     db.commit()
     return (
         db.query(DbUserCountry)
@@ -260,6 +262,7 @@ def set_country_rank(
 
     old_rank = tracker.rank
     tracker.on_rankings = True
+    tracker.on_watchlist = False
     # Remove from its current slot first so the shift math excludes it.
     tracker.rank = None
     db.flush()
@@ -306,6 +309,7 @@ def mark_country(
 
     if tracker is None:
         was_on_rankings = False
+        old_rank = None
         tracker = DbUserCountry(
             user_id=user_pk,
             country_id=country.pk,
@@ -317,6 +321,7 @@ def mark_country(
         db.add(tracker)
     else:
         was_on_rankings = tracker.on_rankings
+        old_rank = tracker.rank
         for key in ('on_watchlist', 'on_rankings', 'notes', 'first_visited'):
             if key in data:
                 setattr(tracker, key, data[key])
@@ -324,8 +329,11 @@ def mark_country(
     # A country only holds a rank while it's on the visited ranking AND was
     # already placed. Entering (or leaving) the ranking resets to unplaced so
     # it lands in the "to rank" bucket rather than at a stale position.
+    enforce_single_home(tracker, data)
     if not tracker.on_rankings or not was_on_rankings:
         tracker.rank = None
+    if old_rank is not None and tracker.rank is None:
+        _close_rank_gap(db, user_pk, old_rank)
     db.commit()
     db.refresh(tracker)
     return tracker
@@ -349,8 +357,10 @@ def update_user_country(
 
     old_rank = tracker.rank
     was_on_rankings = tracker.on_rankings
-    for key, value in request.model_dump(exclude_unset=True).items():
+    data = request.model_dump(exclude_unset=True)
+    for key, value in data.items():
         setattr(tracker, key, value)
+    enforce_single_home(tracker, data)
 
     # Entering (or leaving) the ranking resets to unplaced so a stale rank
     # never places the country automatically; it lands in "to rank" instead.

--- a/app/router/v1/router_games.py
+++ b/app/router/v1/router_games.py
@@ -15,6 +15,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.db.database import get_db
+from app.services.tracker_rules import enforce_single_home
 from app.db.models_sandbox import DbVideoGame, DbUserVideoGame
 from app.auth.oauth2 import get_current_user, require_admin
 from app.schemas.schemas_sandbox import (
@@ -217,6 +218,7 @@ def reorder_rankings(
         if tracker:
             tracker.rank = position
             tracker.on_rankings = True
+            tracker.on_watchlist = False
     db.commit()
     return (
         db.query(DbUserVideoGame)
@@ -267,6 +269,7 @@ def set_game_rank(
 
     old_rank = tracker.rank
     tracker.on_rankings = True
+    tracker.on_watchlist = False
     # Remove from its current slot first so the shift math excludes it.
     tracker.rank = None
     db.flush()
@@ -316,6 +319,7 @@ def mark_game(
 
     if tracker is None:
         was_on_rankings = False
+        old_rank = None
         tracker = DbUserVideoGame(
             user_id=user_pk,
             game_id=game.pk,
@@ -327,6 +331,7 @@ def mark_game(
         db.add(tracker)
     else:
         was_on_rankings = tracker.on_rankings
+        old_rank = tracker.rank
         for key in ('on_watchlist', 'on_rankings', 'notes', 'is_100_percent'):
             if key in data:
                 setattr(tracker, key, data[key])
@@ -334,8 +339,11 @@ def mark_game(
     # A game only holds a rank while it's on the ranked list AND was already
     # placed. Entering Rankings (or leaving it) resets to unplaced so it lands
     # in the "to rank" bucket rather than at a stale/leftover position.
+    enforce_single_home(tracker, data)
     if not tracker.on_rankings or not was_on_rankings:
         tracker.rank = None
+    if old_rank is not None and tracker.rank is None:
+        _close_rank_gap(db, user_pk, old_rank)
     db.commit()
     db.refresh(tracker)
     return tracker
@@ -359,8 +367,10 @@ def update_user_game(
 
     old_rank = tracker.rank
     was_on_rankings = tracker.on_rankings
-    for key, value in request.model_dump(exclude_unset=True).items():
+    data = request.model_dump(exclude_unset=True)
+    for key, value in data.items():
         setattr(tracker, key, value)
+    enforce_single_home(tracker, data)
 
     # Entering Rankings (or leaving it) resets to unplaced so a stale/leftover
     # rank never places the game automatically; it lands in "to rank" instead.

--- a/app/router/v1/router_movies.py
+++ b/app/router/v1/router_movies.py
@@ -10,6 +10,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.db.database import get_db
+from app.services.tracker_rules import enforce_single_home
 from app.db.models_sandbox import DbMovie, DbUserMovie
 from app.auth.oauth2 import get_current_user, require_admin
 from app.schemas.schemas_sandbox import (
@@ -223,6 +224,7 @@ def reorder_rankings(
         if tracker:
             tracker.rank = position
             tracker.on_rankings = True
+            tracker.on_watchlist = False
     db.commit()
     return (
         db.query(DbUserMovie)
@@ -254,6 +256,7 @@ def set_movie_rank(
 
     old_rank = tracker.rank
     tracker.on_rankings = True
+    tracker.on_watchlist = False
     # Remove from its current slot first so the shift math excludes it.
     tracker.rank = None
     db.flush()
@@ -298,6 +301,7 @@ def mark_movie(
 
     if tracker is None:
         was_on_rankings = False
+        old_rank = None
         tracker = DbUserMovie(
             user_id=user_pk,
             movie_id=movie.pk,
@@ -308,6 +312,7 @@ def mark_movie(
         db.add(tracker)
     else:
         was_on_rankings = tracker.on_rankings
+        old_rank = tracker.rank
         for key in ('on_watchlist', 'on_rankings', 'notes'):
             if key in data:
                 setattr(tracker, key, data[key])
@@ -315,8 +320,11 @@ def mark_movie(
     # A movie only holds a rank while it's on the ranked list AND was already
     # placed. Entering Rankings (or leaving it) resets to unplaced so it lands
     # in the "to rank" bucket rather than at a stale/leftover position.
+    enforce_single_home(tracker, data)
     if not tracker.on_rankings or not was_on_rankings:
         tracker.rank = None
+    if old_rank is not None and tracker.rank is None:
+        _close_rank_gap(db, user_pk, old_rank)
     db.commit()
     db.refresh(tracker)
     return tracker
@@ -340,8 +348,10 @@ def update_user_movie(
 
     old_rank = tracker.rank
     was_on_rankings = tracker.on_rankings
-    for key, value in request.model_dump(exclude_unset=True).items():
+    data = request.model_dump(exclude_unset=True)
+    for key, value in data.items():
         setattr(tracker, key, value)
+    enforce_single_home(tracker, data)
 
     # Entering Rankings (or leaving it) resets to unplaced so a stale/leftover
     # rank never places the movie automatically; it lands in "to rank" instead.

--- a/app/router/v1/router_tv.py
+++ b/app/router/v1/router_tv.py
@@ -15,6 +15,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.db.database import get_db
+from app.services.tracker_rules import enforce_single_home
 from app.db.models_sandbox import DbTVShow, DbUserTVShow, DbTVEpisode, DbUserTVEpisode
 from app.auth.oauth2 import get_current_user, require_admin
 from app.schemas.schemas_sandbox import (
@@ -468,6 +469,7 @@ def reorder_rankings(
         if tracker:
             tracker.rank = position
             tracker.on_rankings = True
+            tracker.on_watchlist = False
     db.commit()
     return (
         db.query(DbUserTVShow)
@@ -515,6 +517,7 @@ def set_show_rank(
 
     old_rank = tracker.rank
     tracker.on_rankings = True
+    tracker.on_watchlist = False
     # Remove from its current slot first so the shift math excludes it.
     tracker.rank = None
     db.flush()
@@ -559,6 +562,7 @@ def mark_tv_show(
 
     if tracker is None:
         was_on_rankings = False
+        old_rank = None
         tracker = DbUserTVShow(
             user_id=user_pk,
             tv_show_id=show.pk,
@@ -569,6 +573,7 @@ def mark_tv_show(
         db.add(tracker)
     else:
         was_on_rankings = tracker.on_rankings
+        old_rank = tracker.rank
         for key in ('on_watchlist', 'on_rankings', 'notes'):
             if key in data:
                 setattr(tracker, key, data[key])
@@ -576,8 +581,11 @@ def mark_tv_show(
     # A show only holds a rank while it's on the ranked list AND was already
     # placed. Entering Rankings (or leaving it) resets to unplaced so it lands
     # in the "to rank" bucket rather than at a stale/leftover position.
+    enforce_single_home(tracker, data)
     if not tracker.on_rankings or not was_on_rankings:
         tracker.rank = None
+    if old_rank is not None and tracker.rank is None:
+        _close_rank_gap(db, user_pk, old_rank)
     db.commit()
     db.refresh(tracker)
     return tracker
@@ -601,8 +609,10 @@ def update_user_tv_show(
 
     old_rank = tracker.rank
     was_on_rankings = tracker.on_rankings
-    for key, value in request.model_dump(exclude_unset=True).items():
+    data = request.model_dump(exclude_unset=True)
+    for key, value in data.items():
         setattr(tracker, key, value)
+    enforce_single_home(tracker, data)
 
     # Entering Rankings (or leaving it) resets to unplaced so a stale/leftover
     # rank never places the show automatically; it lands in "to rank" instead.

--- a/app/services/tracker_rules.py
+++ b/app/services/tracker_rules.py
@@ -1,0 +1,26 @@
+"""
+Shared rules for per-user tracker list membership.
+
+The one-home rule (2026-07-18 product decision, aleonard.us-api#145): an item
+lives on exactly one list — Watchlist, To-be-ranked, or Ranked. Moving it to
+one removes it from the others. "To-be-ranked" and "Ranked" are both
+``on_rankings``; the difference is whether ``rank`` is set.
+"""
+
+
+def enforce_single_home(tracker, requested: dict) -> None:
+    """
+    Resolve any watchlist/rankings overlap after a request's fields have been
+    applied to ``tracker``.
+
+    The list the request just asked for wins; when a single request asks for
+    both, Rankings wins (it's the stronger claim — "I've seen this").
+    Rank clearing and gap closing stay with the domain routers, which own
+    their shift math.
+    """
+    if not (tracker.on_watchlist and tracker.on_rankings):
+        return
+    if requested.get('on_watchlist') and not requested.get('on_rankings'):
+        tracker.on_rankings = False
+    else:
+        tracker.on_watchlist = False

--- a/tests/integration/router_books_test.py
+++ b/tests/integration/router_books_test.py
@@ -129,28 +129,35 @@ def test_mark_book_to_rankings_is_unplaced(test_client: TestClient):
     assert data['notes'] == 'A masterpiece.'
 
 
-def test_lists_are_independent(test_client: TestClient):
+def test_lists_are_exclusive(test_client: TestClient):
+    """One-home rule (#145): joining Rankings leaves the Watchlist."""
     book_id = _make_book(test_client)
     headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
 
+    # Add to watchlist only.
     r = test_client.post(
-        f"/v1/users/me/books/{book_id}", headers=headers, json={'on_watchlist': True}
+        f"/v1/users/me/books/{book_id}",
+        headers=headers,
+        json={'on_watchlist': True},
     )
     assert r.json()['on_watchlist'] is True
     assert r.json()['on_rankings'] is False
 
+    # Promote to rankings -> leaves the watchlist (unplaced until positioned).
     r = test_client.post(
-        f"/v1/users/me/books/{book_id}", headers=headers, json={'on_rankings': True}
+        f"/v1/users/me/books/{book_id}",
+        headers=headers,
+        json={'on_rankings': True},
     )
-    assert r.json()['on_watchlist'] is True
     assert r.json()['on_rankings'] is True
+    assert r.json()['on_watchlist'] is False
     assert r.json()['rank'] is None
 
-    # Off both lists -> tracker dropped.
+    # Leave rankings -> on neither list, so the tracker is dropped entirely.
     test_client.put(
         f"/v1/users/me/books/{book_id}",
         headers=headers,
-        json={'on_watchlist': False, 'on_rankings': False},
+        json={'on_rankings': False},
     )
     listing = test_client.get('/v1/users/me/books', headers=headers).json()
     assert all(t['book']['id'] != book_id for t in listing)

--- a/tests/integration/router_exclusivity_test.py
+++ b/tests/integration/router_exclusivity_test.py
@@ -1,0 +1,165 @@
+"""
+Test the one-home rule (#145): watchlist / to-be-ranked / ranked are
+mutually exclusive. Full transition matrix on movies; smoke on the other
+domains, which share the same patched code paths.
+"""
+
+from fastapi.testclient import TestClient
+
+
+def _auth(test_client: TestClient) -> dict:
+    return {'Authorization': f'Bearer {test_client.first_user.token}'}
+
+
+def _movie(test_client: TestClient, title: str, imdb: str) -> str:
+    headers = {'Authorization': f'Bearer {test_client.admin_user.token}'}
+    return test_client.post(
+        '/v1/movies', headers=headers, json={'title': title, 'imdb': imdb}
+    ).json()['id']
+
+
+def _state(test_client: TestClient, movie_id: str) -> dict:
+    return test_client.get(
+        f'/v1/users/me/movies/{movie_id}', headers=_auth(test_client)
+    ).json()
+
+
+def test_ranking_a_watchlisted_movie_leaves_the_watchlist(test_client: TestClient):
+    """
+    watchlist → to-rank via POST merge: rankings wins, watchlist cleared.
+    """
+    movie_id = _movie(test_client, 'Inception', 'tt1375666')
+    test_client.post(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(test_client),
+        json={'on_watchlist': True},
+    )
+    test_client.post(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(test_client),
+        json={'on_rankings': True},
+    )
+    state = _state(test_client, movie_id)
+    assert state['on_rankings'] is True
+    assert state['on_watchlist'] is False
+
+
+def test_requesting_both_lists_at_once_rankings_wins(test_client: TestClient):
+    """
+    A single request asking for both homes resolves to Rankings.
+    """
+    movie_id = _movie(test_client, 'Alien', 'tt0078748')
+    response = test_client.post(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(test_client),
+        json={'on_watchlist': True, 'on_rankings': True},
+    )
+    assert response.json()['on_rankings'] is True
+    assert response.json()['on_watchlist'] is False
+
+
+def test_watchlisting_a_ranked_movie_unranks_and_closes_the_gap(
+    test_client: TestClient,
+):
+    """
+    ranked → watchlist via PUT: leaves rankings, rank cleared, the movie
+    below shifts up into the vacated slot.
+    """
+    first = _movie(test_client, 'Heat', 'tt0113277')
+    second = _movie(test_client, 'Ronin', 'tt0122690')
+    for movie_id in (first, second):
+        test_client.post(
+            f'/v1/users/me/movies/{movie_id}',
+            headers=_auth(test_client),
+            json={'on_rankings': True},
+        )
+        test_client.put(
+            f'/v1/users/me/movies/{movie_id}/rank',
+            headers=_auth(test_client),
+            json={'position': 1 if movie_id == first else 2},
+        )
+
+    test_client.put(
+        f'/v1/users/me/movies/{first}',
+        headers=_auth(test_client),
+        json={'on_watchlist': True},
+    )
+    demoted = _state(test_client, first)
+    assert demoted['on_watchlist'] is True
+    assert demoted['on_rankings'] is False
+    assert demoted['rank'] is None
+    # The former #2 closed the gap
+    assert _state(test_client, second)['rank'] == 1
+
+
+def test_setting_rank_directly_leaves_the_watchlist(test_client: TestClient):
+    """
+    watchlist → ranked in one hop via the rank endpoint.
+    """
+    movie_id = _movie(test_client, 'Sneakers', 'tt0105435')
+    test_client.post(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(test_client),
+        json={'on_watchlist': True},
+    )
+    test_client.put(
+        f'/v1/users/me/movies/{movie_id}/rank',
+        headers=_auth(test_client),
+        json={'position': 1},
+    )
+    state = _state(test_client, movie_id)
+    assert state['rank'] == 1
+    assert state['on_rankings'] is True
+    assert state['on_watchlist'] is False
+
+
+def test_reorder_clears_watchlist_membership(test_client: TestClient):
+    """
+    Drag-and-drop reorder also asserts the one-home rule on every row.
+    """
+    movie_id = _movie(test_client, 'Gattaca', 'tt0119177')
+    test_client.post(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(test_client),
+        json={'on_watchlist': True, 'on_rankings': True},
+    )
+    test_client.put(
+        '/v1/users/me/movies/rankings/order',
+        headers=_auth(test_client),
+        json={'movie_ids': [movie_id]},
+    )
+    state = _state(test_client, movie_id)
+    assert state['rank'] == 1
+    assert state['on_watchlist'] is False
+
+
+def _smoke_domain(test_client: TestClient, noun: str, create_json: dict):
+    """Shared smoke: watchlist item promoted to rankings leaves watchlist."""
+    admin = {'Authorization': f'Bearer {test_client.admin_user.token}'}
+    item_id = test_client.post(f'/v1/{noun}', headers=admin, json=create_json).json()[
+        'id'
+    ]
+    test_client.post(
+        f'/v1/users/me/{noun}/{item_id}',
+        headers=_auth(test_client),
+        json={'on_watchlist': True},
+    )
+    test_client.post(
+        f'/v1/users/me/{noun}/{item_id}',
+        headers=_auth(test_client),
+        json={'on_rankings': True},
+    )
+    state = test_client.get(
+        f'/v1/users/me/{noun}/{item_id}', headers=_auth(test_client)
+    ).json()
+    assert state['on_rankings'] is True
+    assert state['on_watchlist'] is False
+
+
+def test_tv_books_games_share_the_rule(test_client: TestClient):
+    """
+    The other domains run the same patched paths — one promotion each.
+    """
+    _smoke_domain(test_client, 'tv-shows', {'title': 'Severance', 'imdb': 'tt11280740'})
+    _smoke_domain(test_client, 'books', {'title': 'Dune', 'isbn': '9780441172719'})
+    _smoke_domain(test_client, 'games', {'title': 'Hades', 'igdb': 113112})

--- a/tests/integration/router_games_test.py
+++ b/tests/integration/router_games_test.py
@@ -136,28 +136,35 @@ def test_hundred_percent_flag(test_client: TestClient):
     assert r.json()['on_rankings'] is True
 
 
-def test_lists_are_independent(test_client: TestClient):
+def test_lists_are_exclusive(test_client: TestClient):
+    """One-home rule (#145): joining Rankings leaves the Watchlist."""
     game_id = _make_game(test_client)
     headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
 
+    # Add to watchlist only.
     r = test_client.post(
-        f"/v1/users/me/games/{game_id}", headers=headers, json={'on_watchlist': True}
+        f"/v1/users/me/games/{game_id}",
+        headers=headers,
+        json={'on_watchlist': True},
     )
     assert r.json()['on_watchlist'] is True
     assert r.json()['on_rankings'] is False
 
+    # Promote to rankings -> leaves the watchlist (unplaced until positioned).
     r = test_client.post(
-        f"/v1/users/me/games/{game_id}", headers=headers, json={'on_rankings': True}
+        f"/v1/users/me/games/{game_id}",
+        headers=headers,
+        json={'on_rankings': True},
     )
-    assert r.json()['on_watchlist'] is True
     assert r.json()['on_rankings'] is True
+    assert r.json()['on_watchlist'] is False
     assert r.json()['rank'] is None
 
-    # Off both lists -> tracker dropped.
+    # Leave rankings -> on neither list, so the tracker is dropped entirely.
     test_client.put(
         f"/v1/users/me/games/{game_id}",
         headers=headers,
-        json={'on_watchlist': False, 'on_rankings': False},
+        json={'on_rankings': False},
     )
     listing = test_client.get('/v1/users/me/games', headers=headers).json()
     assert all(t['game']['id'] != game_id for t in listing)

--- a/tests/integration/router_movies_test.py
+++ b/tests/integration/router_movies_test.py
@@ -100,48 +100,38 @@ def test_set_movie_rank_inserts_and_shifts(test_client: TestClient):
     assert order == [(1, ids[0]), (2, new_id), (3, ids[1]), (4, ids[2])]
 
 
-def test_lists_are_independent(test_client: TestClient):
+def test_lists_are_exclusive(test_client: TestClient):
+    """One-home rule (#145): joining Rankings leaves the Watchlist."""
     movie_id = _make_movie(test_client)
-    user_headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
+    headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
 
     # Add to watchlist only.
     r = test_client.post(
         f"/v1/users/me/movies/{movie_id}",
-        headers=user_headers,
+        headers=headers,
         json={'on_watchlist': True},
     )
     assert r.json()['on_watchlist'] is True
     assert r.json()['on_rankings'] is False
-    assert r.json()['rank'] is None
 
-    # Also add to rankings (idempotent merge) -> now on both.
+    # Promote to rankings -> leaves the watchlist (unplaced until positioned).
     r = test_client.post(
         f"/v1/users/me/movies/{movie_id}",
-        headers=user_headers,
+        headers=headers,
         json={'on_rankings': True},
     )
-    assert r.json()['on_watchlist'] is True
     assert r.json()['on_rankings'] is True
-    assert r.json()['rank'] is None  # unplaced until positioned
-
-    # Remove from rankings -> still on watchlist, rank cleared.
-    r = test_client.put(
-        f"/v1/users/me/movies/{movie_id}",
-        headers=user_headers,
-        json={'on_rankings': False},
-    )
-    assert r.json()['on_watchlist'] is True
-    assert r.json()['on_rankings'] is False
+    assert r.json()['on_watchlist'] is False
     assert r.json()['rank'] is None
 
-    # Remove from watchlist too -> tracker deleted, gone from the list.
+    # Leave rankings -> on neither list, so the tracker is dropped entirely.
     test_client.put(
         f"/v1/users/me/movies/{movie_id}",
-        headers=user_headers,
-        json={'on_watchlist': False},
+        headers=headers,
+        json={'on_rankings': False},
     )
-    listing = test_client.get('/v1/users/me/movies', headers=user_headers).json()
-    assert all(m['movie']['id'] != movie_id for m in listing)
+    listing = test_client.get('/v1/users/me/movies', headers=headers).json()
+    assert all(t['movie']['id'] != movie_id for t in listing)
 
 
 def test_reentering_rankings_starts_unplaced(test_client: TestClient):

--- a/tests/integration/router_tv_test.py
+++ b/tests/integration/router_tv_test.py
@@ -174,10 +174,12 @@ def test_mark_show_to_rankings_is_unplaced(test_client: TestClient):
     assert data['notes'] == 'Peak TV'
 
 
-def test_lists_are_independent(test_client: TestClient):
+def test_lists_are_exclusive(test_client: TestClient):
+    """One-home rule (#145): joining Rankings leaves the Watchlist."""
     show_id = _make_show(test_client)
     headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
 
+    # Add to watchlist only.
     r = test_client.post(
         f"/v1/users/me/tv-shows/{show_id}",
         headers=headers,
@@ -186,28 +188,21 @@ def test_lists_are_independent(test_client: TestClient):
     assert r.json()['on_watchlist'] is True
     assert r.json()['on_rankings'] is False
 
+    # Promote to rankings -> leaves the watchlist (unplaced until positioned).
     r = test_client.post(
         f"/v1/users/me/tv-shows/{show_id}",
         headers=headers,
         json={'on_rankings': True},
     )
-    assert r.json()['on_watchlist'] is True
     assert r.json()['on_rankings'] is True
+    assert r.json()['on_watchlist'] is False
     assert r.json()['rank'] is None
 
-    r = test_client.put(
-        f"/v1/users/me/tv-shows/{show_id}",
-        headers=headers,
-        json={'on_rankings': False},
-    )
-    assert r.json()['on_watchlist'] is True
-    assert r.json()['on_rankings'] is False
-
-    # Off both lists -> tracker dropped.
+    # Leave rankings -> on neither list, so the tracker is dropped entirely.
     test_client.put(
         f"/v1/users/me/tv-shows/{show_id}",
         headers=headers,
-        json={'on_watchlist': False},
+        json={'on_rankings': False},
     )
     listing = test_client.get('/v1/users/me/tv-shows', headers=headers).json()
     assert all(t['tv_show']['id'] != show_id for t in listing)


### PR DESCRIPTION
## What & why

Closes #145 (your p1). An item now lives on exactly **one** of Watchlist / To-be-ranked / Ranked — moving it to one removes it from the others. Stacked on #149: **merge order #150 → #146 → #147 → #149 → this**.

- **`app/services/tracker_rules.py`** — the rule in one place: after a request's fields apply, any overlap resolves to *the list the request just asked for*; a request asking for both at once resolves to Rankings (the stronger claim).
- **All five domain routers** (movies/tv/books/games/countries) patched identically at every mutation point: `mark_*` (POST merge), `update_user_*` (PUT), `set_*_rank`, and `reorder_rankings` (ranking now always clears `on_watchlist`). The POST path also closes the rank gap a demotion leaves behind — previously only PUT did.
- **Migration `c7d2e91b4f03`** — one-way cleanup of existing overlapping rows across all five tracker tables: `on_watchlist=false` wherever `on_rankings=true` (ranked > to-rank > watchlist, per the issue).
- **Web needs no changes** — `partitionMovies` et al. tolerate exclusive data trivially (an item just never renders in two lists anymore); their "may appear in both" comments can be cleaned opportunistically later.
- The Goodreads importer (#149) already writes exclusive states.

**Ordering note from the issue:** this must land *before* the production data cutover (druthers-infra#3) so prod is born clean — the migration runs via `alembic upgrade head` in the launch runbook / deploy workflow.

## How verified

- 6 new tests (`router_exclusivity_test.py`): the movies transition matrix — watchlist→rankings via POST merge, both-at-once resolves to rankings, ranked→watchlist clears rank *and closes the gap*, direct rank placement and reorder both leave the watchlist — plus a tv/books/games smoke.
- The four old `test_lists_are_independent` tests encoded the previous deliberate overlap design; rewritten as `test_lists_are_exclusive` for the new invariant.
- Full suite **219 passed**; black/pylint 10/10; `alembic heads` single head `c7d2e91b4f03`.

## Checklist

- [x] Branch named `feat/…`, `fix/…`, or `chore/…`
- [ ] CI green (lint + tests)
- [x] No secrets committed
- [x] Docs updated (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
