### PR TITLE
Visibility settings + public read-only profiles

### DIFF
--- a/alembic/versions/d8e3f52a6b14_user_visibility_settings.py
+++ b/alembic/versions/d8e3f52a6b14_user_visibility_settings.py
@@ -1,0 +1,43 @@
+"""user visibility settings
+
+Handle + per-category public flags (#143). Everything defaults private;
+NULL flags read as private.
+
+Revision ID: d8e3f52a6b14
+Revises: c7d2e91b4f03
+Create Date: 2026-07-18 11:05:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'd8e3f52a6b14'
+down_revision: Union[str, Sequence[str], None] = 'c7d2e91b4f03'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('handle', sa.String(length=30), nullable=True))
+        batch_op.add_column(sa.Column('public_movies', sa.Boolean(), nullable=True))
+        batch_op.add_column(sa.Column('public_tv', sa.Boolean(), nullable=True))
+        batch_op.add_column(sa.Column('public_books', sa.Boolean(), nullable=True))
+        batch_op.add_column(sa.Column('public_games', sa.Boolean(), nullable=True))
+        batch_op.create_index(batch_op.f('ix_users_handle'), ['handle'], unique=True)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_users_handle'))
+        batch_op.drop_column('public_games')
+        batch_op.drop_column('public_books')
+        batch_op.drop_column('public_tv')
+        batch_op.drop_column('public_movies')
+        batch_op.drop_column('handle')

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -5,7 +5,7 @@ This module defines the database models.
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 
 from app.db.database import Base
@@ -39,6 +39,15 @@ class DbUser(DBBaseModel):
     display_name = Column(String(length=30))
     user_group = Column(String, default='user')
     password = Column(String)
+
+    # --- Visibility (#143): everything is private by default. A public
+    # profile needs a handle (druthers.io/u/<handle>) plus at least one
+    # category switched on; only ranked lists are ever exposed.
+    handle = Column(String(length=30), unique=True, index=True, nullable=True)
+    public_movies = Column(Boolean, nullable=True, default=False)
+    public_tv = Column(Boolean, nullable=True, default=False)
+    public_books = Column(Boolean, nullable=True, default=False)
+    public_games = Column(Boolean, nullable=True, default=False)
 
 
 class DbApiKey(DBBaseModel):

--- a/app/router/v1/router_visibility.py
+++ b/app/router/v1/router_visibility.py
@@ -1,0 +1,169 @@
+# pylint: disable=missing-function-docstring
+"""
+Visibility settings (#143) and the public read-only profile.
+
+Everything is private by default. A user opts categories in one by one and
+claims a handle; the public endpoint then serves *ranked lists only* — no
+notes, no watchlist, no watch state, no activity.
+"""
+
+import re
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.auth.oauth2 import get_current_user
+from app.db.database import get_db
+from app.db.models import DbUser
+from app.db.models_sandbox import (
+    DbBook,
+    DbMovie,
+    DbTVShow,
+    DbUserBook,
+    DbUserMovie,
+    DbUserTVShow,
+    DbUserVideoGame,
+    DbVideoGame,
+)
+from app.schemas.model_schemas import InVisibilityUpdate, OutVisibility
+
+router = APIRouter(prefix='/v1', tags=['Visibility'])
+
+HANDLE_RE = re.compile(r'^[a-z0-9][a-z0-9-]{2,29}$')
+# Namespace words a profile handle must never shadow.
+RESERVED_HANDLES = {
+    'about',
+    'admin',
+    'api',
+    'druthers',
+    'login',
+    'me',
+    'public',
+    'settings',
+    'u',
+    'www',
+}
+
+# (flag attribute, label, tracker model, catalog model, join column)
+_SHELVES = (
+    ('public_movies', 'Movies', DbUserMovie, DbMovie, 'movie_id'),
+    ('public_tv', 'TV', DbUserTVShow, DbTVShow, 'tv_show_id'),
+    ('public_books', 'Books', DbUserBook, DbBook, 'book_id'),
+    ('public_games', 'Video Games', DbUserVideoGame, DbVideoGame, 'game_id'),
+)
+
+
+@router.get('/users/me/visibility', response_model=OutVisibility)
+def get_visibility(current_user: list = Depends(get_current_user)):
+    return current_user[0]
+
+
+@router.put('/users/me/visibility', response_model=OutVisibility)
+def update_visibility(
+    request: InVisibilityUpdate,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """
+    Update the handle and/or per-category public flags. Opening any category
+    to the public requires a handle (that's the profile URL).
+    """
+    user = current_user[0]
+    data = request.model_dump(exclude_unset=True)
+
+    if 'handle' in data:
+        handle = (data['handle'] or '').strip().lower() or None
+        if handle is not None:
+            if not HANDLE_RE.match(handle):
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                    detail='Handle must be 3-30 chars: lowercase letters, '
+                    'digits, hyphens; starting with a letter or digit',
+                )
+            if handle in RESERVED_HANDLES:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail='That handle is reserved',
+                )
+            taken = (
+                db.query(DbUser)
+                .filter(DbUser.handle == handle, DbUser.pk != user.pk)
+                .first()
+            )
+            if taken:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail='That handle is taken',
+                )
+        user.handle = handle
+
+    for flag, _, _, _, _ in _SHELVES:
+        if flag in data and data[flag] is not None:
+            setattr(user, flag, bool(data[flag]))
+
+    if not user.handle and any(getattr(user, flag) for flag, *_ in _SHELVES):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail='Pick a handle before making a category public — it '
+            'becomes your profile URL',
+        )
+
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@router.get('/public/{handle}')
+def public_profile(handle: str, db: Session = Depends(get_db)):
+    """
+    Read-only public profile: ranked lists of the categories the owner has
+    opted in, best first. Fully private profiles (and unknown handles) 404
+    identically, so the endpoint never confirms a private account exists.
+    """
+    user = db.query(DbUser).filter(DbUser.handle == handle.lower()).first()
+    not_found = HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND, detail='No public profile here'
+    )
+    if user is None:
+        raise not_found
+
+    shelves = []
+    for flag, label, tracker_model, catalog_model, join_col in _SHELVES:
+        if not getattr(user, flag):
+            continue
+        rows = (
+            db.query(tracker_model, catalog_model)
+            .join(catalog_model, getattr(tracker_model, join_col) == catalog_model.pk)
+            .filter(
+                tracker_model.user_id == user.pk,
+                tracker_model.on_rankings.is_(True),
+                tracker_model.rank.isnot(None),
+            )
+            .order_by(tracker_model.rank)
+            .all()
+        )
+        shelves.append(
+            {
+                'category': label,
+                'ranked_count': len(rows),
+                'items': [
+                    {
+                        'rank': tracker.rank,
+                        'title': item.title,
+                        'year': item.year,
+                        'poster_url': item.poster_url,
+                    }
+                    for tracker, item in rows
+                ],
+            }
+        )
+
+    if not shelves:
+        raise not_found
+
+    return {
+        'handle': user.handle,
+        'display_name': user.display_name,
+        'shelves': shelves,
+        'total_ranked': sum(s['ranked_count'] for s in shelves),
+    }

--- a/app/run.py
+++ b/app/run.py
@@ -30,6 +30,7 @@ from .router.v1 import (
     router_import,
     router_notifications,
     router_search,
+    router_visibility,
     router_movies,
     router_games,
     router_books,
@@ -98,6 +99,7 @@ app.include_router(router_search.router)
 app.include_router(router_api_keys.router)
 app.include_router(router_export.router)
 app.include_router(router_import.router)
+app.include_router(router_visibility.router)
 
 # Serve static files
 app.mount('/static', StaticFiles(directory='app/static'), name='static')

--- a/app/schemas/model_schemas.py
+++ b/app/schemas/model_schemas.py
@@ -97,3 +97,30 @@ class OutApiKeyCreated(OutApiKey):
     """
 
     key: str
+
+
+class InVisibilityUpdate(BaseModel):
+    """
+    Request body for visibility settings. Only sent fields change; a null
+    handle clears it (allowed only while everything is private).
+    """
+
+    handle: Optional[str] = None
+    public_movies: Optional[bool] = None
+    public_tv: Optional[bool] = None
+    public_books: Optional[bool] = None
+    public_games: Optional[bool] = None
+
+
+class OutVisibility(BaseModel):
+    """
+    The caller's visibility settings. NULL flags read as private.
+    """
+
+    handle: Optional[str] = None
+    public_movies: Optional[bool] = False
+    public_tv: Optional[bool] = False
+    public_books: Optional[bool] = False
+    public_games: Optional[bool] = False
+
+    model_config = ConfigDict(from_attributes=True)

--- a/tests/integration/router_visibility_test.py
+++ b/tests/integration/router_visibility_test.py
@@ -1,0 +1,128 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+from fastapi.testclient import TestClient
+
+
+def _auth(token: str) -> dict:
+    return {'Authorization': f'Bearer {token}'}
+
+
+def _rank_a_movie(test_client: TestClient, token: str, title='Heat', imdb='tt0113277'):
+    admin = _auth(test_client.admin_user.token)
+    movie_id = test_client.post(
+        '/v1/movies', headers=admin, json={'title': title, 'imdb': imdb, 'year': 1995}
+    ).json()['id']
+    test_client.post(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(token),
+        json={'on_rankings': True, 'notes': 'private note!'},
+    )
+    test_client.put(
+        f'/v1/users/me/movies/{movie_id}/rank',
+        headers=_auth(token),
+        json={'position': 1},
+    )
+
+
+def test_defaults_are_fully_private(test_client: TestClient):
+    body = test_client.get(
+        '/v1/users/me/visibility', headers=_auth(test_client.first_user.token)
+    ).json()
+    assert body['handle'] is None
+    assert not any(
+        body[f] for f in ('public_movies', 'public_tv', 'public_books', 'public_games')
+    )
+
+
+def test_public_flag_requires_a_handle(test_client: TestClient):
+    response = test_client.put(
+        '/v1/users/me/visibility',
+        headers=_auth(test_client.first_user.token),
+        json={'public_movies': True},
+    )
+    assert response.status_code == 422
+    assert 'handle' in response.json()['message'].lower()
+
+
+def test_handle_validation_and_uniqueness(test_client: TestClient):
+    token = test_client.first_user.token
+    assert (
+        test_client.put(
+            '/v1/users/me/visibility',
+            headers=_auth(token),
+            json={'handle': 'No Spaces!'},
+        ).status_code
+        == 422
+    )
+    assert (
+        test_client.put(
+            '/v1/users/me/visibility', headers=_auth(token), json={'handle': 'settings'}
+        ).status_code
+        == 409
+    )
+    assert (
+        test_client.put(
+            '/v1/users/me/visibility', headers=_auth(token), json={'handle': 'Avery'}
+        ).json()['handle']
+        == 'avery'
+    )
+    # Second user can't take it
+    assert (
+        test_client.put(
+            '/v1/users/me/visibility',
+            headers=_auth(test_client.second_user.token),
+            json={'handle': 'avery'},
+        ).status_code
+        == 409
+    )
+
+
+def test_public_profile_exposes_only_public_ranked_lists(test_client: TestClient):
+    token = test_client.first_user.token
+    _rank_a_movie(test_client, token)
+    test_client.put(
+        '/v1/users/me/visibility',
+        headers=_auth(token),
+        json={'handle': 'avery', 'public_movies': True},
+    )
+
+    body = test_client.get('/v1/public/avery').json()
+    assert body['handle'] == 'avery'
+    assert [s['category'] for s in body['shelves']] == ['Movies']
+    item = body['shelves'][0]['items'][0]
+    assert item == {
+        'rank': 1,
+        'title': 'Heat',
+        'year': 1995,
+        'poster_url': None,
+    }
+    # Nothing private leaks anywhere in the payload
+    flat = str(body)
+    assert 'private note!' not in flat
+    assert 'on_watchlist' not in flat
+    assert test_client.first_user.email not in flat
+
+
+def test_private_and_unknown_profiles_404_identically(test_client: TestClient):
+    token = test_client.second_user.token
+    test_client.put(
+        '/v1/users/me/visibility', headers=_auth(token), json={'handle': 'ghost'}
+    )
+    private = test_client.get('/v1/public/ghost')
+    unknown = test_client.get('/v1/public/nobody-here')
+    assert private.status_code == unknown.status_code == 404
+    assert private.json() == unknown.json()
+
+
+def test_toggling_a_category_off_removes_it(test_client: TestClient):
+    token = test_client.first_user.token
+    _rank_a_movie(test_client, token, title='Ronin', imdb='tt0122690')
+    test_client.put(
+        '/v1/users/me/visibility',
+        headers=_auth(token),
+        json={'handle': 'avery', 'public_movies': True},
+    )
+    assert test_client.get('/v1/public/avery').status_code == 200
+    test_client.put(
+        '/v1/users/me/visibility', headers=_auth(token), json={'public_movies': False}
+    )
+    assert test_client.get('/v1/public/avery').status_code == 404


### PR DESCRIPTION
## What & why

API side of #143 — public/private sharing settings. Stacked on #151: **merge order #150 → #146 → #147 → #149 → #151 → this**.

- **Model** (migration `d8e3f52a6b14`): `users` gains `handle` (unique, the profile URL) and four per-category flags — `public_movies/tv/books/games`. **Everything defaults private**; NULL reads as private.
- **`GET/PUT /v1/users/me/visibility`** — read/update settings. Handles are normalized lowercase, validated (`3–30 chars, [a-z0-9-]`), uniqueness-checked (409), and a reserved list (`settings`, `api`, `admin`, `u`, …) can't be claimed. Making any category public **requires a handle first** (422 with a helpful message) — no anonymous-URL half-state.
- **`GET /v1/public/{handle}`** (no auth) — the read-only profile: for each opted-in category, the **ranked list only** (rank/title/year/poster, best first) plus counts. No notes, no watchlist, no watch state, no email, no activity. Fully-private and unknown handles **404 identically**, so the endpoint never confirms a private account exists.
- Share cards get their real URL from this: `druthers.io/u/<handle>` (web PR adds the page and the settings UI).

## How verified

- 6 new tests: private-by-default, public-flag-requires-handle, handle validation/reserved/uniqueness + lowercase normalization, profile payload contains exactly the public ranked list and provably no private strings (note text, email, `on_watchlist` all absent from the serialized payload), private≡unknown 404 parity, and toggling a category off takes the profile down.
- Full suite **225 passed**; black/pylint 10/10; single alembic head `d8e3f52a6b14`.

## Checklist

- [x] Branch named `feat/…`, `fix/…`, or `chore/…`
- [ ] CI green (lint + tests)
- [x] No secrets committed
- [x] Docs updated (n/a — OpenAPI self-documents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
