### PR TITLE
Fix Cloud Run boot: serve uvicorn on the running event loop

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -68,6 +68,7 @@ class DbApiKey(DBBaseModel):
 
     user = relationship('DbUser', backref='api_keys')
 
+
 # Import sandbox models to ensure they are registered with the Base metadata
 # pylint: disable=cyclic-import, wrong-import-position, unused-import
 from app.db import models_sandbox  # noqa: F401

--- a/app/run.py
+++ b/app/run.py
@@ -12,7 +12,6 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
-from sqlalchemy.exc import SQLAlchemyError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from .auth import authentication
@@ -171,19 +170,38 @@ async def start_server():
             created = seed_countries(db)
             db.commit()
             logger.info('Seeded countries catalog: %d created', created)
-    except SQLAlchemyError as e:
-        logger.error('Unexpected error: %s', e)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        # Startup seeding is best-effort: a misconfigured admin seed or an
+        # unreachable database must never stop the server from listening
+        # (Cloud Run kills revisions that don't bind their port).
+        logger.error('Startup seeding skipped: %s', e)
 
     if settings.is_local:
         await generate_openapi_json()
 
-    uvicorn.run(
+    port = int(os.getenv('PORT', '8000'))
+    if settings.is_local:
+        # The reloader must own the process (it spawns worker subprocesses),
+        # so local dev keeps the sync entry point.
+        uvicorn.run(
+            'app.run:app',
+            host='0.0.0.0',
+            port=port,
+            reload=True,
+            log_level=settings.log_level.lower(),
+        )
+        return
+
+    # We're already inside asyncio.run() here — the sync uvicorn.run() would
+    # try to start a second event loop and crash (exactly what took down the
+    # first Cloud Run revision). Serve on the running loop instead.
+    config = uvicorn.Config(
         'app.run:app',
         host='0.0.0.0',
-        port=int(os.getenv('PORT', '8000')),
-        reload=settings.is_local,
+        port=port,
         log_level=settings.log_level.lower(),
     )
+    await uvicorn.Server(config).serve()
 
 
 def run():


### PR DESCRIPTION
Launch blocker: revision druthers-api-00002-j58 died with `RuntimeError: asyncio.run() cannot be called from a running event loop` — async `start_server()` calling sync `uvicorn.run()`, masked until now by `reload=True` forking a subprocess. Non-local envs now await `uvicorn.Server.serve()` on the existing loop; local keeps the reloader. Also: startup seeding (admin/countries) is now genuinely best-effort — any seed failure logs and continues instead of killing the boot (a second crash class the smoke test surfaced: the admin seed raises HTTPException when env is incomplete).

Verified by booting the app with ENV=prod + PORT like Cloud Run does: `/` and `/docs` serve. Full suite 225 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)