### PR TITLE
Auth hardening: password-login kill switch, rate limits, catalog-add caps

### DIFF
--- a/app/auth/authentication.py
+++ b/app/auth/authentication.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm.session import Session
 
 from app.auth import oauth2
+from app.services.rate_limit import auth_rate_limit
 from app.config import get_settings
 from app.db import models
 from app.db.database import get_db
@@ -39,7 +40,7 @@ def _token_response(user: models.DbUser) -> dict:
     }
 
 
-@router.post('/token')
+@router.post('/token', dependencies=[Depends(auth_rate_limit)])
 def get_token(
     request: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)
 ):
@@ -53,6 +54,11 @@ def get_token(
     Returns:
         Access token
     """
+    if get_settings().disable_password_login:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail='Password sign-in is disabled — use Google or an API key',
+        )
     user = (
         # OAuth2PasswordRequestForm requires username instead of email
         db.query(models.DbUser)
@@ -71,7 +77,7 @@ def get_token(
     return _token_response(user)
 
 
-@router.post('/google')
+@router.post('/google', dependencies=[Depends(auth_rate_limit)])
 def google_login(request: GoogleAuthRequest, db: Session = Depends(get_db)):
     """
     Sign in with a Google Identity Services ID token.

--- a/app/config.py
+++ b/app/config.py
@@ -39,6 +39,15 @@ class Settings(BaseSettings):
     access_token_expire_minutes: int = 30
     google_client_id: Optional[str] = None
 
+    # --- Abuse resistance (#148, threat model H1/H2) ---
+    # Kill switch for /v1/auth/token: prod is Google + API keys only.
+    disable_password_login: bool = False
+    # None = enforce in dev/prod, skip in local/CI; set explicitly to override.
+    rate_limits_enabled: Optional[bool] = None
+    rate_limit_auth: int = 10  # sign-in attempts per IP per 5 minutes
+    rate_limit_search: int = 60  # search-proxy calls per user per minute
+    catalog_add_daily_cap: int = 200  # catalog creations per user per day
+
     # --- Observability ---
     loki_url: Optional[str] = None
 

--- a/app/router/v1/router_books.py
+++ b/app/router/v1/router_books.py
@@ -14,6 +14,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.db.database import get_db
+from app.services.rate_limit import catalog_add_cap, search_rate_limit
 from app.services.tracker_rules import enforce_single_home
 from app.db.models_sandbox import DbBook, DbUserBook
 from app.auth.oauth2 import get_current_user, require_admin
@@ -45,7 +46,11 @@ def get_all_books(db: Session = Depends(get_db)):
     return db.query(DbBook).all()
 
 
-@router.get('/books/search', response_model=List[BookSearchResult])
+@router.get(
+    '/books/search',
+    response_model=List[BookSearchResult],
+    dependencies=[Depends(search_rate_limit)],
+)
 def search_books_endpoint(
     q: str,
     current_user: list = Depends(get_current_user),
@@ -59,7 +64,12 @@ def search_books_endpoint(
     return results
 
 
-@router.post('/books', response_model=BookResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    '/books',
+    response_model=BookResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(catalog_add_cap)],
+)
 def create_book(
     request: BookCreate,
     db: Session = Depends(get_db),

--- a/app/router/v1/router_games.py
+++ b/app/router/v1/router_games.py
@@ -15,6 +15,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.db.database import get_db
+from app.services.rate_limit import catalog_add_cap, search_rate_limit
 from app.services.tracker_rules import enforce_single_home
 from app.db.models_sandbox import DbVideoGame, DbUserVideoGame
 from app.auth.oauth2 import get_current_user, require_admin
@@ -46,7 +47,11 @@ def get_all_games(db: Session = Depends(get_db)):
     return db.query(DbVideoGame).all()
 
 
-@router.get('/games/search', response_model=List[GameSearchResult])
+@router.get(
+    '/games/search',
+    response_model=List[GameSearchResult],
+    dependencies=[Depends(search_rate_limit)],
+)
 def search_games_endpoint(
     q: str,
     current_user: list = Depends(get_current_user),
@@ -61,7 +66,10 @@ def search_games_endpoint(
 
 
 @router.post(
-    '/games', response_model=VideoGameResponse, status_code=status.HTTP_201_CREATED
+    '/games',
+    response_model=VideoGameResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(catalog_add_cap)],
 )
 def create_game(
     request: VideoGameCreate,

--- a/app/router/v1/router_movies.py
+++ b/app/router/v1/router_movies.py
@@ -10,6 +10,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.db.database import get_db
+from app.services.rate_limit import catalog_add_cap, search_rate_limit
 from app.services.tracker_rules import enforce_single_home
 from app.db.models_sandbox import DbMovie, DbUserMovie
 from app.auth.oauth2 import get_current_user, require_admin
@@ -40,7 +41,11 @@ def get_all_movies(db: Session = Depends(get_db)):
     return db.query(DbMovie).all()
 
 
-@router.get('/movies/search', response_model=List[MovieSearchResult])
+@router.get(
+    '/movies/search',
+    response_model=List[MovieSearchResult],
+    dependencies=[Depends(search_rate_limit)],
+)
 def search_movies_endpoint(
     q: str,
     current_user: list = Depends(get_current_user),
@@ -55,7 +60,10 @@ def search_movies_endpoint(
 
 
 @router.post(
-    '/movies', response_model=MovieResponse, status_code=status.HTTP_201_CREATED
+    '/movies',
+    response_model=MovieResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(catalog_add_cap)],
 )
 def create_movie(
     request: MovieCreate,

--- a/app/router/v1/router_search.py
+++ b/app/router/v1/router_search.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from app.auth.oauth2 import get_current_user
 from app.schemas.schemas_sandbox import GlobalSearchResponse
+from app.services.rate_limit import search_rate_limit
 from app.services.book_search import search_books
 from app.services.game_search import search_games
 from app.services.movie_search import search_movies
@@ -51,7 +52,11 @@ def _fan_out(q: str, only: Optional[List[str]] = None) -> Dict[str, List[dict]]:
         return {name: future.result() for name, future in futures.items()}
 
 
-@router.get('/search', response_model=GlobalSearchResponse)
+@router.get(
+    '/search',
+    response_model=GlobalSearchResponse,
+    dependencies=[Depends(search_rate_limit)],
+)
 def global_search(
     q: str,
     current_user: list = Depends(get_current_user),

--- a/app/router/v1/router_tv.py
+++ b/app/router/v1/router_tv.py
@@ -15,6 +15,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.db.database import get_db
+from app.services.rate_limit import catalog_add_cap, search_rate_limit
 from app.services.tracker_rules import enforce_single_home
 from app.db.models_sandbox import DbTVShow, DbUserTVShow, DbTVEpisode, DbUserTVEpisode
 from app.auth.oauth2 import get_current_user, require_admin
@@ -55,7 +56,11 @@ def get_all_tv_shows(db: Session = Depends(get_db)):
     return db.query(DbTVShow).all()
 
 
-@router.get('/tv-shows/search', response_model=List[TVShowSearchResult])
+@router.get(
+    '/tv-shows/search',
+    response_model=List[TVShowSearchResult],
+    dependencies=[Depends(search_rate_limit)],
+)
 def search_tv_shows_endpoint(
     q: str,
     current_user: list = Depends(get_current_user),
@@ -70,7 +75,10 @@ def search_tv_shows_endpoint(
 
 
 @router.post(
-    '/tv-shows', response_model=TVShowResponse, status_code=status.HTTP_201_CREATED
+    '/tv-shows',
+    response_model=TVShowResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(catalog_add_cap)],
 )
 def create_tv_show(
     request: TVShowCreate,

--- a/app/services/rate_limit.py
+++ b/app/services/rate_limit.py
@@ -1,0 +1,97 @@
+"""
+Abuse resistance (#148, threat model H1/H2): lightweight sliding-window rate
+limits served as FastAPI dependencies.
+
+Limits are in-memory and therefore per-instance — plenty for a small Cloud
+Run service where the caps exist to stop bots and runaway loops, not to
+meter a distributed fleet. Enforcement is on in deployed environments
+(dev/prod) and off in local/CI unless ``RATE_LIMITS_ENABLED`` says otherwise;
+defaults are generous enough that a human never notices them.
+"""
+
+import threading
+import time
+from collections import defaultdict, deque
+
+from fastapi import Depends, HTTPException, Request, status
+
+from app.auth.oauth2 import get_current_user
+from app.config import get_settings
+
+_lock = threading.Lock()
+_events: dict = defaultdict(deque)
+
+AUTH_WINDOW_SECONDS = 300
+SEARCH_WINDOW_SECONDS = 60
+CATALOG_WINDOW_SECONDS = 86400
+
+
+def reset() -> None:
+    """Clear all recorded events (tests only)."""
+    with _lock:
+        _events.clear()
+
+
+def _enforced() -> bool:
+    settings = get_settings()
+    if settings.rate_limits_enabled is not None:
+        return settings.rate_limits_enabled
+    return settings.env in ('dev', 'prod')
+
+
+def client_ip(request: Request) -> str:
+    """
+    Best-effort caller IP. Behind Cloud Run/Cloudflare the connecting peer is
+    the proxy, so prefer the first X-Forwarded-For hop.
+    """
+    forwarded = request.headers.get('x-forwarded-for')
+    if forwarded:
+        return forwarded.split(',')[0].strip()
+    return request.client.host if request.client else 'unknown'
+
+
+def _allow(key: str, limit: int, window_seconds: int) -> bool:
+    now = time.monotonic()
+    with _lock:
+        events = _events[key]
+        while events and events[0] <= now - window_seconds:
+            events.popleft()
+        if len(events) >= limit:
+            return False
+        events.append(now)
+        return True
+
+
+def _reject(what: str, retry_after_seconds: int):
+    raise HTTPException(
+        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        detail=f'Too many {what} — try again later',
+        headers={'Retry-After': str(retry_after_seconds)},
+    )
+
+
+def auth_rate_limit(request: Request) -> None:
+    """Per-IP cap on sign-in attempts (password and Google alike)."""
+    if not _enforced():
+        return
+    limit = get_settings().rate_limit_auth
+    if not _allow(f'auth:{client_ip(request)}', limit, AUTH_WINDOW_SECONDS):
+        _reject('sign-in attempts', AUTH_WINDOW_SECONDS)
+
+
+def search_rate_limit(current_user: list = Depends(get_current_user)) -> None:
+    """Per-user cap on external search-proxy calls (they burn API quotas)."""
+    if not _enforced():
+        return
+    limit = get_settings().rate_limit_search
+    if not _allow(f'search:{current_user[0].pk}', limit, SEARCH_WINDOW_SECONDS):
+        _reject('searches', SEARCH_WINDOW_SECONDS)
+
+
+def catalog_add_cap(current_user: list = Depends(get_current_user)) -> None:
+    """Per-user daily cap on catalog creation (spam/pollution brake)."""
+    if not _enforced():
+        return
+    limit = get_settings().catalog_add_daily_cap
+    if not _allow(f'catalog:{current_user[0].pk}', limit, CATALOG_WINDOW_SECONDS):
+        _reject('catalog additions for today', CATALOG_WINDOW_SECONDS)

--- a/app/utils/exceptions.py
+++ b/app/utils/exceptions.py
@@ -17,12 +17,16 @@ from app.schemas.model_schemas import OutResponseBaseModel
 async def http_exception_handler(_: Request, exc: HTTPException):
     """
     Custom handler for HTTPException.
+
+    Forwards ``exc.headers`` — auth challenges (WWW-Authenticate) and rate
+    limits (Retry-After) are meaningless without them.
     """
     return JSONResponse(
         status_code=exc.status_code,
         content=OutResponseBaseModel(
             success=False, message=exc.detail, data=[]
         ).model_dump(exclude_none=True),
+        headers=getattr(exc, 'headers', None),
     )
 
 

--- a/tests/integration/rate_limit_test.py
+++ b/tests/integration/rate_limit_test.py
@@ -1,0 +1,118 @@
+"""
+Test the abuse-resistance layer (#148): password-login kill switch, per-IP
+auth limits, per-user search limits, and the daily catalog-add cap.
+"""
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from app.config import Settings
+from app.services import rate_limit
+
+ENABLED = {'env': 'github', 'rate_limits_enabled': True}
+
+
+def _auth(test_client: TestClient) -> dict:
+    return {'Authorization': f'Bearer {test_client.first_user.token}'}
+
+
+@patch('app.auth.authentication.get_settings')
+def test_password_login_kill_switch(mock_settings, test_client: TestClient):
+    """
+    DISABLE_PASSWORD_LOGIN turns /v1/auth/token off with a clear 403.
+    """
+    mock_settings.return_value = Settings(env='github', disable_password_login=True)
+    response = test_client.post(
+        '/v1/auth/token',
+        data={'username': test_client.first_user.email, 'password': 'whatever'},
+    )
+    assert response.status_code == 403
+    assert 'Google or an API key' in response.json()['message']
+
+
+@patch('app.services.rate_limit.get_settings')
+def test_auth_attempts_are_rate_limited_per_ip(mock_settings, test_client: TestClient):
+    """
+    The 4th sign-in attempt inside the window gets a 429 with Retry-After.
+    """
+    rate_limit.reset()
+    mock_settings.return_value = Settings(**ENABLED, rate_limit_auth=3)
+    for _ in range(3):
+        response = test_client.post(
+            '/v1/auth/token', data={'username': 'x@y.z', 'password': 'wrong'}
+        )
+        assert response.status_code == 404
+    response = test_client.post(
+        '/v1/auth/token', data={'username': 'x@y.z', 'password': 'wrong'}
+    )
+    assert response.status_code == 429
+    assert response.headers['retry-after'] == '300'
+    rate_limit.reset()
+
+
+@patch('app.router.v1.router_movies.omdb_search_movies')
+@patch('app.services.rate_limit.get_settings')
+def test_search_is_rate_limited_per_user(
+    mock_settings, mock_search, test_client: TestClient
+):
+    """
+    Search proxies burn external quotas — the per-user cap kicks in.
+    """
+    rate_limit.reset()
+    mock_settings.return_value = Settings(**ENABLED, rate_limit_search=2)
+    mock_search.return_value = [
+        {
+            'imdb': 'tt1',
+            'title': 'X',
+            'year': '2020',
+            'poster_url': None,
+            'type': 'movie',
+        }
+    ]
+    for _ in range(2):
+        assert (
+            test_client.get(
+                '/v1/movies/search?q=x', headers=_auth(test_client)
+            ).status_code
+            == 200
+        )
+    assert (
+        test_client.get('/v1/movies/search?q=x', headers=_auth(test_client)).status_code
+        == 429
+    )
+    rate_limit.reset()
+
+
+@patch('app.services.rate_limit.get_settings')
+def test_catalog_adds_have_a_daily_cap(mock_settings, test_client: TestClient):
+    """
+    The N+1th catalog creation of the day is refused.
+    """
+    rate_limit.reset()
+    mock_settings.return_value = Settings(**ENABLED, catalog_add_daily_cap=2)
+    headers = {'Authorization': f'Bearer {test_client.admin_user.token}'}
+    for i in range(2):
+        response = test_client.post(
+            '/v1/movies', headers=headers, json={'title': f'M{i}', 'imdb': f'tt55{i}'}
+        )
+        assert response.status_code == 201
+    response = test_client.post(
+        '/v1/movies', headers=headers, json={'title': 'M3', 'imdb': 'tt553'}
+    )
+    assert response.status_code == 429
+    assert 'today' in response.json()['message']
+    rate_limit.reset()
+
+
+def test_limits_are_off_in_ci_by_default(test_client: TestClient):
+    """
+    Without the explicit enable, CI/local traffic is never throttled — the
+    rest of the suite depends on this.
+    """
+    rate_limit.reset()
+    for _ in range(15):
+        response = test_client.post(
+            '/v1/auth/token', data={'username': 'x@y.z', 'password': 'wrong'}
+        )
+        assert response.status_code == 404


### PR DESCRIPTION
Closes #148 — threat model H1/H2.

- **`DISABLE_PASSWORD_LOGIN`** env flag: `/v1/auth/token` returns a clear 403; Google sign-in and `drk_` API keys unaffected. The seed admin keeps admin access by signing in with Google on the same email. Deploy script sets it for prod (druthers-infra).
- **Rate limits** as FastAPI dependencies (`app/services/rate_limit.py`): sign-in **10/5min per IP** (X-Forwarded-For aware for Cloudflare/Cloud Run), search proxies **60/min per user** (they burn OMDb/IGDB quotas), catalog creation **200/day per user** (spam brake). In-memory sliding windows — per-instance by design and documented as such (same locality SlowAPI defaults to, zero new dependencies). Enforced in dev/prod, off in local/CI, every number env-tunable, all generous enough that one human never notices.
- **Bug fix en route:** the custom HTTPException handler dropped `exc.headers`, so 429s had no `Retry-After` — and 401s have been missing `WWW-Authenticate` all along. Now forwarded.

## How verified
5 new integration tests: kill-switch 403 wording, 4th auth attempt 429 with `Retry-After: 300`, per-user search cap (OMDb mocked), daily catalog cap, and limits-off-in-CI (the rest of the suite depends on that). Full suite **230 passed**; black/pylint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)