### PR TITLE
Fix N+1 lazy loading that made the site hang after the cutover

### DIFF
--- a/app/router/v1/router_activity.py
+++ b/app/router/v1/router_activity.py
@@ -11,34 +11,32 @@ import random
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from app.db.database import get_db
 from app.db.models_sandbox import (
-    DbBook,
-    DbCountry,
-    DbMovie,
     DbTVEpisode,
-    DbTVShow,
     DbUserBook,
     DbUserCountry,
     DbUserMovie,
     DbUserTVEpisode,
     DbUserTVShow,
     DbUserVideoGame,
-    DbVideoGame,
 )
 from app.auth.oauth2 import get_current_user
 from app.schemas.schemas_sandbox import ActivityItem, BoredItem, BoredResponse
 
 router = APIRouter(prefix='/v1', tags=['Activity'])
 
+# Hard ceiling on the returned feed; also bounds per-domain SQL fetches.
+MAX_FEED = 200
+
 
 # --- Activity Log ---
 def _movie_activity(db: Session, user_pk: int) -> List[ActivityItem]:
     trackers = (
         db.query(DbUserMovie)
-        .join(DbMovie, DbUserMovie.movie_id == DbMovie.pk)
+        .options(joinedload(DbUserMovie.movie))
         .filter(DbUserMovie.user_id == user_pk)
         .all()
     )
@@ -73,7 +71,7 @@ def _movie_activity(db: Session, user_pk: int) -> List[ActivityItem]:
 def _tv_show_activity(db: Session, user_pk: int) -> List[ActivityItem]:
     trackers = (
         db.query(DbUserTVShow)
-        .join(DbTVShow, DbUserTVShow.tv_show_id == DbTVShow.pk)
+        .options(joinedload(DbUserTVShow.tv_show))
         .filter(DbUserTVShow.user_id == user_pk)
         .all()
     )
@@ -108,9 +106,13 @@ def _tv_show_activity(db: Session, user_pk: int) -> List[ActivityItem]:
 def _episode_activity(db: Session, user_pk: int) -> List[ActivityItem]:
     rows = (
         db.query(DbUserTVEpisode)
-        .join(DbTVEpisode, DbUserTVEpisode.episode_id == DbTVEpisode.pk)
-        .join(DbTVShow, DbTVEpisode.tv_show_id == DbTVShow.pk)
+        .options(joinedload(DbUserTVEpisode.episode).joinedload(DbTVEpisode.tv_show))
         .filter(DbUserTVEpisode.user_id == user_pk, DbUserTVEpisode.watched == 1)
+        # Episode marks dwarf every other domain (tens of thousands once a
+        # library is imported) and occurred_at is updated_at here, so only the
+        # newest MAX_FEED can survive the merged sort — bound it in SQL.
+        .order_by(DbUserTVEpisode.updated_at.desc())
+        .limit(MAX_FEED)
         .all()
     )
     items = []
@@ -137,7 +139,7 @@ def _episode_activity(db: Session, user_pk: int) -> List[ActivityItem]:
 def _game_activity(db: Session, user_pk: int) -> List[ActivityItem]:
     trackers = (
         db.query(DbUserVideoGame)
-        .join(DbVideoGame, DbUserVideoGame.game_id == DbVideoGame.pk)
+        .options(joinedload(DbUserVideoGame.game))
         .filter(DbUserVideoGame.user_id == user_pk)
         .all()
     )
@@ -173,7 +175,7 @@ def _game_activity(db: Session, user_pk: int) -> List[ActivityItem]:
 def _book_activity(db: Session, user_pk: int) -> List[ActivityItem]:
     trackers = (
         db.query(DbUserBook)
-        .join(DbBook, DbUserBook.book_id == DbBook.pk)
+        .options(joinedload(DbUserBook.book))
         .filter(DbUserBook.user_id == user_pk)
         .all()
     )
@@ -208,7 +210,7 @@ def _book_activity(db: Session, user_pk: int) -> List[ActivityItem]:
 def _country_activity(db: Session, user_pk: int) -> List[ActivityItem]:
     trackers = (
         db.query(DbUserCountry)
-        .join(DbCountry, DbUserCountry.country_id == DbCountry.pk)
+        .options(joinedload(DbUserCountry.country))
         .filter(DbUserCountry.user_id == user_pk)
         .all()
     )
@@ -256,14 +258,14 @@ def get_activity(
     if category:
         items = [i for i in items if i.category == category]
     items.sort(key=lambda i: i.occurred_at, reverse=True)
-    return items[: max(1, min(limit, 200))]
+    return items[: max(1, min(limit, MAX_FEED))]
 
 
 # --- "I'm bored" recommendation ---
 def _movie_pool(db: Session, user_pk: int) -> List[BoredItem]:
     trackers = (
         db.query(DbUserMovie)
-        .join(DbMovie, DbUserMovie.movie_id == DbMovie.pk)
+        .options(joinedload(DbUserMovie.movie))
         .filter(DbUserMovie.user_id == user_pk, DbUserMovie.on_watchlist.is_(True))
         .all()
     )
@@ -281,7 +283,7 @@ def _movie_pool(db: Session, user_pk: int) -> List[BoredItem]:
 def _tv_show_pool(db: Session, user_pk: int) -> List[BoredItem]:
     trackers = (
         db.query(DbUserTVShow)
-        .join(DbTVShow, DbUserTVShow.tv_show_id == DbTVShow.pk)
+        .options(joinedload(DbUserTVShow.tv_show))
         .filter(DbUserTVShow.user_id == user_pk, DbUserTVShow.on_watchlist.is_(True))
         .all()
     )
@@ -299,7 +301,7 @@ def _tv_show_pool(db: Session, user_pk: int) -> List[BoredItem]:
 def _game_pool(db: Session, user_pk: int) -> List[BoredItem]:
     trackers = (
         db.query(DbUserVideoGame)
-        .join(DbVideoGame, DbUserVideoGame.game_id == DbVideoGame.pk)
+        .options(joinedload(DbUserVideoGame.game))
         .filter(
             DbUserVideoGame.user_id == user_pk, DbUserVideoGame.on_watchlist.is_(True)
         )
@@ -319,7 +321,7 @@ def _game_pool(db: Session, user_pk: int) -> List[BoredItem]:
 def _book_pool(db: Session, user_pk: int) -> List[BoredItem]:
     trackers = (
         db.query(DbUserBook)
-        .join(DbBook, DbUserBook.book_id == DbBook.pk)
+        .options(joinedload(DbUserBook.book))
         .filter(DbUserBook.user_id == user_pk, DbUserBook.on_watchlist.is_(True))
         .all()
     )
@@ -338,7 +340,7 @@ def _book_pool(db: Session, user_pk: int) -> List[BoredItem]:
 def _country_pool(db: Session, user_pk: int) -> List[BoredItem]:
     trackers = (
         db.query(DbUserCountry)
-        .join(DbCountry, DbUserCountry.country_id == DbCountry.pk)
+        .options(joinedload(DbUserCountry.country))
         .filter(DbUserCountry.user_id == user_pk, DbUserCountry.on_watchlist.is_(True))
         .all()
     )

--- a/app/router/v1/router_books.py
+++ b/app/router/v1/router_books.py
@@ -11,7 +11,7 @@ from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from app.db.database import get_db
 from app.services.rate_limit import catalog_add_cap, search_rate_limit
@@ -206,7 +206,12 @@ def _close_rank_gap(db: Session, user_pk: int, vacated_rank) -> None:
 def get_user_books(
     db: Session = Depends(get_db), current_user: list = Depends(get_current_user)
 ):
-    return db.query(DbUserBook).filter(DbUserBook.user_id == current_user[0].pk).all()
+    return (
+        db.query(DbUserBook)
+        .options(joinedload(DbUserBook.book))
+        .filter(DbUserBook.user_id == current_user[0].pk)
+        .all()
+    )
 
 
 @router.put('/users/me/books/rankings/order', response_model=List[UserBookResponse])

--- a/app/router/v1/router_games.py
+++ b/app/router/v1/router_games.py
@@ -12,7 +12,7 @@ from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from app.db.database import get_db
 from app.services.rate_limit import catalog_add_cap, search_rate_limit
@@ -203,6 +203,7 @@ def get_user_games(
 ):
     return (
         db.query(DbUserVideoGame)
+        .options(joinedload(DbUserVideoGame.game))
         .filter(DbUserVideoGame.user_id == current_user[0].pk)
         .all()
     )

--- a/app/router/v1/router_movies.py
+++ b/app/router/v1/router_movies.py
@@ -7,7 +7,7 @@ from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from app.db.database import get_db
 from app.services.rate_limit import catalog_add_cap, search_rate_limit
@@ -197,7 +197,12 @@ def _close_rank_gap(db: Session, user_pk: int, vacated_rank) -> None:
 def get_user_movies(
     db: Session = Depends(get_db), current_user: list = Depends(get_current_user)
 ):
-    return db.query(DbUserMovie).filter(DbUserMovie.user_id == current_user[0].pk).all()
+    return (
+        db.query(DbUserMovie)
+        .options(joinedload(DbUserMovie.movie))
+        .filter(DbUserMovie.user_id == current_user[0].pk)
+        .all()
+    )
 
 
 @router.get('/users/me/movies/{movie_id}', response_model=UserMovieResponse)

--- a/app/router/v1/router_tv.py
+++ b/app/router/v1/router_tv.py
@@ -12,7 +12,7 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from app.db.database import get_db
 from app.services.rate_limit import catalog_add_cap, search_rate_limit
@@ -323,7 +323,12 @@ def get_user_tv_shows(
     db: Session = Depends(get_db), current_user: list = Depends(get_current_user)
 ):
     user_pk = current_user[0].pk
-    trackers = db.query(DbUserTVShow).filter(DbUserTVShow.user_id == user_pk).all()
+    trackers = (
+        db.query(DbUserTVShow)
+        .options(joinedload(DbUserTVShow.tv_show))
+        .filter(DbUserTVShow.user_id == user_pk)
+        .all()
+    )
     show_pks = [t.tv_show_id for t in trackers]
     # airdate is stored tz-naive (see tv_search._to_date), so compare naive.
     now = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -397,6 +402,7 @@ def get_schedule(  # pylint: disable=too-many-locals
 
     trackers = (
         db.query(DbUserTVShow)
+        .options(joinedload(DbUserTVShow.tv_show))
         .filter(
             DbUserTVShow.user_id == user_pk,
             (DbUserTVShow.on_watchlist.is_(True))


### PR DESCRIPTION
**Launch-blocking:** druthers.io hangs after sign-in now that real data is in prod.

## Root cause
`.join(DbMovie, ...)` filters and joins but does **not** populate the `t.movie` relationship — so every access of a nested catalog object fired its own SELECT. There was no eager loading anywhere in the codebase. Invisible with the 4-row dev dataset; with the imported library one `/v1/users/me/activity` request issued roughly **29,000 queries** (13,723 watched episodes × 2 levels, plus 1341 movies, 251 shows, 211 books, 176 games). The endpoint also builds the entire feed in Python before applying `limit`.

## Measured against real prod data (Neon)
| | before | after |
|---|---|---|
| movies activity | 1342 queries / 114.7s | 1 query / 2.1s |
| tv activity | 252 queries / 17.3s | 1 query / 0.15s |
| **all five domains** | ~29,000 queries | **5 queries / 4.1s** |

(Measured from a laptop with ~85ms RTT to Neon; Cloud Run runs in the same region, so wall time will be far lower. Query *count* is the thing that mattered.)

## Changes
- `joinedload` on all six activity helpers, all five "bored" pools, the four `/v1/users/me/{movies,tv-shows,books,games}` list endpoints (their responses serialize the nested catalog object), and the schedule's frozen-shows query.
- Episode activity is now bounded in SQL (`ORDER BY updated_at DESC LIMIT MAX_FEED`). Safe because `occurred_at` **is** `updated_at` for episodes, and the endpoint already caps output at 200 — only the newest 200 could ever survive the merged sort. This also stops the cost growing with library size.
- Dropped 5 catalog imports left unused once the manual joins went away.

## Verification
Full suite **233 passed**; black/pylint 10/10; probe re-run against prod data confirms the numbers above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)