### PR TITLE
Add recurring TV refresh job for the production cron

### DIFF
--- a/app/jobs/__init__.py
+++ b/app/jobs/__init__.py
@@ -1,0 +1,7 @@
+"""
+Recurring maintenance jobs.
+
+Distinct from ``app.migration``, which holds one-shot backfills that go quiet
+once complete. Everything here is meant to run on a schedule, forever, and
+must be idempotent.
+"""

--- a/app/jobs/refresh_tv.py
+++ b/app/jobs/refresh_tv.py
@@ -1,0 +1,137 @@
+"""
+Keep tracked TV shows current: pull newly aired episodes and refresh show
+status from TVMaze.
+
+This is the recurring counterpart to ``app.migration.enrich_tv``, which only
+touches shows *missing* detail and therefore goes silent once the backfill is
+done — it would never notice a new season. This job re-syncs shows a user
+actually tracks, so the Schedule page keeps working.
+
+Usage::
+
+    DATABASE_URL=... ENV=prod python -m app.jobs.refresh_tv [--all] [--limit N]
+
+Idempotent: ``sync_episodes`` upserts on the TVMaze episode id, so re-running
+only ever adds new episodes and refreshes existing titles/airdates.
+"""
+
+import argparse
+import time
+
+from sqlalchemy import or_
+
+from app.db.database import SessionLocal
+from app.db.models_sandbox import (
+    DbTVShow,
+    DbUserTVShow,
+)
+from app.log.logging_config import logger
+from app.services.tv_search import (
+    apply_detail_to_show,
+    get_tv_show_detail,
+    sync_episodes,
+)
+
+# TVMaze allows ~20 requests / 10s; each show costs two calls (detail +
+# episodes), so 1.5s between shows keeps a full pass well inside the limit.
+THROTTLE_SECONDS = 1.5
+# Consecutive detail misses almost always mean we are being rate limited
+# rather than that every remaining show vanished — stop and try again later.
+STOP_AFTER_CONSECUTIVE_MISSES = 15
+# Shows in these states can still gain episodes. Anything else is only worth
+# refreshing on an explicit --all pass.
+ACTIVE_STATUSES = ('Running', 'To Be Determined', 'In Development')
+
+
+def _shows_to_refresh(db, include_ended: bool):
+    """
+    Shows tracked by at least one user, newest-airing first.
+
+    Untracked catalog entries are skipped deliberately: they cost the same
+    TVMaze budget but nothing in the product reads them.
+    """
+    query = (
+        db.query(DbTVShow)
+        .join(DbUserTVShow, DbUserTVShow.tv_show_id == DbTVShow.pk)
+        .filter(DbTVShow.tvmaze.isnot(None))
+    )
+    if not include_ended:
+        query = query.filter(
+            or_(
+                DbTVShow.status.in_(ACTIVE_STATUSES),
+                DbTVShow.status.is_(None),
+            )
+        )
+    return query.distinct().all()
+
+
+def run(include_ended: bool = False, limit: int = 0) -> dict:
+    """Refresh tracked shows. Returns a small report dict."""
+    db = SessionLocal()
+    report = {'shows': 0, 'episodes_created': 0, 'detail_updated': 0, 'misses': 0}
+    try:
+        shows = _shows_to_refresh(db, include_ended)
+        if limit:
+            shows = shows[:limit]
+        logger.info('refresh_tv: %d shows to refresh', len(shows))
+
+        consecutive_misses = 0
+        for show in shows:
+            detail = get_tv_show_detail(show.tvmaze)
+            if detail:
+                apply_detail_to_show(show, detail)
+                report['detail_updated'] += 1
+                consecutive_misses = 0
+            else:
+                report['misses'] += 1
+                consecutive_misses += 1
+                if consecutive_misses >= STOP_AFTER_CONSECUTIVE_MISSES:
+                    logger.warning(
+                        'refresh_tv: %d consecutive misses - stopping early '
+                        '(likely rate limited)',
+                        consecutive_misses,
+                    )
+                    break
+
+            created = sync_episodes(db, show)
+            report['episodes_created'] += created
+            report['shows'] += 1
+            # Commit per show so an early stop still keeps completed work.
+            db.commit()
+            time.sleep(THROTTLE_SECONDS)
+    finally:
+        db.close()
+
+    logger.info(
+        'refresh_tv: shows=%(shows)d episodes_created=%(episodes_created)d '
+        'detail_updated=%(detail_updated)d misses=%(misses)d',
+        report,
+    )
+    return report
+
+
+def main() -> None:
+    """CLI entrypoint."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--all',
+        action='store_true',
+        dest='include_ended',
+        help='Also refresh ended/cancelled shows (default: active only).',
+    )
+    parser.add_argument(
+        '--limit',
+        type=int,
+        default=0,
+        help='Cap the number of shows processed (0 = no cap).',
+    )
+    args = parser.parse_args()
+    report = run(include_ended=args.include_ended, limit=args.limit)
+    print(
+        'refresh_tv: shows={shows} episodes_created={episodes_created} '
+        'detail_updated={detail_updated} misses={misses}'.format(**report)
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/unit/refresh_tv_test.py
+++ b/tests/unit/refresh_tv_test.py
@@ -1,0 +1,81 @@
+"""
+Test the recurring TV refresh job's show-selection rules.
+"""
+
+# The selection helper is the contract worth pinning here, private or not.
+# pylint: disable=protected-access
+
+from unittest.mock import patch
+
+from app.db.models_sandbox import DbTVShow, DbUserTVShow
+from app.jobs import refresh_tv
+
+
+def _show(db, title, tvmaze, status):
+    show = DbTVShow(title=title, tvmaze=tvmaze, status=status)
+    db.add(show)
+    db.flush()
+    return show
+
+
+def test_only_tracked_shows_are_refreshed(test_db_session):
+    """
+    Untracked catalog entries cost TVMaze budget for nothing.
+    """
+    tracked = _show(test_db_session, 'Tracked', 101, 'Running')
+    _show(test_db_session, 'Untracked', 102, 'Running')
+    test_db_session.add(DbUserTVShow(user_id=1, tv_show_id=tracked.pk))
+    test_db_session.flush()
+
+    picked = refresh_tv._shows_to_refresh(test_db_session, include_ended=False)
+    assert [s.title for s in picked] == ['Tracked']
+
+
+def test_ended_shows_are_skipped_by_default_and_included_with_all(test_db_session):
+    """
+    Ended shows cannot gain episodes, so they are off the nightly path but
+    reachable with --all.
+    """
+    ended = _show(test_db_session, 'Ended Show', 201, 'Ended')
+    running = _show(test_db_session, 'Running Show', 202, 'Running')
+    unknown = _show(test_db_session, 'Unknown Status', 203, None)
+    for s in (ended, running, unknown):
+        test_db_session.add(DbUserTVShow(user_id=1, tv_show_id=s.pk))
+    test_db_session.flush()
+
+    default = {s.title for s in refresh_tv._shows_to_refresh(test_db_session, False)}
+    assert default == {'Running Show', 'Unknown Status'}
+
+    every = {s.title for s in refresh_tv._shows_to_refresh(test_db_session, True)}
+    assert every == {'Ended Show', 'Running Show', 'Unknown Status'}
+
+
+def test_shows_without_a_tvmaze_id_are_skipped(test_db_session):
+    """
+    There is nothing to refresh against without an upstream id.
+    """
+    show = _show(test_db_session, 'No TVMaze', None, 'Running')
+    test_db_session.add(DbUserTVShow(user_id=1, tv_show_id=show.pk))
+    test_db_session.flush()
+
+    assert refresh_tv._shows_to_refresh(test_db_session, include_ended=False) == []
+
+
+@patch('app.jobs.refresh_tv.sync_episodes', return_value=3)
+@patch('app.jobs.refresh_tv.get_tv_show_detail', return_value=None)
+@patch('app.jobs.refresh_tv.time.sleep')
+def test_stops_early_after_consecutive_misses(_sleep, _detail, _sync, test_db_session):
+    """
+    A run of misses means rate limiting — stop rather than hammer TVMaze.
+    """
+    for i in range(refresh_tv.STOP_AFTER_CONSECUTIVE_MISSES + 5):
+        show = _show(test_db_session, f'Show {i}', 300 + i, 'Running')
+        test_db_session.add(DbUserTVShow(user_id=1, tv_show_id=show.pk))
+    test_db_session.flush()
+
+    with patch('app.jobs.refresh_tv.SessionLocal', return_value=test_db_session):
+        report = refresh_tv.run()
+
+    assert report['misses'] == refresh_tv.STOP_AFTER_CONSECUTIVE_MISSES
+    # Stopped before touching every show
+    assert report['shows'] < refresh_tv.STOP_AFTER_CONSECUTIVE_MISSES + 5


### PR DESCRIPTION
Closes the TV-freshness half of the cutover's cron requirement.

## Why a new job
`app.migration.enrich_tv` selects only shows **missing** detail (`summary IS NULL AND premiered IS NULL`). It's a backfill: once it completes it goes silent and will never notice a new season. Nothing in the codebase kept episodes current, so prod TV data would quietly rot and the Schedule page would stop showing new episodes.

## What this does
`app/jobs/refresh_tv.py` (new `app.jobs` package for *recurring* work, vs `app.migration` for one-shot backfills) re-syncs shows a user actually tracks: refreshes status/detail from TVMaze and upserts episodes through the existing `sync_episodes`.

- **Scoped to tracked shows** — untracked catalog rows cost the same TVMaze budget and nothing reads them.
- **Active shows by default.** Prod is 223 Ended vs 31 Running + 6 TBD + 3 unknown, so a nightly pass is ~40 shows ≈ 60s of throttled calls. `--all` sweeps ended shows too.
- **Commits per show**, so hitting the rate-limit circuit breaker still keeps completed work.
- Reuses `enrich_tv`'s throttle and consecutive-miss stop.

## Verified against production data
- 2-show run found **16 missing episodes** (the orion import genuinely left TV data behind).
- Immediate re-run created **0** — idempotent, which is the property that matters for a cron.
- 4 new unit tests cover the selection rules (tracked-only, ended excluded by default and included with `--all`, shows without a TVMaze id skipped) and the rate-limit circuit breaker. Full suite **237 passed**, pylint 10/10.

## Deployment
Runs on hephaestus from adam's crontab via the GHCR image, against Neon — needs a release to reach `ghcr.io/aleonard9/aleonard.us-api` before the cron can be enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)