### PR TITLE
completed_at: the date an item was finished, with orion history recovery

### DIFF
--- a/alembic/versions/f2a5b74c8d36_tracker_completed_at.py
+++ b/alembic/versions/f2a5b74c8d36_tracker_completed_at.py
@@ -1,0 +1,47 @@
+"""tracker completed_at
+
+The date the user finished an item (#159) — the old site's ``g_first`` field,
+lost/partially conflated by the orion import. Defaults to the day an item
+enters Rankings; editable on the detail page. Historical values are restored
+separately by ``app.migration.backfill_completed_at`` (better data than any
+in-schema backfill could manage).
+
+Countries deliberately excluded — the product no longer tracks them.
+
+Revision ID: f2a5b74c8d36
+Revises: e9f4a63b7c25
+Create Date: 2026-07-19 07:40:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'f2a5b74c8d36'
+down_revision: Union[str, Sequence[str], None] = 'e9f4a63b7c25'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TRACKER_TABLES = (
+    'user_movies',
+    'user_tv_shows',
+    'user_books',
+    'user_video_games',
+)
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    for table_name in TRACKER_TABLES:
+        with op.batch_alter_table(table_name, schema=None) as batch_op:
+            batch_op.add_column(sa.Column('completed_at', sa.Date(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    for table_name in TRACKER_TABLES:
+        with op.batch_alter_table(table_name, schema=None) as batch_op:
+            batch_op.drop_column('completed_at')

--- a/app/db/models_sandbox.py
+++ b/app/db/models_sandbox.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     Integer,
     String,
     Float,
+    Date,
     DateTime,
     ForeignKey,
     Text,
@@ -117,6 +118,9 @@ class DbUserMovie(DBBaseModel):
     ranked_at = Column(DateTime, nullable=True)
     completed = Column(Integer, nullable=True)
     notes = Column(Text, nullable=True)
+    # When the user finished it (#159): defaults to the day it entered
+    # Rankings, editable on the detail page.
+    completed_at = Column(Date, nullable=True)
 
     movie = relationship('DbMovie', back_populates='user_movies')
     user = relationship('DbUser', backref='user_movies')
@@ -159,6 +163,9 @@ class DbUserTVShow(DBBaseModel):
     # and other tracker updates never re-date a ranking (#141).
     ranked_at = Column(DateTime, nullable=True)
     notes = Column(Text, nullable=True)
+    # When the user finished it (#159): defaults to the day it entered
+    # Rankings, editable on the detail page.
+    completed_at = Column(Date, nullable=True)
     status = Column(String(254), nullable=True)
     freeze = Column(Integer, default=0)
 
@@ -230,6 +237,9 @@ class DbUserVideoGame(DBBaseModel):
     ranked_at = Column(DateTime, nullable=True)
     completed = Column(Integer, nullable=True)
     notes = Column(Text, nullable=True)
+    # When the user finished it (#159): defaults to the day it entered
+    # Rankings, editable on the detail page.
+    completed_at = Column(Date, nullable=True)
     is_100_percent = Column(Boolean, default=False)
 
     game = relationship('DbVideoGame', back_populates='user_games')
@@ -272,6 +282,9 @@ class DbUserBook(DBBaseModel):
     ranked_at = Column(DateTime, nullable=True)
     completed = Column(Integer, nullable=True)
     notes = Column(Text, nullable=True)
+    # When the user finished it (#159): defaults to the day it entered
+    # Rankings, editable on the detail page.
+    completed_at = Column(Date, nullable=True)
 
     book = relationship('DbBook', back_populates='user_books')
     user = relationship('DbUser', backref='user_books')

--- a/app/migration/backfill_completed_at.py
+++ b/app/migration/backfill_completed_at.py
@@ -1,0 +1,185 @@
+"""
+Recover the old site's completed dates (``g_first``) into ``completed_at``.
+
+The orion import handled ``g_first`` inconsistently: movies conflated it into
+``created_at`` (with a ``g_updated`` fallback), and books/games never fetched
+it at all. This one-shot reads the orion source again and restores the real
+dates, falling back to ``g_created`` (the day the row was added — the old
+site's default) for completed rows that never had an explicit date.
+
+Joins use the same natural keys as ``orion_import``: movies/tv by ``imdb``,
+books by ``googleid or title`` (exactly what the import wrote into phoenix's
+``googleid`` column), games by ``igdb``. TV is excluded — orion never had a
+per-show completed date.
+
+Idempotent: only rows whose ``completed_at`` is currently NULL are touched,
+so user edits are never clobbered and re-running is safe.
+
+Usage::
+
+    ORION_MYSQL_URL=mysql+pymysql://root:pw@127.0.0.1:13307/orion \\
+    DATABASE_URL=postgresql://... ENV=prod \\
+        python -m app.migration.backfill_completed_at [--dry-run] \\
+        [--email adamleonard9@gmail.com]
+"""
+
+import argparse
+import os
+import sys
+
+from sqlalchemy import create_engine, text
+
+from app.db.database import SessionLocal
+from app.db.models import DbUser
+from app.db.models_sandbox import (
+    DbBook,
+    DbMovie,
+    DbUserBook,
+    DbUserMovie,
+    DbUserVideoGame,
+    DbVideoGame,
+)
+
+DEFAULT_EMAIL = 'adamleonard9@gmail.com'
+
+# (label, orion SQL producing natural_key/g_first/g_created, catalog model,
+#  catalog key column, tracker model, tracker fk column)
+DOMAINS = (
+    (
+        'movies',
+        '''SELECT m.imdb AS natural_key, g.g_first, g.g_created
+           FROM g_user_movies g
+           JOIN movies m ON m.id = g.movies_id
+           WHERE g.user_id = :uid AND g.completed = 1''',
+        DbMovie,
+        'imdb',
+        DbUserMovie,
+        'movie_id',
+    ),
+    (
+        'books',
+        '''SELECT COALESCE(NULLIF(b.googleid, ''), b.title) AS natural_key,
+                  g.g_first, g.g_created
+           FROM g_user_books g
+           JOIN books b ON b.id = g.books_id
+           WHERE g.user_id = :uid AND g.completed = 1''',
+        DbBook,
+        'googleid',
+        DbUserBook,
+        'book_id',
+    ),
+    (
+        'games',
+        '''SELECT v.igdb AS natural_key, g.g_first, g.g_created
+           FROM g_user_videogames g
+           JOIN videogames v ON v.id = g.videogames_id
+           WHERE g.user_id = :uid AND g.completed = 1''',
+        DbVideoGame,
+        'igdb',
+        DbUserVideoGame,
+        'game_id',
+    ),
+)
+
+
+def run(  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
+    dry_run: bool, email: str
+) -> None:
+    """Execute the backfill (or report what it would do)."""
+    orion_url = os.environ.get('ORION_MYSQL_URL')
+    if not orion_url:
+        sys.exit('ORION_MYSQL_URL is required (throwaway MySQL with the dump)')
+
+    orion = create_engine(orion_url)
+    db = SessionLocal()
+    try:
+        user = db.query(DbUser).filter(DbUser.email == email).first()
+        if user is None:
+            sys.exit(f'No phoenix user with email {email}')
+
+        with orion.connect() as conn:
+            orion_uid = conn.execute(
+                text('SELECT id FROM users WHERE email = :email'),
+                {'email': email},
+            ).scalar()
+            if orion_uid is None:
+                sys.exit(f'No orion user with email {email}')
+
+            print(
+                f'{"domain":8} {"matched":>8} {"g_first":>8} '
+                f'{"default":>8} {"skipped":>8} {"unmatched":>10}'
+            )
+            for label, sql, catalog, key_col, tracker, fk_col in DOMAINS:
+                rows = conn.execute(text(sql), {'uid': orion_uid}).mappings().all()
+                matched = from_first = from_default = skipped = unmatched = 0
+                misses = []
+                for row in rows:
+                    key = row['natural_key']
+                    if key is None:
+                        unmatched += 1
+                        continue
+                    item = (
+                        db.query(catalog)
+                        .filter(getattr(catalog, key_col) == str(key).strip())
+                        .first()
+                    )
+                    if item is None:
+                        unmatched += 1
+                        misses.append(str(key)[:40])
+                        continue
+                    t = (
+                        db.query(tracker)
+                        .filter(
+                            tracker.user_id == user.pk,
+                            getattr(tracker, fk_col) == item.pk,
+                        )
+                        .first()
+                    )
+                    if t is None:
+                        unmatched += 1
+                        misses.append(f'(no tracker) {str(key)[:32]}')
+                        continue
+                    if t.completed_at is not None:
+                        skipped += 1  # already set — never clobber
+                        continue
+                    source = row['g_first'] or row['g_created']
+                    if source is None:
+                        skipped += 1
+                        continue
+                    t.completed_at = source.date()
+                    matched += 1
+                    if row['g_first']:
+                        from_first += 1
+                    else:
+                        from_default += 1
+                print(
+                    f'{label:8} {matched:8} {from_first:8} '
+                    f'{from_default:8} {skipped:8} {unmatched:10}'
+                )
+                if misses:
+                    print(
+                        f'  unmatched in {label}: {", ".join(misses[:8])}'
+                        + (' …' if len(misses) > 8 else '')
+                    )
+
+        if dry_run:
+            db.rollback()
+            print('\n(dry run - no changes were committed)')
+        else:
+            db.commit()
+            print('\ncommitted')
+    finally:
+        db.close()
+
+
+def main() -> None:
+    """CLI entrypoint."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--dry-run', action='store_true')
+    parser.add_argument('--email', default=DEFAULT_EMAIL)
+    args = parser.parse_args()
+    run(dry_run=args.dry_run, email=args.email)
+
+
+if __name__ == '__main__':
+    main()

--- a/app/router/v1/router_books.py
+++ b/app/router/v1/router_books.py
@@ -15,7 +15,11 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.db.database import get_db
 from app.services.rate_limit import catalog_add_cap, search_rate_limit
-from app.services.tracker_rules import enforce_single_home, utc_now
+from app.services.tracker_rules import (
+    default_completed_at,
+    enforce_single_home,
+    utc_now,
+)
 from app.db.models_sandbox import DbBook, DbUserBook
 from app.auth.oauth2 import get_current_user, require_admin
 from app.schemas.schemas_sandbox import (
@@ -279,8 +283,10 @@ def set_book_rank(
         )
 
     old_rank = tracker.rank
+    was_on_rankings = tracker.on_rankings
     tracker.on_rankings = True
     tracker.on_watchlist = False
+    default_completed_at(tracker, was_on_rankings)
     # Remove from its current slot first so the shift math excludes it.
     tracker.rank = None
     db.flush()
@@ -333,12 +339,13 @@ def mark_book(
             on_watchlist=bool(data.get('on_watchlist', False)),
             on_rankings=bool(data.get('on_rankings', False)),
             notes=data.get('notes'),
+            completed_at=data.get('completed_at'),
         )
         db.add(tracker)
     else:
         was_on_rankings = tracker.on_rankings
         old_rank = tracker.rank
-        for key in ('on_watchlist', 'on_rankings', 'notes'):
+        for key in ('on_watchlist', 'on_rankings', 'notes', 'completed_at'):
             if key in data:
                 setattr(tracker, key, data[key])
 
@@ -346,6 +353,7 @@ def mark_book(
     # placed. Entering Rankings (or leaving it) resets to unplaced so it lands
     # in the "to rank" bucket rather than at a stale/leftover position.
     enforce_single_home(tracker, data)
+    default_completed_at(tracker, was_on_rankings)
     if not tracker.on_rankings or not was_on_rankings:
         tracker.rank = None
         tracker.ranked_at = None
@@ -378,6 +386,7 @@ def update_user_book(
     for key, value in data.items():
         setattr(tracker, key, value)
     enforce_single_home(tracker, data)
+    default_completed_at(tracker, was_on_rankings)
 
     # Entering Rankings (or leaving it) resets to unplaced so a stale/leftover
     # rank never places the book automatically; it lands in "to rank" instead.

--- a/app/router/v1/router_games.py
+++ b/app/router/v1/router_games.py
@@ -16,7 +16,11 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.db.database import get_db
 from app.services.rate_limit import catalog_add_cap, search_rate_limit
-from app.services.tracker_rules import enforce_single_home, utc_now
+from app.services.tracker_rules import (
+    default_completed_at,
+    enforce_single_home,
+    utc_now,
+)
 from app.db.models_sandbox import DbVideoGame, DbUserVideoGame
 from app.auth.oauth2 import get_current_user, require_admin
 from app.schemas.schemas_sandbox import (
@@ -279,8 +283,10 @@ def set_game_rank(
         )
 
     old_rank = tracker.rank
+    was_on_rankings = tracker.on_rankings
     tracker.on_rankings = True
     tracker.on_watchlist = False
+    default_completed_at(tracker, was_on_rankings)
     # Remove from its current slot first so the shift math excludes it.
     tracker.rank = None
     db.flush()
@@ -338,13 +344,20 @@ def mark_game(
             on_watchlist=bool(data.get('on_watchlist', False)),
             on_rankings=bool(data.get('on_rankings', False)),
             notes=data.get('notes'),
+            completed_at=data.get('completed_at'),
             is_100_percent=bool(data.get('is_100_percent', False)),
         )
         db.add(tracker)
     else:
         was_on_rankings = tracker.on_rankings
         old_rank = tracker.rank
-        for key in ('on_watchlist', 'on_rankings', 'notes', 'is_100_percent'):
+        for key in (
+            'on_watchlist',
+            'on_rankings',
+            'notes',
+            'completed_at',
+            'is_100_percent',
+        ):
             if key in data:
                 setattr(tracker, key, data[key])
 
@@ -352,6 +365,7 @@ def mark_game(
     # placed. Entering Rankings (or leaving it) resets to unplaced so it lands
     # in the "to rank" bucket rather than at a stale/leftover position.
     enforce_single_home(tracker, data)
+    default_completed_at(tracker, was_on_rankings)
     if not tracker.on_rankings or not was_on_rankings:
         tracker.rank = None
         tracker.ranked_at = None
@@ -384,6 +398,7 @@ def update_user_game(
     for key, value in data.items():
         setattr(tracker, key, value)
     enforce_single_home(tracker, data)
+    default_completed_at(tracker, was_on_rankings)
 
     # Entering Rankings (or leaving it) resets to unplaced so a stale/leftover
     # rank never places the game automatically; it lands in "to rank" instead.

--- a/app/router/v1/router_movies.py
+++ b/app/router/v1/router_movies.py
@@ -11,7 +11,11 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.db.database import get_db
 from app.services.rate_limit import catalog_add_cap, search_rate_limit
-from app.services.tracker_rules import enforce_single_home, utc_now
+from app.services.tracker_rules import (
+    default_completed_at,
+    enforce_single_home,
+    utc_now,
+)
 from app.db.models_sandbox import DbMovie, DbUserMovie
 from app.auth.oauth2 import get_current_user, require_admin
 from app.schemas.schemas_sandbox import (
@@ -270,8 +274,10 @@ def set_movie_rank(
         )
 
     old_rank = tracker.rank
+    was_on_rankings = tracker.on_rankings
     tracker.on_rankings = True
     tracker.on_watchlist = False
+    default_completed_at(tracker, was_on_rankings)
     # Remove from its current slot first so the shift math excludes it.
     tracker.rank = None
     db.flush()
@@ -324,12 +330,13 @@ def mark_movie(
             on_watchlist=bool(data.get('on_watchlist', False)),
             on_rankings=bool(data.get('on_rankings', False)),
             notes=data.get('notes'),
+            completed_at=data.get('completed_at'),
         )
         db.add(tracker)
     else:
         was_on_rankings = tracker.on_rankings
         old_rank = tracker.rank
-        for key in ('on_watchlist', 'on_rankings', 'notes'):
+        for key in ('on_watchlist', 'on_rankings', 'notes', 'completed_at'):
             if key in data:
                 setattr(tracker, key, data[key])
 
@@ -337,6 +344,7 @@ def mark_movie(
     # placed. Entering Rankings (or leaving it) resets to unplaced so it lands
     # in the "to rank" bucket rather than at a stale/leftover position.
     enforce_single_home(tracker, data)
+    default_completed_at(tracker, was_on_rankings)
     if not tracker.on_rankings or not was_on_rankings:
         tracker.rank = None
         tracker.ranked_at = None
@@ -369,6 +377,7 @@ def update_user_movie(
     for key, value in data.items():
         setattr(tracker, key, value)
     enforce_single_home(tracker, data)
+    default_completed_at(tracker, was_on_rankings)
 
     # Entering Rankings (or leaving it) resets to unplaced so a stale/leftover
     # rank never places the movie automatically; it lands in "to rank" instead.

--- a/app/router/v1/router_tv.py
+++ b/app/router/v1/router_tv.py
@@ -16,7 +16,11 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.db.database import get_db
 from app.services.rate_limit import catalog_add_cap, search_rate_limit
-from app.services.tracker_rules import enforce_single_home, utc_now
+from app.services.tracker_rules import (
+    default_completed_at,
+    enforce_single_home,
+    utc_now,
+)
 from app.db.models_sandbox import DbTVShow, DbUserTVShow, DbTVEpisode, DbUserTVEpisode
 from app.auth.oauth2 import get_current_user, require_admin
 from app.schemas.schemas_sandbox import (
@@ -532,8 +536,10 @@ def set_show_rank(
         )
 
     old_rank = tracker.rank
+    was_on_rankings = tracker.on_rankings
     tracker.on_rankings = True
     tracker.on_watchlist = False
+    default_completed_at(tracker, was_on_rankings)
     # Remove from its current slot first so the shift math excludes it.
     tracker.rank = None
     db.flush()
@@ -586,12 +592,13 @@ def mark_tv_show(
             on_watchlist=bool(data.get('on_watchlist', False)),
             on_rankings=bool(data.get('on_rankings', False)),
             notes=data.get('notes'),
+            completed_at=data.get('completed_at'),
         )
         db.add(tracker)
     else:
         was_on_rankings = tracker.on_rankings
         old_rank = tracker.rank
-        for key in ('on_watchlist', 'on_rankings', 'notes'):
+        for key in ('on_watchlist', 'on_rankings', 'notes', 'completed_at'):
             if key in data:
                 setattr(tracker, key, data[key])
 
@@ -599,6 +606,7 @@ def mark_tv_show(
     # placed. Entering Rankings (or leaving it) resets to unplaced so it lands
     # in the "to rank" bucket rather than at a stale/leftover position.
     enforce_single_home(tracker, data)
+    default_completed_at(tracker, was_on_rankings)
     if not tracker.on_rankings or not was_on_rankings:
         tracker.rank = None
         tracker.ranked_at = None
@@ -631,6 +639,7 @@ def update_user_tv_show(
     for key, value in data.items():
         setattr(tracker, key, value)
     enforce_single_home(tracker, data)
+    default_completed_at(tracker, was_on_rankings)
 
     # Entering Rankings (or leaving it) resets to unplaced so a stale/leftover
     # rank never places the show automatically; it lands in "to rank" instead.

--- a/app/schemas/schemas_sandbox.py
+++ b/app/schemas/schemas_sandbox.py
@@ -4,7 +4,7 @@ This module contains Pydantic schemas for Sandbox entities.
 
 # pylint: disable=missing-class-docstring
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict
@@ -151,6 +151,7 @@ class UserMovieBase(BaseModel):
     rank: Optional[int] = None
     completed: Optional[int] = None
     notes: Optional[str] = None
+    completed_at: Optional[date] = None
 
 
 class UserMovieCreate(UserMovieBase):
@@ -257,6 +258,7 @@ class UserTVShowBase(BaseModel):
     on_rankings: Optional[bool] = None
     rank: Optional[int] = None
     notes: Optional[str] = None
+    completed_at: Optional[date] = None
     status: Optional[str] = None
     freeze: Optional[int] = None
 
@@ -438,6 +440,7 @@ class UserVideoGameBase(BaseModel):
     rank: Optional[int] = None
     completed: Optional[int] = None
     notes: Optional[str] = None
+    completed_at: Optional[date] = None
     is_100_percent: Optional[bool] = None
 
 
@@ -533,6 +536,7 @@ class UserBookBase(BaseModel):
     rank: Optional[int] = None
     completed: Optional[int] = None
     notes: Optional[str] = None
+    completed_at: Optional[date] = None
 
 
 class UserBookCreate(UserBookBase):

--- a/app/services/tracker_rules.py
+++ b/app/services/tracker_rules.py
@@ -31,3 +31,13 @@ def enforce_single_home(tracker, requested: dict) -> None:
         tracker.on_rankings = False
     else:
         tracker.on_watchlist = False
+
+
+def default_completed_at(tracker, was_on_rankings: bool) -> None:
+    """
+    Completed-date rule: entering Rankings means "I finished this", so stamp
+    today unless a date is already set (imported history or an explicit value
+    in the same request always wins). Editable later on the detail page.
+    """
+    if tracker.on_rankings and not was_on_rankings and tracker.completed_at is None:
+        tracker.completed_at = utc_now().date()

--- a/tests/integration/router_completed_at_test.py
+++ b/tests/integration/router_completed_at_test.py
@@ -1,0 +1,148 @@
+"""
+Test the completed-date rule (#159): defaults to the day an item enters
+Rankings, explicit values win, editable and clearable afterwards.
+"""
+
+from datetime import date
+
+from fastapi.testclient import TestClient
+
+
+def _auth(test_client: TestClient) -> dict:
+    return {'Authorization': f'Bearer {test_client.first_user.token}'}
+
+
+def _movie(test_client: TestClient, title='Heat', imdb='tt0113277') -> str:
+    admin = {'Authorization': f'Bearer {test_client.admin_user.token}'}
+    return test_client.post(
+        '/v1/movies', headers=admin, json={'title': title, 'imdb': imdb}
+    ).json()['id']
+
+
+def test_entering_rankings_stamps_today(test_client: TestClient):
+    """
+    Adding to Rankings means "I finished this" — completed_at defaults to
+    today.
+    """
+    movie_id = _movie(test_client)
+    body = test_client.post(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(test_client),
+        json={'on_rankings': True},
+    ).json()
+    assert body['completed_at'] == date.today().isoformat()
+
+
+def test_watchlist_does_not_stamp(test_client: TestClient):
+    """
+    Queueing something is not finishing it.
+    """
+    movie_id = _movie(test_client)
+    body = test_client.post(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(test_client),
+        json={'on_watchlist': True},
+    ).json()
+    assert body['completed_at'] is None
+
+
+def test_explicit_date_wins_over_the_default(test_client: TestClient):
+    """
+    Supplying a date in the same request that enters Rankings keeps it.
+    """
+    movie_id = _movie(test_client)
+    body = test_client.post(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(test_client),
+        json={'on_rankings': True, 'completed_at': '2019-06-01'},
+    ).json()
+    assert body['completed_at'] == '2019-06-01'
+
+
+def test_date_is_editable_and_clearable(test_client: TestClient):
+    """
+    The detail page can change or clear the date after the fact.
+    """
+    movie_id = _movie(test_client)
+    test_client.post(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(test_client),
+        json={'on_rankings': True},
+    )
+    edited = test_client.put(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(test_client),
+        json={'completed_at': '2020-12-25'},
+    ).json()
+    assert edited['completed_at'] == '2020-12-25'
+
+    cleared = test_client.put(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(test_client),
+        json={'completed_at': None},
+    ).json()
+    assert cleared['completed_at'] is None
+
+
+def test_reentering_rankings_does_not_overwrite_history(test_client: TestClient):
+    """
+    Demote to watchlist and re-promote: an existing date must survive.
+    """
+    movie_id = _movie(test_client)
+    test_client.post(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(test_client),
+        json={'on_rankings': True, 'completed_at': '2018-03-15'},
+    )
+    test_client.put(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(test_client),
+        json={'on_watchlist': True},
+    )
+    body = test_client.post(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(test_client),
+        json={'on_rankings': True},
+    ).json()
+    assert body['completed_at'] == '2018-03-15'
+
+
+def test_rank_endpoint_one_hop_stamps(test_client: TestClient):
+    """
+    watchlist -> ranked directly via the rank endpoint also counts as
+    finishing.
+    """
+    movie_id = _movie(test_client)
+    test_client.post(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(test_client),
+        json={'on_watchlist': True},
+    )
+    body = test_client.put(
+        f'/v1/users/me/movies/{movie_id}/rank',
+        headers=_auth(test_client),
+        json={'position': 1},
+    ).json()
+    assert body['completed_at'] == date.today().isoformat()
+
+
+def test_other_domains_share_the_rule(test_client: TestClient):
+    """
+    TV, books, and games run the same patched paths.
+    """
+    admin = {'Authorization': f'Bearer {test_client.admin_user.token}'}
+    cases = [
+        ('tv-shows', {'title': 'Severance', 'imdb': 'tt11280740'}),
+        ('books', {'title': 'Dune', 'isbn': '9780441172719'}),
+        ('games', {'title': 'Hades', 'igdb': 113112}),
+    ]
+    for noun, payload in cases:
+        item_id = test_client.post(f'/v1/{noun}', headers=admin, json=payload).json()[
+            'id'
+        ]
+        body = test_client.post(
+            f'/v1/users/me/{noun}/{item_id}',
+            headers=_auth(test_client),
+            json={'on_rankings': True},
+        ).json()
+        assert body['completed_at'] == date.today().isoformat(), noun


### PR DESCRIPTION
Restores a critical field the old site had that the modern stack lost: **the date you completed something**.

## Part A — what happened to the data
Audit of the orion source (schema + per-row inspection of the cutover dump):
- Orion stored it as **`g_first`** (timestamp) on movies/books/games trackers; `completed` was just a 0/1 flag. TV never had one (episode marks carry dates).
- The import handled it **inconsistently**: movies conflated `g_first` into `created_at` (with a `g_updated` fallback — semantically smeared); **books and games never even fetched it** — dropped entirely.
- Adam's real history at stake: 216 movies, 86 books, 28 games with explicit completion dates among completed rows.

## Part B — the feature
- `completed_at` (**Date**) on `user_movies/tv_shows/books/video_games` (migration `f2a5b74c8d36`; countries excluded — product dropped them).
- **Defaults to the day an item enters Rankings** ("I finished this"), via a shared `default_completed_at` rule applied at every transition point: POST merge, PUT, and the one-hop watchlist→ranked path through the rank endpoint.
- **Explicit values always win** — a date supplied in the same request, imported history, or a later detail-page edit is never overwritten; re-entering rankings preserves existing dates. Editable and clearable via PUT.

## Part C — recovery (`app.migration.backfill_completed_at`)
One-shot that re-reads the orion source and restores history using the import's own natural keys (movies→`imdb`, books→`googleid or title` exactly as the import wrote it, games→`igdb`). `COALESCE(g_first, g_created)` per the old site's default rule. Only touches NULL rows — idempotent, never clobbers.

**Rehearsed offline** (scratch Postgres at head + the actual cutover dump + the actual orion dump):
| domain | matched | real g_first | defaulted | unmatched |
|---|---|---|---|---|
| movies | 1303 | 216 | 1087 | **0** |
| books | 194 | 86 | 108 | **0** |
| games | 156 | 28 | 128 | **0** |

Matched counts exactly equal each domain's ranked counts. Spot-checked dates byte-identical to MySQL. Re-run skips all 1,653 rows.

## Verification
7 new integration tests (default stamp, watchlist doesn't stamp, explicit wins, edit/clear, history survives re-ranking, rank-endpoint one-hop, cross-domain). Full suite **244 passed**; black/pylint clean; single head `f2a5b74c8d36`.

Web + MCP exposure follow in companion PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)