### PR TITLE
watched_at: real episode watch dates + corrected tracker created_at

### DIFF
--- a/alembic/versions/a7c8d95e2f41_episode_watched_at.py
+++ b/alembic/versions/a7c8d95e2f41_episode_watched_at.py
@@ -1,0 +1,35 @@
+"""episode watched_at
+
+When an episode was actually watched (#160): stamped on mark going forward,
+restored from orion's ``g_first``/``g_created`` for pre-cutover history by
+``app.migration.backfill_orion_timestamps``. The Activity feed orders episode
+entries by ``COALESCE(watched_at, updated_at)``.
+
+Revision ID: a7c8d95e2f41
+Revises: f2a5b74c8d36
+Create Date: 2026-07-19 08:55:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'a7c8d95e2f41'
+down_revision: Union[str, Sequence[str], None] = 'f2a5b74c8d36'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('user_tv_episodes', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('watched_at', sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('user_tv_episodes', schema=None) as batch_op:
+        batch_op.drop_column('watched_at')

--- a/app/db/models_sandbox.py
+++ b/app/db/models_sandbox.py
@@ -195,6 +195,9 @@ class DbUserTVEpisode(DBBaseModel):
     user_id = Column(Integer, ForeignKey('users.pk'), nullable=False)
 
     watched = Column(Integer, default=0)
+    # When the episode was actually watched (#160): stamped on mark, restored
+    # from orion's g_first for pre-cutover history. Activity orders by this.
+    watched_at = Column(DateTime, nullable=True)
 
     episode = relationship('DbTVEpisode', back_populates='user_episodes')
     user = relationship('DbUser', backref='user_tv_episodes')

--- a/app/migration/backfill_orion_timestamps.py
+++ b/app/migration/backfill_orion_timestamps.py
@@ -1,0 +1,232 @@
+"""
+Recover the remaining orion timestamps (#160):
+
+1. **Episode watch dates** — ``g_user_tvepisodes.g_first`` was fetched by the
+   import but never used, so every pre-cutover watch mark carries an
+   import-time timestamp. Restores ``watched_at = COALESCE(g_first,
+   g_created)`` for watched marks, keyed deterministically through the TVMaze
+   episode id.
+2. **Tracker "date added"** — ``g_created`` was dropped (books/games/tv) or
+   overwritten (movies), so ``created_at`` is wrong across the tracker
+   tables. Corrects it from the orion source using the import's natural keys.
+
+Idempotent: watched_at only fills NULLs; created_at only changes when it
+differs from the orion value.
+
+Usage::
+
+    ORION_MYSQL_URL=mysql+pymysql://root:pw@127.0.0.1:13307/orion \\
+    DATABASE_URL=postgresql://... ENV=prod \\
+        python -m app.migration.backfill_orion_timestamps [--dry-run] \\
+        [--email adamleonard9@gmail.com]
+"""
+
+import argparse
+import os
+import sys
+
+from sqlalchemy import create_engine, text
+
+from app.db.database import SessionLocal
+from app.db.models import DbUser
+from app.db.models_sandbox import (
+    DbBook,
+    DbMovie,
+    DbTVEpisode,
+    DbTVShow,
+    DbUserBook,
+    DbUserMovie,
+    DbUserTVEpisode,
+    DbUserTVShow,
+    DbUserVideoGame,
+    DbVideoGame,
+)
+
+DEFAULT_EMAIL = 'adamleonard9@gmail.com'
+
+# Tracker created_at recovery: same natural keys the import used.
+TRACKER_DOMAINS = (
+    (
+        'movies',
+        '''SELECT m.imdb AS natural_key, g.g_created
+           FROM g_user_movies g JOIN movies m ON m.id = g.movies_id
+           WHERE g.user_id = :uid''',
+        DbMovie,
+        'imdb',
+        DbUserMovie,
+        'movie_id',
+    ),
+    (
+        'tv',
+        '''SELECT t.tvmaze AS natural_key, g.g_created
+           FROM g_user_tv g JOIN tv t ON t.id = g.tv_id
+           WHERE g.user_id = :uid''',
+        DbTVShow,
+        'tvmaze',
+        DbUserTVShow,
+        'tv_show_id',
+    ),
+    (
+        'books',
+        '''SELECT COALESCE(NULLIF(b.googleid, ''), b.title) AS natural_key,
+                  g.g_created
+           FROM g_user_books g JOIN books b ON b.id = g.books_id
+           WHERE g.user_id = :uid''',
+        DbBook,
+        'googleid',
+        DbUserBook,
+        'book_id',
+    ),
+    (
+        'games',
+        '''SELECT v.igdb AS natural_key, g.g_created
+           FROM g_user_videogames g JOIN videogames v ON v.id = g.videogames_id
+           WHERE g.user_id = :uid''',
+        DbVideoGame,
+        'igdb',
+        DbUserVideoGame,
+        'game_id',
+    ),
+)
+
+EPISODE_SQL = '''
+    SELECT e.tvmaze AS episode_tvmaze,
+           COALESCE(g.g_first, g.g_created) AS watched_source
+    FROM g_user_tvepisodes g
+    JOIN tvepisodes e ON e.id = g.tvepisode_id
+    WHERE g.user_id = :uid AND g.watched = 1
+'''
+
+
+def _resolve_users(db, conn, email):
+    user = db.query(DbUser).filter(DbUser.email == email).first()
+    if user is None:
+        sys.exit(f'No phoenix user with email {email}')
+    orion_uid = conn.execute(
+        text('SELECT id FROM users WHERE email = :email'), {'email': email}
+    ).scalar()
+    if orion_uid is None:
+        sys.exit(f'No orion user with email {email}')
+    return user, orion_uid
+
+
+def _backfill_episodes(db, conn, user, orion_uid) -> None:
+    rows = conn.execute(text(EPISODE_SQL), {'uid': orion_uid}).mappings().all()
+    # One pass: map tvmaze episode id -> phoenix tracker, then fill.
+    episode_by_tvmaze = {
+        tvmaze: (pk, watched_at)
+        for tvmaze, pk, watched_at in (
+            db.query(DbTVEpisode.tvmaze, DbUserTVEpisode.pk, DbUserTVEpisode.watched_at)
+            .join(DbUserTVEpisode, DbUserTVEpisode.episode_id == DbTVEpisode.pk)
+            .filter(DbUserTVEpisode.user_id == user.pk, DbTVEpisode.tvmaze.isnot(None))
+            .all()
+        )
+    }
+    filled = skipped = unmatched = 0
+    for row in rows:
+        target = episode_by_tvmaze.get(row['episode_tvmaze'])
+        if target is None or row['watched_source'] is None:
+            unmatched += 1
+            continue
+        pk, existing = target
+        if existing is not None:
+            skipped += 1
+            continue
+        db.query(DbUserTVEpisode).filter(DbUserTVEpisode.pk == pk).update(
+            {
+                DbUserTVEpisode.watched_at: row['watched_source'],
+                # Pin updated_at to itself: Column(onupdate=...) fires on ANY
+                # SQLAlchemy UPDATE unless the column is explicitly set, and a
+                # backfill must never re-date rows in the Activity feed.
+                DbUserTVEpisode.updated_at: DbUserTVEpisode.updated_at,
+            },
+            synchronize_session=False,
+        )
+        filled += 1
+    print(
+        f'{"episodes":10} filled={filled:6} skipped={skipped:6} unmatched={unmatched:6}'
+    )
+
+
+def _backfill_created_at(  # pylint: disable=too-many-locals
+    db, conn, user, orion_uid
+) -> None:
+    for label, sql, catalog, key_col, tracker, fk_col in TRACKER_DOMAINS:
+        rows = conn.execute(text(sql), {'uid': orion_uid}).mappings().all()
+        fixed = same = unmatched = 0
+        for row in rows:
+            key = row['natural_key']
+            if key is None or row['g_created'] is None:
+                unmatched += 1
+                continue
+            item = (
+                db.query(catalog)
+                .filter(getattr(catalog, key_col) == str(key).strip())
+                .first()
+            )
+            t = (
+                item
+                and db.query(tracker)
+                .filter(
+                    tracker.user_id == user.pk,
+                    getattr(tracker, fk_col) == item.pk,
+                )
+                .first()
+            )
+            if not t:
+                unmatched += 1
+                continue
+            if t.created_at == row['g_created']:
+                same += 1
+                continue
+            # Bulk update on purpose: attribute assignment would fire the
+            # base model's onupdate and re-date updated_at across thousands
+            # of rows, making everything look freshly edited in Activity.
+            db.query(tracker).filter(tracker.pk == t.pk).update(
+                {
+                    tracker.created_at: row['g_created'],
+                    # Same onupdate pin as the episode fill above.
+                    tracker.updated_at: tracker.updated_at,
+                },
+                synchronize_session=False,
+            )
+            fixed += 1
+        print(f'{label:10} fixed={fixed:7} same={same:7} unmatched={unmatched:6}')
+
+
+def run(dry_run: bool, email: str) -> None:
+    """Execute the backfill (or report what it would do)."""
+    orion_url = os.environ.get('ORION_MYSQL_URL')
+    if not orion_url:
+        sys.exit('ORION_MYSQL_URL is required (throwaway MySQL with the dump)')
+
+    orion = create_engine(orion_url)
+    db = SessionLocal()
+    try:
+        with orion.connect() as conn:
+            user, orion_uid = _resolve_users(db, conn, email)
+            print('--- episode watched_at ---')
+            _backfill_episodes(db, conn, user, orion_uid)
+            print('--- tracker created_at ---')
+            _backfill_created_at(db, conn, user, orion_uid)
+        if dry_run:
+            db.rollback()
+            print('\n(dry run - no changes were committed)')
+        else:
+            db.commit()
+            print('\ncommitted')
+    finally:
+        db.close()
+
+
+def main() -> None:
+    """CLI entrypoint."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--dry-run', action='store_true')
+    parser.add_argument('--email', default=DEFAULT_EMAIL)
+    args = parser.parse_args()
+    run(dry_run=args.dry_run, email=args.email)
+
+
+if __name__ == '__main__':
+    main()

--- a/app/router/v1/router_activity.py
+++ b/app/router/v1/router_activity.py
@@ -11,6 +11,7 @@ import random
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
 
 from app.db.database import get_db
@@ -111,7 +112,9 @@ def _episode_activity(db: Session, user_pk: int) -> List[ActivityItem]:
         # Episode marks dwarf every other domain (tens of thousands once a
         # library is imported) and occurred_at is updated_at here, so only the
         # newest MAX_FEED can survive the merged sort — bound it in SQL.
-        .order_by(DbUserTVEpisode.updated_at.desc())
+        .order_by(
+            func.coalesce(DbUserTVEpisode.watched_at, DbUserTVEpisode.updated_at).desc()
+        )
         .limit(MAX_FEED)
         .all()
     )
@@ -130,7 +133,7 @@ def _episode_activity(db: Session, user_pk: int) -> List[ActivityItem]:
                 subtitle=f'{label} - {ep.title}' if label else ep.title,
                 entity_id=show.id,
                 poster_url=show.poster_url,
-                occurred_at=row.updated_at,
+                occurred_at=row.watched_at or row.updated_at,
             )
         )
     return items

--- a/app/router/v1/router_tv.py
+++ b/app/router/v1/router_tv.py
@@ -728,10 +728,14 @@ def mark_episode_watched(
         .first()
     )
     if tracker is None:
-        tracker = DbUserTVEpisode(user_id=user_pk, episode_id=episode.pk, watched=1)
+        tracker = DbUserTVEpisode(
+            user_id=user_pk, episode_id=episode.pk, watched=1, watched_at=utc_now()
+        )
         db.add(tracker)
     else:
         tracker.watched = 1
+        if tracker.watched_at is None:
+            tracker.watched_at = utc_now()
     db.commit()
     db.refresh(tracker)
     return tracker
@@ -775,9 +779,18 @@ def mark_all_episodes_watched(
     for ep in episodes:
         tracker = existing_by_episode.get(ep.pk)
         if tracker is None:
-            db.add(DbUserTVEpisode(user_id=user_pk, episode_id=ep.pk, watched=1))
+            db.add(
+                DbUserTVEpisode(
+                    user_id=user_pk,
+                    episode_id=ep.pk,
+                    watched=1,
+                    watched_at=utc_now(),
+                )
+            )
         else:
             tracker.watched = 1
+            if tracker.watched_at is None:
+                tracker.watched_at = utc_now()
     db.commit()
 
     return (

--- a/app/schemas/schemas_sandbox.py
+++ b/app/schemas/schemas_sandbox.py
@@ -328,6 +328,7 @@ class TVEpisodeResponse(TVEpisodeBase):
 
 class UserTVEpisodeBase(BaseModel):
     watched: Optional[int] = 0
+    watched_at: Optional[datetime] = None
 
 
 class UserTVEpisodeResponse(UserTVEpisodeBase):

--- a/tests/integration/router_watched_at_test.py
+++ b/tests/integration/router_watched_at_test.py
@@ -1,0 +1,48 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+from fastapi.testclient import TestClient
+
+
+def _auth(test_client: TestClient) -> dict:
+    return {'Authorization': f'Bearer {test_client.first_user.token}'}
+
+
+def _show_with_episode(test_client: TestClient):
+    admin = {'Authorization': f'Bearer {test_client.admin_user.token}'}
+    show_id = test_client.post(
+        '/v1/tv-shows', headers=admin, json={'title': 'Severance', 'imdb': 'tt11280740'}
+    ).json()['id']
+    episode_id = test_client.post(
+        f'/v1/tv-shows/{show_id}/episodes',
+        headers=admin,
+        json={'title': 'Good News About Hell', 'season': 1, 'season_number': 1},
+    ).json()['id']
+    return show_id, episode_id
+
+
+def test_marking_watched_stamps_watched_at(test_client: TestClient):
+    _, episode_id = _show_with_episode(test_client)
+    body = test_client.post(
+        f'/v1/users/me/episodes/{episode_id}', headers=_auth(test_client)
+    ).json()
+    assert body['watched'] == 1
+    assert body['watched_at'] is not None
+
+
+def test_remarking_preserves_original_watched_at(test_client: TestClient):
+    _, episode_id = _show_with_episode(test_client)
+    first = test_client.post(
+        f'/v1/users/me/episodes/{episode_id}', headers=_auth(test_client)
+    ).json()['watched_at']
+    second = test_client.post(
+        f'/v1/users/me/episodes/{episode_id}', headers=_auth(test_client)
+    ).json()['watched_at']
+    assert second == first
+
+
+def test_watch_all_stamps_watched_at(test_client: TestClient):
+    show_id, _ = _show_with_episode(test_client)
+    marks = test_client.post(
+        f'/v1/users/me/tv-shows/{show_id}/episodes/watch-all',
+        headers=_auth(test_client),
+    ).json()
+    assert marks and all(m['watched_at'] is not None for m in marks)


### PR DESCRIPTION
Closes #160 — the last of the orion timestamp recovery, and the data foundation for the timeline dashboard (aleonard.us-web#25).

- **`watched_at`** on `user_tv_episodes` (migration `a7c8d95e2f41`): stamped on mark and watch-all (re-marks preserve the original), exposed in responses.
- **Activity** episode entries now use `watched_at or updated_at`, and the SQL bound's `ORDER BY` switched to the matching `COALESCE` so the limit stays provably correct.
- **`backfill_orion_timestamps`**: episode watch dates keyed via TVMaze id (`COALESCE(g_first, g_created)`), tracker `created_at` corrected from `g_created` via the import's natural keys. Both bulk updates **pin `updated_at` to itself** — `Column(onupdate=...)` fires on any SQLAlchemy UPDATE unless the column is explicitly set, and a backfill must never re-date Activity entries.

## Rehearsed offline (fresh scratch DB + real dumps)
| | filled/fixed | skipped/same | unmatched |
|---|---|---|---|
| episodes | **12,735** | 0 | **0** |
| movies created_at | 1,163 | 178 | 0 |
| tv / books / games created_at | 251 / 211 / 176 | — | 0 |

Spot-checks byte-identical to MySQL; watched_at spans 2017-01-24 → 2026-07-13 across 1,208 distinct days (real history, not the import-time cluster); canary column identical before/after; re-run is a no-op.

3 new tests. Full suite **247 passed**; single head `a7c8d95e2f41`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)