### PR TITLE
Activity: semantic timestamps everywhere; updated_at is technical-only

### DIFF
--- a/app/router/v1/router_activity.py
+++ b/app/router/v1/router_activity.py
@@ -33,6 +33,20 @@ router = APIRouter(prefix='/v1', tags=['Activity'])
 MAX_FEED = 200
 
 
+def _tracker_occurred_at(tracker, action):
+    """
+    The semantic timestamp for a tracker's feed entry. updated_at is a
+    technical "row was touched" column — it is only ever a last-resort
+    fallback here, never the meaning (#141 follow-up, 2026-07-19).
+    """
+    if action == 'ranked':
+        return tracker.ranked_at or tracker.updated_at
+    if action == 'marked_done':
+        return getattr(tracker, 'completed_at', None) or tracker.updated_at
+    # watchlist_added: when the row was created is when it was added.
+    return tracker.created_at or tracker.updated_at
+
+
 # --- Activity Log ---
 def _movie_activity(db: Session, user_pk: int) -> List[ActivityItem]:
     trackers = (
@@ -59,11 +73,7 @@ def _movie_activity(db: Session, user_pk: int) -> List[ActivityItem]:
                 entity_id=t.movie.id,
                 poster_url=t.movie.poster_url,
                 rank=t.rank if action == 'ranked' else None,
-                occurred_at=(
-                    (t.ranked_at or t.updated_at)
-                    if action == 'ranked'
-                    else t.updated_at
-                ),
+                occurred_at=_tracker_occurred_at(t, action),
             )
         )
     return items
@@ -94,11 +104,7 @@ def _tv_show_activity(db: Session, user_pk: int) -> List[ActivityItem]:
                 entity_id=t.tv_show.id,
                 poster_url=t.tv_show.poster_url,
                 rank=t.rank if action == 'ranked' else None,
-                occurred_at=(
-                    (t.ranked_at or t.updated_at)
-                    if action == 'ranked'
-                    else t.updated_at
-                ),
+                occurred_at=_tracker_occurred_at(t, action),
             )
         )
     return items
@@ -165,11 +171,7 @@ def _game_activity(db: Session, user_pk: int) -> List[ActivityItem]:
                 entity_id=t.game.id,
                 poster_url=t.game.poster_url,
                 rank=t.rank if action == 'ranked' else None,
-                occurred_at=(
-                    (t.ranked_at or t.updated_at)
-                    if action == 'ranked'
-                    else t.updated_at
-                ),
+                occurred_at=_tracker_occurred_at(t, action),
             )
         )
     return items
@@ -200,11 +202,7 @@ def _book_activity(db: Session, user_pk: int) -> List[ActivityItem]:
                 entity_id=t.book.id,
                 poster_url=t.book.poster_url,
                 rank=t.rank if action == 'ranked' else None,
-                occurred_at=(
-                    (t.ranked_at or t.updated_at)
-                    if action == 'ranked'
-                    else t.updated_at
-                ),
+                occurred_at=_tracker_occurred_at(t, action),
             )
         )
     return items

--- a/tests/integration/router_ranked_at_test.py
+++ b/tests/integration/router_ranked_at_test.py
@@ -88,3 +88,30 @@ def test_leaving_rankings_clears_the_stamp(test_client: TestClient):
     feed = test_client.get('/v1/users/me/activity', headers=_auth(test_client)).json()
     entry = next(a for a in feed if a['title'] == 'Heat')
     assert entry['action'] == 'watchlist_added'
+
+
+def test_watchlist_entry_pinned_to_created_at(test_client: TestClient):
+    """
+    updated_at is technical, not semantic (#141 follow-up): editing notes on
+    a watchlist item must not re-date its 'watchlist_added' feed entry.
+    """
+    admin = {'Authorization': f'Bearer {test_client.admin_user.token}'}
+    movie_id = test_client.post(
+        '/v1/movies', headers=admin, json={'title': 'Sneakers', 'imdb': 'tt0105435'}
+    ).json()['id']
+    test_client.post(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(test_client),
+        json={'on_watchlist': True},
+    )
+    feed = test_client.get('/v1/users/me/activity', headers=_auth(test_client)).json()
+    before = next(a for a in feed if a['title'] == 'Sneakers')['occurred_at']
+
+    test_client.put(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(test_client),
+        json={'notes': 'note edit must not re-date the add'},
+    )
+    feed = test_client.get('/v1/users/me/activity', headers=_auth(test_client)).json()
+    after = next(a for a in feed if a['title'] == 'Sneakers')['occurred_at']
+    assert after == before


### PR DESCRIPTION
Follow-up to #141/#164, prompted by Adam's principle: *updated_at should reflect when the row was touched and have no bearing on the row's meaning.* Now true in code:

| action | occurred_at |
|---|---|
| ranked | `ranked_at` |
| marked_done | `completed_at` |
| watchlist_added | `created_at` (when the row was created **is** when it was added) |
| watched_episode | `watched_at` |

`updated_at` remains only as a last-resort NULL fallback — after the #159/#164 backfills those fallbacks are rarely reachable. New test pins the last exposed case: a notes edit on a *watchlist* item no longer re-dates its feed entry.

Full suite **248 passed**; pylint 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)