### PR TITLE
Replace dev-era root message with a druthers.io-branded one

### DIFF
--- a/app/run.py
+++ b/app/run.py
@@ -114,7 +114,7 @@ def index():
     """
     Index endpoint that returns a welcome message.
     """
-    return OutResponseBaseModel(message="Welcome to Adam's API folks!")
+    return OutResponseBaseModel(message='druthers.io API — your favorites, ranked.')
 
 
 @app.get('/favicon.ico', include_in_schema=False)

--- a/tests/integration/main_test.py
+++ b/tests/integration/main_test.py
@@ -23,7 +23,7 @@ def test_index():
     assert response_data['success'] is True
     assert isinstance(response_data['data'], list)
     assert len(response_data['data']) == 0
-    assert response_data['message'] == "Welcome to Adam's API folks!"
+    assert response_data['message'] == 'druthers.io API — your favorites, ranked.'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
"Welcome to Adam's API folks!" -> "druthers.io API — your favorites, ranked." Trivial, but it's the first thing anyone poking at the API sees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)