### PR TITLE
Add alembic to requirements/base.txt — fixes broken release-deploy migrations

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,6 +3,7 @@ uvicorn==0.51.0
 h11>=0.16.0 # Pinned to fix HTTP Request Smuggling vulnerability
 starlette>=1.3.1 # not directly required, pinned by Snyk to avoid a vulnerability
 SQLAlchemy==2.0.51
+alembic==1.18.5
 pydantic==2.13.4
 pydantic-settings==2.14.2
 pwdlib[argon2]


### PR DESCRIPTION
## Story
As the operator, I want the release-triggered deploy pipeline to actually run migrations, since it's been silently failing on every release and prod has only stayed in sync via manual out-of-band deploys.

## What was wrong
`Deploy to Cloud Run`'s "Run database migrations" step does `pip install -r requirements/base.txt` then `alembic upgrade head`. `alembic` was never listed in `requirements/base.txt` — confirmed missing at every release tag from v2.0.0 through v2.3.1 (`git show <tag>:requirements/base.txt`). Every one of those 5 releases failed at that step with `alembic: command not found` (exit 127). The `Deploy to Cloud Run` step that follows never ran on any of them.

Prod is not actually broken — schema is at head (`a7c8d95e2f41`) and the API works — because `gcp/30-deploy.sh` (manual Docker build + `gcloud run deploy`) has been used as a side-channel workaround each time, which happens to run migrations via a locally-built venv that already has `alembic` on the path for unrelated reasons.

## Fix
One line: `alembic==1.18.5` in `requirements/base.txt`, matching the already-pinned version alembic resolves to via the local dev venv (`requirements/dev.txt` → `-r base.txt`).

## Verification
- [x] `git show v2.3.1:requirements/base.txt` confirms alembic was absent at every failed release
- [x] Local venv's `alembic upgrade head` already works against prod (heads at `a7c8d95e2f41`, matches Neon) — this only fixes the CI path, not prod schema state
- [ ] Next release tag after this merges should show `Deploy to Cloud Run` green end-to-end for the first time

## Context
Found while investigating "fix all the alembic errors and get the pipelines green." Discovered mid-investigation that this exact fix had already been made locally on this machine in an earlier, uncommitted session — never pushed.