### PR TITLE
Bound schedule + activity queries in SQL

### DIFF
--- a/alembic/versions/bdf47c1723a4_tracker_fk_indexes.py
+++ b/alembic/versions/bdf47c1723a4_tracker_fk_indexes.py
@@ -1,0 +1,49 @@
+"""tracker fk indexes
+
+Postgres does not auto-index FK columns (#161). Every per-user query on the
+five tracker tables was seq-scanning: invisible at 1 user / ~14k rows, not at
+10x. Composite (user_id, <fk>) matches the real access pattern (a user's
+tracker row for one catalog item) and covers user_id-only lookups too, since
+it's the leading column.
+
+Revision ID: bdf47c1723a4
+Revises: a7c8d95e2f41
+Create Date: 2026-07-20 07:59:28.807850
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'bdf47c1723a4'
+down_revision: Union[str, Sequence[str], None] = 'a7c8d95e2f41'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# (table, fk_column) — composite index is (user_id, fk_column)
+TRACKER_FKS = (
+    ('user_movies', 'movie_id'),
+    ('user_tv_shows', 'tv_show_id'),
+    ('user_tv_episodes', 'episode_id'),
+    ('user_books', 'book_id'),
+    ('user_video_games', 'game_id'),
+)
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    for table_name, fk_column in TRACKER_FKS:
+        op.create_index(
+            f'ix_{table_name}_user_id_{fk_column}',
+            table_name,
+            ['user_id', fk_column],
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    for table_name, fk_column in TRACKER_FKS:
+        op.drop_index(f'ix_{table_name}_user_id_{fk_column}', table_name=table_name)

--- a/app/router/v1/router_activity.py
+++ b/app/router/v1/router_activity.py
@@ -11,7 +11,7 @@ import random
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import func
+from sqlalchemy import case, func
 from sqlalchemy.orm import Session, joinedload
 
 from app.db.database import get_db
@@ -47,13 +47,42 @@ def _tracker_occurred_at(tracker, action):
     return tracker.created_at or tracker.updated_at
 
 
+def _bounded_tracker_rows(db: Session, model, user_pk: int, *loader_options):
+    """
+    Rows on watchlist or rankings, newest-by-_tracker_occurred_at first,
+    bounded to MAX_FEED in SQL — mirrors _tracker_occurred_at's branching so
+    the SQL order matches the Python-computed occurred_at exactly. Movies/TV
+    shows/games/books share these column names (on_rankings, rank, ranked_at,
+    completed_at, created_at, updated_at).
+    """
+    occurred_at = case(
+        (
+            (model.on_rankings.is_(True)) & (model.rank.isnot(None)),
+            func.coalesce(model.ranked_at, model.updated_at),
+        ),
+        (
+            model.on_rankings.is_(True),
+            func.coalesce(model.completed_at, model.updated_at),
+        ),
+        else_=func.coalesce(model.created_at, model.updated_at),
+    )
+    return (
+        db.query(model)
+        .options(*loader_options)
+        .filter(
+            model.user_id == user_pk,
+            (model.on_rankings.is_(True)) | (model.on_watchlist.is_(True)),
+        )
+        .order_by(occurred_at.desc())
+        .limit(MAX_FEED)
+        .all()
+    )
+
+
 # --- Activity Log ---
 def _movie_activity(db: Session, user_pk: int) -> List[ActivityItem]:
-    trackers = (
-        db.query(DbUserMovie)
-        .options(joinedload(DbUserMovie.movie))
-        .filter(DbUserMovie.user_id == user_pk)
-        .all()
+    trackers = _bounded_tracker_rows(
+        db, DbUserMovie, user_pk, joinedload(DbUserMovie.movie)
     )
     items = []
     for t in trackers:
@@ -80,11 +109,8 @@ def _movie_activity(db: Session, user_pk: int) -> List[ActivityItem]:
 
 
 def _tv_show_activity(db: Session, user_pk: int) -> List[ActivityItem]:
-    trackers = (
-        db.query(DbUserTVShow)
-        .options(joinedload(DbUserTVShow.tv_show))
-        .filter(DbUserTVShow.user_id == user_pk)
-        .all()
+    trackers = _bounded_tracker_rows(
+        db, DbUserTVShow, user_pk, joinedload(DbUserTVShow.tv_show)
     )
     items = []
     for t in trackers:
@@ -146,11 +172,8 @@ def _episode_activity(db: Session, user_pk: int) -> List[ActivityItem]:
 
 
 def _game_activity(db: Session, user_pk: int) -> List[ActivityItem]:
-    trackers = (
-        db.query(DbUserVideoGame)
-        .options(joinedload(DbUserVideoGame.game))
-        .filter(DbUserVideoGame.user_id == user_pk)
-        .all()
+    trackers = _bounded_tracker_rows(
+        db, DbUserVideoGame, user_pk, joinedload(DbUserVideoGame.game)
     )
     items = []
     for t in trackers:
@@ -178,11 +201,8 @@ def _game_activity(db: Session, user_pk: int) -> List[ActivityItem]:
 
 
 def _book_activity(db: Session, user_pk: int) -> List[ActivityItem]:
-    trackers = (
-        db.query(DbUserBook)
-        .options(joinedload(DbUserBook.book))
-        .filter(DbUserBook.user_id == user_pk)
-        .all()
+    trackers = _bounded_tracker_rows(
+        db, DbUserBook, user_pk, joinedload(DbUserBook.book)
     )
     items = []
     for t in trackers:
@@ -209,10 +229,20 @@ def _book_activity(db: Session, user_pk: int) -> List[ActivityItem]:
 
 
 def _country_activity(db: Session, user_pk: int) -> List[ActivityItem]:
+    # Countries don't use _tracker_occurred_at (occurred_at is always
+    # first_visited/updated_at here, regardless of action) — bound separately.
     trackers = (
         db.query(DbUserCountry)
         .options(joinedload(DbUserCountry.country))
-        .filter(DbUserCountry.user_id == user_pk)
+        .filter(
+            DbUserCountry.user_id == user_pk,
+            (DbUserCountry.on_rankings.is_(True))
+            | (DbUserCountry.on_watchlist.is_(True)),
+        )
+        .order_by(
+            func.coalesce(DbUserCountry.first_visited, DbUserCountry.updated_at).desc()
+        )
+        .limit(MAX_FEED)
         .all()
     )
     items = []

--- a/app/router/v1/router_tv.py
+++ b/app/router/v1/router_tv.py
@@ -424,26 +424,35 @@ def get_schedule(  # pylint: disable=too-many-locals
     upcoming: List[ScheduleEpisodeItem] = []
     catch_up: List[ScheduleEpisodeItem] = []
     if active_show_pks:
-        watched_episode_pks = {
-            row.episode_id
-            for row in db.query(DbUserTVEpisode.episode_id).filter(
-                DbUserTVEpisode.user_id == user_pk, DbUserTVEpisode.watched == 1
-            )
-        }
         shows_by_pk = {
             s.pk: s for s in db.query(DbTVShow).filter(DbTVShow.pk.in_(active_show_pks))
         }
+        # catch_up only needs airdate <= now; upcoming only needs <= window_end
+        # (>= window_start is checked in Python below). window_end >= now
+        # always, so bounding the fetch to airdate <= window_end covers both.
+        # The unwatched anti-join is pushed into SQL too, instead of loading
+        # every episode of every active show and filtering in Python — row
+        # count no longer scales with the full episode catalog.
+        watched_exists = (
+            db.query(DbUserTVEpisode.pk)
+            .filter(
+                DbUserTVEpisode.episode_id == DbTVEpisode.pk,
+                DbUserTVEpisode.user_id == user_pk,
+                DbUserTVEpisode.watched == 1,
+            )
+            .exists()
+        )
         episodes = (
             db.query(DbTVEpisode)
             .filter(
                 DbTVEpisode.tv_show_id.in_(active_show_pks),
                 DbTVEpisode.airdate.isnot(None),
+                DbTVEpisode.airdate <= window_end,
+                ~watched_exists,
             )
             .all()
         )
         for ep in episodes:
-            if ep.pk in watched_episode_pks:
-                continue
             show = shows_by_pk.get(ep.tv_show_id)
             if show is None:
                 continue


### PR DESCRIPTION
Closes #162. See commit message for the full breakdown (schedule anti-join + window bound, activity MAX_FEED-in-SQL via a shared CASE expression mirroring _tracker_occurred_at). 248 tests pass locally.