### PR TITLE
Search results carry on_watchlist/on_rankings/rank (api half of web#31)

### DIFF
--- a/alembic/versions/bdf47c1723a4_tracker_fk_indexes.py
+++ b/alembic/versions/bdf47c1723a4_tracker_fk_indexes.py
@@ -1,0 +1,49 @@
+"""tracker fk indexes
+
+Postgres does not auto-index FK columns (#161). Every per-user query on the
+five tracker tables was seq-scanning: invisible at 1 user / ~14k rows, not at
+10x. Composite (user_id, <fk>) matches the real access pattern (a user's
+tracker row for one catalog item) and covers user_id-only lookups too, since
+it's the leading column.
+
+Revision ID: bdf47c1723a4
+Revises: a7c8d95e2f41
+Create Date: 2026-07-20 07:59:28.807850
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'bdf47c1723a4'
+down_revision: Union[str, Sequence[str], None] = 'a7c8d95e2f41'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# (table, fk_column) — composite index is (user_id, fk_column)
+TRACKER_FKS = (
+    ('user_movies', 'movie_id'),
+    ('user_tv_shows', 'tv_show_id'),
+    ('user_tv_episodes', 'episode_id'),
+    ('user_books', 'book_id'),
+    ('user_video_games', 'game_id'),
+)
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    for table_name, fk_column in TRACKER_FKS:
+        op.create_index(
+            f'ix_{table_name}_user_id_{fk_column}',
+            table_name,
+            ['user_id', fk_column],
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    for table_name, fk_column in TRACKER_FKS:
+        op.drop_index(f'ix_{table_name}_user_id_{fk_column}', table_name=table_name)

--- a/app/router/v1/router_activity.py
+++ b/app/router/v1/router_activity.py
@@ -11,7 +11,7 @@ import random
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import func
+from sqlalchemy import case, func
 from sqlalchemy.orm import Session, joinedload
 
 from app.db.database import get_db
@@ -47,13 +47,42 @@ def _tracker_occurred_at(tracker, action):
     return tracker.created_at or tracker.updated_at
 
 
+def _bounded_tracker_rows(db: Session, model, user_pk: int, *loader_options):
+    """
+    Rows on watchlist or rankings, newest-by-_tracker_occurred_at first,
+    bounded to MAX_FEED in SQL — mirrors _tracker_occurred_at's branching so
+    the SQL order matches the Python-computed occurred_at exactly. Movies/TV
+    shows/games/books share these column names (on_rankings, rank, ranked_at,
+    completed_at, created_at, updated_at).
+    """
+    occurred_at = case(
+        (
+            (model.on_rankings.is_(True)) & (model.rank.isnot(None)),
+            func.coalesce(model.ranked_at, model.updated_at),
+        ),
+        (
+            model.on_rankings.is_(True),
+            func.coalesce(model.completed_at, model.updated_at),
+        ),
+        else_=func.coalesce(model.created_at, model.updated_at),
+    )
+    return (
+        db.query(model)
+        .options(*loader_options)
+        .filter(
+            model.user_id == user_pk,
+            (model.on_rankings.is_(True)) | (model.on_watchlist.is_(True)),
+        )
+        .order_by(occurred_at.desc())
+        .limit(MAX_FEED)
+        .all()
+    )
+
+
 # --- Activity Log ---
 def _movie_activity(db: Session, user_pk: int) -> List[ActivityItem]:
-    trackers = (
-        db.query(DbUserMovie)
-        .options(joinedload(DbUserMovie.movie))
-        .filter(DbUserMovie.user_id == user_pk)
-        .all()
+    trackers = _bounded_tracker_rows(
+        db, DbUserMovie, user_pk, joinedload(DbUserMovie.movie)
     )
     items = []
     for t in trackers:
@@ -80,11 +109,8 @@ def _movie_activity(db: Session, user_pk: int) -> List[ActivityItem]:
 
 
 def _tv_show_activity(db: Session, user_pk: int) -> List[ActivityItem]:
-    trackers = (
-        db.query(DbUserTVShow)
-        .options(joinedload(DbUserTVShow.tv_show))
-        .filter(DbUserTVShow.user_id == user_pk)
-        .all()
+    trackers = _bounded_tracker_rows(
+        db, DbUserTVShow, user_pk, joinedload(DbUserTVShow.tv_show)
     )
     items = []
     for t in trackers:
@@ -146,11 +172,8 @@ def _episode_activity(db: Session, user_pk: int) -> List[ActivityItem]:
 
 
 def _game_activity(db: Session, user_pk: int) -> List[ActivityItem]:
-    trackers = (
-        db.query(DbUserVideoGame)
-        .options(joinedload(DbUserVideoGame.game))
-        .filter(DbUserVideoGame.user_id == user_pk)
-        .all()
+    trackers = _bounded_tracker_rows(
+        db, DbUserVideoGame, user_pk, joinedload(DbUserVideoGame.game)
     )
     items = []
     for t in trackers:
@@ -178,11 +201,8 @@ def _game_activity(db: Session, user_pk: int) -> List[ActivityItem]:
 
 
 def _book_activity(db: Session, user_pk: int) -> List[ActivityItem]:
-    trackers = (
-        db.query(DbUserBook)
-        .options(joinedload(DbUserBook.book))
-        .filter(DbUserBook.user_id == user_pk)
-        .all()
+    trackers = _bounded_tracker_rows(
+        db, DbUserBook, user_pk, joinedload(DbUserBook.book)
     )
     items = []
     for t in trackers:
@@ -209,10 +229,20 @@ def _book_activity(db: Session, user_pk: int) -> List[ActivityItem]:
 
 
 def _country_activity(db: Session, user_pk: int) -> List[ActivityItem]:
+    # Countries don't use _tracker_occurred_at (occurred_at is always
+    # first_visited/updated_at here, regardless of action) — bound separately.
     trackers = (
         db.query(DbUserCountry)
         .options(joinedload(DbUserCountry.country))
-        .filter(DbUserCountry.user_id == user_pk)
+        .filter(
+            DbUserCountry.user_id == user_pk,
+            (DbUserCountry.on_rankings.is_(True))
+            | (DbUserCountry.on_watchlist.is_(True)),
+        )
+        .order_by(
+            func.coalesce(DbUserCountry.first_visited, DbUserCountry.updated_at).desc()
+        )
+        .limit(MAX_FEED)
         .all()
     )
     items = []

--- a/app/router/v1/router_books.py
+++ b/app/router/v1/router_books.py
@@ -40,6 +40,7 @@ from app.services.book_search import (
     search_books as openlibrary_search_books,
 )
 from app.services.search_correction import correct_query
+from app.services.tracked_status import attach_tracked_status
 
 router = APIRouter(prefix='/v1', tags=['Books'])
 
@@ -57,15 +58,15 @@ def get_all_books(db: Session = Depends(get_db)):
 )
 def search_books_endpoint(
     q: str,
+    db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
 ):
-    del current_user  # any authenticated user may search
     results = openlibrary_search_books(q)
     if not results:
         corrected = correct_query(q)
         if corrected:
             results = openlibrary_search_books(corrected)
-    return results
+    return attach_tracked_status(db, current_user[0].pk, results, 'books')
 
 
 @router.post(

--- a/app/router/v1/router_games.py
+++ b/app/router/v1/router_games.py
@@ -41,6 +41,7 @@ from app.services.game_search import (
     search_games as igdb_search_games,
 )
 from app.services.search_correction import correct_query
+from app.services.tracked_status import attach_tracked_status
 
 router = APIRouter(prefix='/v1', tags=['Video Games'])
 
@@ -58,15 +59,15 @@ def get_all_games(db: Session = Depends(get_db)):
 )
 def search_games_endpoint(
     q: str,
+    db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
 ):
-    del current_user  # any authenticated user may search
     results = igdb_search_games(q)
     if not results:
         corrected = correct_query(q)
         if corrected:
             results = igdb_search_games(corrected)
-    return results
+    return attach_tracked_status(db, current_user[0].pk, results, 'games')
 
 
 @router.post(

--- a/app/router/v1/router_movies.py
+++ b/app/router/v1/router_movies.py
@@ -35,6 +35,7 @@ from app.services.movie_search import (
     search_movies as omdb_search_movies,
 )
 from app.services.search_correction import correct_query
+from app.services.tracked_status import attach_tracked_status
 
 router = APIRouter(prefix='/v1', tags=['Movies'])
 
@@ -52,15 +53,15 @@ def get_all_movies(db: Session = Depends(get_db)):
 )
 def search_movies_endpoint(
     q: str,
+    db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
 ):
-    del current_user  # any authenticated user may search
     results = omdb_search_movies(q)
     if not results:
         corrected = correct_query(q)
         if corrected:
             results = omdb_search_movies(corrected)
-    return results
+    return attach_tracked_status(db, current_user[0].pk, results, 'movies')
 
 
 @router.post(

--- a/app/router/v1/router_search.py
+++ b/app/router/v1/router_search.py
@@ -12,14 +12,17 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Callable, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
 
 from app.auth.oauth2 import get_current_user
+from app.db.database import get_db
 from app.schemas.schemas_sandbox import GlobalSearchResponse
 from app.services.rate_limit import search_rate_limit
 from app.services.book_search import search_books
 from app.services.game_search import search_games
 from app.services.movie_search import search_movies
 from app.services.search_correction import correct_query
+from app.services.tracked_status import attach_tracked_status
 from app.services.tv_search import search_tv_shows
 
 router = APIRouter(prefix='/v1', tags=['Search'])
@@ -59,9 +62,9 @@ def _fan_out(q: str, only: Optional[List[str]] = None) -> Dict[str, List[dict]]:
 )
 def global_search(
     q: str,
+    db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
 ):
-    del current_user  # any authenticated user may search
     results = _fan_out(q)
     corrected = None
     # Some providers fuzzy-match and some don't, so retry only the domains
@@ -74,4 +77,7 @@ def global_search(
             if any(retried.values()):
                 corrected = respelled
                 results.update(retried)
+    user_pk = current_user[0].pk
+    for domain, hits in results.items():
+        attach_tracked_status(db, user_pk, hits, domain)
     return GlobalSearchResponse(query=q, corrected=corrected, **results)

--- a/app/router/v1/router_tv.py
+++ b/app/router/v1/router_tv.py
@@ -424,26 +424,35 @@ def get_schedule(  # pylint: disable=too-many-locals
     upcoming: List[ScheduleEpisodeItem] = []
     catch_up: List[ScheduleEpisodeItem] = []
     if active_show_pks:
-        watched_episode_pks = {
-            row.episode_id
-            for row in db.query(DbUserTVEpisode.episode_id).filter(
-                DbUserTVEpisode.user_id == user_pk, DbUserTVEpisode.watched == 1
-            )
-        }
         shows_by_pk = {
             s.pk: s for s in db.query(DbTVShow).filter(DbTVShow.pk.in_(active_show_pks))
         }
+        # catch_up only needs airdate <= now; upcoming only needs <= window_end
+        # (>= window_start is checked in Python below). window_end >= now
+        # always, so bounding the fetch to airdate <= window_end covers both.
+        # The unwatched anti-join is pushed into SQL too, instead of loading
+        # every episode of every active show and filtering in Python — row
+        # count no longer scales with the full episode catalog.
+        watched_exists = (
+            db.query(DbUserTVEpisode.pk)
+            .filter(
+                DbUserTVEpisode.episode_id == DbTVEpisode.pk,
+                DbUserTVEpisode.user_id == user_pk,
+                DbUserTVEpisode.watched == 1,
+            )
+            .exists()
+        )
         episodes = (
             db.query(DbTVEpisode)
             .filter(
                 DbTVEpisode.tv_show_id.in_(active_show_pks),
                 DbTVEpisode.airdate.isnot(None),
+                DbTVEpisode.airdate <= window_end,
+                ~watched_exists,
             )
             .all()
         )
         for ep in episodes:
-            if ep.pk in watched_episode_pks:
-                continue
             show = shows_by_pk.get(ep.tv_show_id)
             if show is None:
                 continue

--- a/app/router/v1/router_tv.py
+++ b/app/router/v1/router_tv.py
@@ -50,6 +50,7 @@ from app.services.tv_search import (
     sync_episodes,
 )
 from app.services.search_correction import correct_query
+from app.services.tracked_status import attach_tracked_status
 
 router = APIRouter(prefix='/v1', tags=['TV'])
 
@@ -67,15 +68,15 @@ def get_all_tv_shows(db: Session = Depends(get_db)):
 )
 def search_tv_shows_endpoint(
     q: str,
+    db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
 ):
-    del current_user  # any authenticated user may search
     results = tvmaze_search_shows(q)
     if not results:
         corrected = correct_query(q)
         if corrected:
             results = tvmaze_search_shows(corrected)
-    return results
+    return attach_tracked_status(db, current_user[0].pk, results, 'tv_shows')
 
 
 @router.post(

--- a/app/schemas/schemas_sandbox.py
+++ b/app/schemas/schemas_sandbox.py
@@ -143,6 +143,9 @@ class MovieSearchResult(BaseModel):
     year: Optional[str] = None
     poster_url: Optional[str] = None
     type: Optional[str] = None
+    on_watchlist: bool = False
+    on_rankings: bool = False
+    rank: Optional[int] = None
 
 
 class UserMovieBase(BaseModel):
@@ -251,6 +254,9 @@ class TVShowSearchResult(BaseModel):
     status: Optional[str] = None
     network: Optional[str] = None
     poster_url: Optional[str] = None
+    on_watchlist: bool = False
+    on_rankings: bool = False
+    rank: Optional[int] = None
 
 
 class UserTVShowBase(BaseModel):
@@ -433,6 +439,9 @@ class GameSearchResult(BaseModel):
     year: Optional[str] = None
     platforms: Optional[str] = None
     poster_url: Optional[str] = None
+    on_watchlist: bool = False
+    on_rankings: bool = False
+    rank: Optional[int] = None
 
 
 class UserVideoGameBase(BaseModel):
@@ -529,6 +538,9 @@ class BookSearchResult(BaseModel):
     authors: Optional[str] = None
     year: Optional[str] = None
     poster_url: Optional[str] = None
+    on_watchlist: bool = False
+    on_rankings: bool = False
+    rank: Optional[int] = None
 
 
 class UserBookBase(BaseModel):

--- a/app/services/tracked_status.py
+++ b/app/services/tracked_status.py
@@ -1,0 +1,85 @@
+"""
+Attaches on_watchlist/on_rankings/rank to raw search-provider results by
+joining the current user's tracker row via the domain's external catalog id
+(imdb/tvmaze/igdb/isbn) — so search can badge items the user already tracks
+instead of only offering "add" (web#31).
+"""
+
+from typing import List
+
+from sqlalchemy.orm import Session
+
+from app.db.models_sandbox import (
+    DbBook,
+    DbMovie,
+    DbTVShow,
+    DbUserBook,
+    DbUserMovie,
+    DbUserTVShow,
+    DbUserVideoGame,
+    DbVideoGame,
+)
+
+# domain -> (catalog model, catalog's external-id column, tracker model, tracker's FK column)
+_DOMAIN_CONFIG = {
+    'movies': (DbMovie, 'imdb', DbUserMovie, 'movie_id'),
+    'tv_shows': (DbTVShow, 'tvmaze', DbUserTVShow, 'tv_show_id'),
+    'games': (DbVideoGame, 'igdb', DbUserVideoGame, 'game_id'),
+    'books': (DbBook, 'isbn', DbUserBook, 'book_id'),
+}
+
+
+def _catalog_pk_by_external_id(
+    db: Session, catalog_model, external_key: str, ids: list
+):
+    rows = (
+        db.query(catalog_model)
+        .filter(getattr(catalog_model, external_key).in_(ids))
+        .all()
+    )
+    return {getattr(row, external_key): row.pk for row in rows}
+
+
+def _tracker_by_catalog_pk(
+    db: Session, tracker_model, fk_column: str, user_pk: int, catalog_pks: list
+):
+    if not catalog_pks:
+        return {}
+    rows = (
+        db.query(tracker_model)
+        .filter(
+            tracker_model.user_id == user_pk,
+            getattr(tracker_model, fk_column).in_(catalog_pks),
+        )
+        .all()
+    )
+    return {getattr(t, fk_column): t for t in rows}
+
+
+def attach_tracked_status(
+    db: Session, user_pk: int, results: List[dict], domain: str
+) -> List[dict]:
+    """
+    Mutates each result dict in place, adding on_watchlist/on_rankings/rank
+    for items the user already tracks. Results without the domain's external
+    id (e.g. a book missing an ISBN) are left untracked — there's nothing to
+    join on. Safe to call with an empty results list.
+    """
+    catalog_model, external_key, tracker_model, fk_column = _DOMAIN_CONFIG[domain]
+    ids = [r[external_key] for r in results if r.get(external_key)]
+    if not ids:
+        return results
+
+    catalog_pk_by_id = _catalog_pk_by_external_id(db, catalog_model, external_key, ids)
+    tracker_by_pk = _tracker_by_catalog_pk(
+        db, tracker_model, fk_column, user_pk, list(catalog_pk_by_id.values())
+    )
+
+    for r in results:
+        catalog_pk = catalog_pk_by_id.get(r.get(external_key))
+        tracker = tracker_by_pk.get(catalog_pk) if catalog_pk else None
+        r['on_watchlist'] = bool(tracker.on_watchlist) if tracker else False
+        r['on_rankings'] = bool(tracker.on_rankings) if tracker else False
+        r['rank'] = tracker.rank if tracker and tracker.on_rankings else None
+
+    return results

--- a/tests/integration/router_movies_test.py
+++ b/tests/integration/router_movies_test.py
@@ -331,3 +331,43 @@ def test_search_no_retry_when_spelling_correct(mock_search, test_client: TestCli
     assert response.status_code == 200
     assert response.json() == []
     assert mock_search.call_count == 1
+
+
+@patch('app.router.v1.router_movies.omdb_search_movies')
+def test_search_badges_already_ranked_result(mock_search, test_client: TestClient):
+    """web#31: a search hit matching a movie the user has ranked carries
+    on_rankings + rank; an untracked hit in the same response stays false/None."""
+    admin_headers = {'Authorization': f"Bearer {test_client.admin_user.token}"}
+    create_resp = test_client.post(
+        '/v1/movies',
+        headers=admin_headers,
+        json={'title': 'Inception', 'imdb': 'tt1375666'},
+    )
+    movie_id = create_resp.json()['id']
+
+    user_headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
+    mark_resp = test_client.post(
+        f"/v1/users/me/movies/{movie_id}",
+        headers=user_headers,
+        json={'on_rankings': True},
+    )
+    assert mark_resp.status_code == 201
+    rank_resp = test_client.put(
+        f"/v1/users/me/movies/{movie_id}/rank",
+        headers=user_headers,
+        json={'position': 1},
+    )
+    assert rank_resp.status_code == 200
+
+    mock_search.return_value = [
+        {'imdb': 'tt1375666', 'title': 'Inception', 'year': '2010'},
+        {'imdb': 'tt0107290', 'title': 'Jurassic Park', 'year': '1993'},
+    ]
+    response = test_client.get('/v1/movies/search?q=inception', headers=user_headers)
+    assert response.status_code == 200
+    data = {r['imdb']: r for r in response.json()}
+    assert data['tt1375666']['on_rankings'] is True
+    assert data['tt1375666']['rank'] == 1
+    assert data['tt0107290']['on_rankings'] is False
+    assert data['tt0107290']['on_watchlist'] is False
+    assert data['tt0107290']['rank'] is None


### PR DESCRIPTION
API half of aleonard.us-web#31. All five search surfaces (movies/tv/games/books + global cross-domain search) join the current user's tracker row by external id and attach `on_watchlist`/`on_rankings`/`rank` to each result, via a shared `attach_tracked_status` helper.

New integration test confirms a ranked movie's search hit carries the real rank; an untracked hit in the same response stays false/None.

Web-side badge UI is the follow-up PR on aleonard.us-web.