### PR TITLE
Move release workflows off deprecated Node 20

### DIFF
--- a/.github/workflows/deploy_cloud_run.yaml
+++ b/.github/workflows/deploy_cloud_run.yaml
@@ -20,16 +20,16 @@ jobs:
       IMAGE: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/druthers/aleonard.us-api:${{ github.event.release.tag_name }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
           service_account: ${{ vars.GCP_DEPLOY_SA }}
 
       - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Build and push image
         run: |

--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -18,7 +18,7 @@ jobs:
         id-token: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Log in to the Container registry
       uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1


### PR DESCRIPTION
Part of druthers-infra#4. Bumps checkout v4→v5, google-github-actions/auth v2→v3, setup-gcloud v2→v3 on the deploy + publish workflows; clears the Node 20 deprecation annotation seen on the v2.3.x deploy runs. Core WIF inputs unchanged. This repo keeps attest-build-provenance (it's public, so attestation works).