### PR TITLE
QA env parity: treat 'qa' as a real env; fix evening-only test flake

### DIFF
--- a/app/auth/oauth2.py
+++ b/app/auth/oauth2.py
@@ -33,7 +33,7 @@ def _resolve_secret_key() -> str:
     # openssl rand -hex 32 to generate a new secret key
     if settings.jwt_secret_key:
         return settings.jwt_secret_key
-    if settings.env in ('dev', 'prod', 'gs'):
+    if settings.env in ('dev', 'qa', 'prod', 'gs'):
         raise RuntimeError(
             f'JWT_SECRET_KEY must be set in the {settings.env} environment'
         )

--- a/app/services/rate_limit.py
+++ b/app/services/rate_limit.py
@@ -36,7 +36,7 @@ def _enforced() -> bool:
     settings = get_settings()
     if settings.rate_limits_enabled is not None:
         return settings.rate_limits_enabled
-    return settings.env in ('dev', 'prod')
+    return settings.env in ('dev', 'qa', 'prod')
 
 
 def client_ip(request: Request) -> str:

--- a/tests/integration/router_completed_at_test.py
+++ b/tests/integration/router_completed_at_test.py
@@ -3,9 +3,9 @@ Test the completed-date rule (#159): defaults to the day an item enters
 Rankings, explicit values win, editable and clearable afterwards.
 """
 
-from datetime import date
-
 from fastapi.testclient import TestClient
+
+from app.services.tracker_rules import utc_now
 
 
 def _auth(test_client: TestClient) -> dict:
@@ -30,7 +30,7 @@ def test_entering_rankings_stamps_today(test_client: TestClient):
         headers=_auth(test_client),
         json={'on_rankings': True},
     ).json()
-    assert body['completed_at'] == date.today().isoformat()
+    assert body['completed_at'] == utc_now().date().isoformat()
 
 
 def test_watchlist_does_not_stamp(test_client: TestClient):
@@ -123,7 +123,7 @@ def test_rank_endpoint_one_hop_stamps(test_client: TestClient):
         headers=_auth(test_client),
         json={'position': 1},
     ).json()
-    assert body['completed_at'] == date.today().isoformat()
+    assert body['completed_at'] == utc_now().date().isoformat()
 
 
 def test_other_domains_share_the_rule(test_client: TestClient):
@@ -145,4 +145,4 @@ def test_other_domains_share_the_rule(test_client: TestClient):
             headers=_auth(test_client),
             json={'on_rankings': True},
         ).json()
-        assert body['completed_at'] == date.today().isoformat(), noun
+        assert body['completed_at'] == utc_now().date().isoformat(), noun


### PR DESCRIPTION
- rate_limit.py / oauth2.py: add 'qa' to the env tuples so QA runs with rate limiting and the JWT fail-fast check, matching prod.
- router_completed_at_test.py: assert against utc_now().date() — the same clock tracker_rules stamps with — instead of local date.today(), which failed daily between 19:00 and midnight Central once UTC rolled over.

<!-- See SDLC.md for the workflow. -->

## What & why

<!-- What does this change do, and why is it needed? -->

## How verified

<!-- Tests run, manual checks, screenshots. -->

## Checklist

- [x] Branch named `feat/…`, `fix/…`, or `chore/…`
- [x] CI green (lint + tests)
- [x] No secrets committed
- [x] Docs/README updated if behavior changed
