### PR TITLE
Home summary endpoint; bound tracker lists; re-base legacy movie ranks

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -33,6 +33,12 @@ class Settings(BaseSettings):
     postgres_host: Optional[str] = None
     postgres_connection_port: str = '5432'
     postgres_db: str = 'phoenix'
+    # SQLAlchemy's default pool is 5 + 10 overflow. One page render fans out
+    # several concurrent API calls, so the default silently serialises the
+    # tail of a render behind the pool. Sized here instead of implied.
+    db_pool_size: int = 10
+    db_max_overflow: int = 10
+    db_pool_timeout: int = 10
 
     # --- Auth ---
     jwt_secret_key: Optional[str] = None

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -21,7 +21,13 @@ else:
     # pool_pre_ping recycles dead connections so the app survives a DB restart
     # instead of erroring until the pool is exhausted.
     engine = create_engine(
-        SQLALCHEMY_DATABASE_URL, pool_pre_ping=True, pool_recycle=1800
+        SQLALCHEMY_DATABASE_URL,
+        pool_pre_ping=True,
+        pool_recycle=1800,
+        pool_size=settings.db_pool_size,
+        max_overflow=settings.db_max_overflow,
+        # Fail fast rather than hanging a request behind an exhausted pool.
+        pool_timeout=settings.db_pool_timeout,
     )
 SessionLocal = sessionmaker(
     autocommit=False, autoflush=False, bind=engine

--- a/app/migration/backfill_rank_base.py
+++ b/app/migration/backfill_rank_base.py
@@ -1,0 +1,110 @@
+"""
+Re-base legacy 0-based ranks onto the API's 1-based contract.
+
+The old site stored ranks 0-based. ``orion_import`` corrects this for TV
+(``rank + 1``) but movies were imported unadjusted, so a migrated user's best
+movie sits at rank 0 — it renders as "0" on the public profile and the home
+Top 5, and it's off by one against every rank the API itself writes
+(``reorder_rankings`` enumerates from 1; ``RankPlacement`` documents a 1-based
+position).
+
+Rather than assume which domains are affected, this shifts any shelf whose
+ranks actually start at 0. Books and games were imported with a rank-0
+sentinel meaning "unranked" (nulled at import), so they should already be
+clean — if they aren't, this catches them too.
+
+Idempotent: a shelf is only shifted when its minimum rank is 0, which stops
+being true after the first run. Safe to re-run.
+
+Usage::
+
+    DATABASE_URL=postgresql://... ENV=prod \\
+        python -m app.migration.backfill_rank_base [--dry-run] \\
+        [--email adamleonard9@gmail.com | --all-users]
+"""
+
+import argparse
+import sys
+
+from sqlalchemy import func
+
+from app.db.database import SessionLocal
+from app.db.models import DbUser
+from app.services.shelves import SHELVES
+
+
+def _shift_shelf(db, shelf, user) -> int:
+    """Shift one user's ranks on one shelf up by 1. Returns rows changed."""
+    tracker = shelf.tracker_model
+    ranked = (
+        tracker.user_id == user.pk,
+        tracker.on_rankings.is_(True),
+        tracker.rank.isnot(None),
+    )
+    lowest = db.query(func.min(tracker.rank)).filter(*ranked).scalar()
+    if lowest != 0:
+        return 0
+    return (
+        db.query(tracker)
+        .filter(*ranked)
+        .update({tracker.rank: tracker.rank + 1}, synchronize_session=False)
+    )
+
+
+def run_backfill(db, email: str = None, dry_run: bool = False) -> int:
+    """
+    Re-base every affected shelf on an existing session. Returns rows changed.
+
+    A dry run undoes its own writes via a SAVEPOINT rather than rolling back
+    the whole transaction, so it can't discard anything the caller had
+    pending.
+    """
+    users = db.query(DbUser)
+    if email:
+        users = users.filter(DbUser.email == email)
+    users = users.all()
+    if email and not users:
+        print(f'No user with email {email}', file=sys.stderr)
+        return 0
+
+    changed = 0
+    savepoint = db.begin_nested()
+    for user in users:
+        for shelf in SHELVES:
+            rows = _shift_shelf(db, shelf, user)
+            if rows:
+                changed += rows
+                print(f'{user.email}: {shelf.category} re-based 0 -> 1 ({rows} rows)')
+
+    if dry_run:
+        savepoint.rollback()
+        print(f'DRY RUN — {changed} rows would change')
+    else:
+        savepoint.commit()
+        db.commit()
+        print(f'Done — {changed} rows changed')
+    return changed
+
+
+def backfill(email: str = None, dry_run: bool = False) -> int:
+    """Open a session and re-base. Returns the number of rows changed."""
+    db = SessionLocal()
+    try:
+        return run_backfill(db, email=email, dry_run=dry_run)
+    finally:
+        db.close()
+
+
+def main():
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--dry-run', action='store_true')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--email', help='Re-base a single user')
+    group.add_argument('--all-users', action='store_true', help='Re-base every user')
+    args = parser.parse_args()
+    backfill(email=None if args.all_users else args.email, dry_run=args.dry_run)
+
+
+if __name__ == '__main__':
+    main()

--- a/app/migration/orion_import.py
+++ b/app/migration/orion_import.py
@@ -253,7 +253,16 @@ def run_import(dry_run: bool = False) -> Report:
                         'movie_id': movie_map.get(r['movies_id']),
                     },
                     {
-                        'rank': r['rank'],
+                        # Legacy movie ranks are 0-based, like TV's below; the
+                        # API contract is 1-based (reorder_rankings enumerates
+                        # from 1). Only ranked (completed) rows are re-based,
+                        # matching backfill_rank_base's scope for the rows
+                        # already in prod.
+                        'rank': (
+                            r['rank'] + 1
+                            if r['completed'] == 1 and r['rank'] is not None
+                            else r['rank']
+                        ),
                         'completed': r['completed'],
                         'notes': r['notes'],
                         # Derive the two lists here too (not only in the alembic

--- a/app/router/v1/router_books.py
+++ b/app/router/v1/router_books.py
@@ -15,6 +15,11 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.db.database import get_db
 from app.services.rate_limit import catalog_add_cap, search_rate_limit
+from app.services.tracker_query import (
+    apply_list_params,
+    guard_truncation,
+    list_params,
+)
 from app.services.tracker_rules import (
     default_completed_at,
     enforce_single_home,
@@ -209,14 +214,17 @@ def _close_rank_gap(db: Session, user_pk: int, vacated_rank) -> None:
 
 @router.get('/users/me/books', response_model=List[UserBookResponse])
 def get_user_books(
-    db: Session = Depends(get_db), current_user: list = Depends(get_current_user)
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+    params: dict = Depends(list_params),
 ):
-    return (
+    query = (
         db.query(DbUserBook)
         .options(joinedload(DbUserBook.book))
         .filter(DbUserBook.user_id == current_user[0].pk)
-        .all()
     )
+    rows = apply_list_params(query, DbUserBook, params).all()
+    return guard_truncation(rows, params, 'Book')
 
 
 @router.put('/users/me/books/rankings/order', response_model=List[UserBookResponse])

--- a/app/router/v1/router_games.py
+++ b/app/router/v1/router_games.py
@@ -16,6 +16,11 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.db.database import get_db
 from app.services.rate_limit import catalog_add_cap, search_rate_limit
+from app.services.tracker_query import (
+    apply_list_params,
+    guard_truncation,
+    list_params,
+)
 from app.services.tracker_rules import (
     default_completed_at,
     enforce_single_home,
@@ -204,14 +209,17 @@ def _close_rank_gap(db: Session, user_pk: int, vacated_rank) -> None:
 
 @router.get('/users/me/games', response_model=List[UserVideoGameResponse])
 def get_user_games(
-    db: Session = Depends(get_db), current_user: list = Depends(get_current_user)
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+    params: dict = Depends(list_params),
 ):
-    return (
+    query = (
         db.query(DbUserVideoGame)
         .options(joinedload(DbUserVideoGame.game))
         .filter(DbUserVideoGame.user_id == current_user[0].pk)
-        .all()
     )
+    rows = apply_list_params(query, DbUserVideoGame, params).all()
+    return guard_truncation(rows, params, 'Game')
 
 
 @router.put(

--- a/app/router/v1/router_movies.py
+++ b/app/router/v1/router_movies.py
@@ -36,6 +36,11 @@ from app.services.movie_search import (
 )
 from app.services.search_correction import correct_query
 from app.services.tracked_status import attach_tracked_status
+from app.services.tracker_query import (
+    apply_list_params,
+    guard_truncation,
+    list_params,
+)
 
 router = APIRouter(prefix='/v1', tags=['Movies'])
 
@@ -200,14 +205,17 @@ def _close_rank_gap(db: Session, user_pk: int, vacated_rank) -> None:
 
 @router.get('/users/me/movies', response_model=List[UserMovieResponse])
 def get_user_movies(
-    db: Session = Depends(get_db), current_user: list = Depends(get_current_user)
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+    params: dict = Depends(list_params),
 ):
-    return (
+    query = (
         db.query(DbUserMovie)
         .options(joinedload(DbUserMovie.movie))
         .filter(DbUserMovie.user_id == current_user[0].pk)
-        .all()
     )
+    rows = apply_list_params(query, DbUserMovie, params).all()
+    return guard_truncation(rows, params, 'Movie')
 
 
 @router.get('/users/me/movies/{movie_id}', response_model=UserMovieResponse)

--- a/app/router/v1/router_summary.py
+++ b/app/router/v1/router_summary.py
@@ -1,0 +1,29 @@
+# pylint: disable=missing-function-docstring
+"""
+The home summary endpoint — one bounded call behind the landing page.
+"""
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.auth.oauth2 import get_current_user
+from app.db.database import get_db
+from app.schemas.model_schemas import OutSummary
+from app.services.summary import TOP_N, build_summary
+
+router = APIRouter(prefix='/v1', tags=['Summary'])
+
+
+@router.get('/users/me/summary', response_model=OutSummary)
+def get_summary(
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+    top: int = Query(TOP_N, ge=1, le=TOP_N, description='Entries per shelf'),
+):
+    """
+    Per-shelf Top 5 plus ranked/queued counts for the signed-in user.
+
+    Replaces the home page's four full-collection fetches; row count is
+    independent of library size.
+    """
+    return build_summary(db, current_user[0], top_n=top)

--- a/app/router/v1/router_tv.py
+++ b/app/router/v1/router_tv.py
@@ -16,6 +16,11 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.db.database import get_db
 from app.services.rate_limit import catalog_add_cap, search_rate_limit
+from app.services.tracker_query import (
+    apply_list_params,
+    guard_truncation,
+    list_params,
+)
 from app.services.tracker_rules import (
     default_completed_at,
     enforce_single_home,
@@ -325,14 +330,18 @@ def _watch_status(aired: int, watched: int, show_status: Optional[str]) -> str:
 
 @router.get('/users/me/tv-shows', response_model=List[UserTVShowWithStatus])
 def get_user_tv_shows(
-    db: Session = Depends(get_db), current_user: list = Depends(get_current_user)
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+    params: dict = Depends(list_params),
 ):
     user_pk = current_user[0].pk
-    trackers = (
+    query = (
         db.query(DbUserTVShow)
         .options(joinedload(DbUserTVShow.tv_show))
         .filter(DbUserTVShow.user_id == user_pk)
-        .all()
+    )
+    trackers = guard_truncation(
+        apply_list_params(query, DbUserTVShow, params).all(), params, 'TV'
     )
     show_pks = [t.tv_show_id for t in trackers]
     # airdate is stored tz-naive (see tv_search._to_date), so compare naive.

--- a/app/router/v1/router_visibility.py
+++ b/app/router/v1/router_visibility.py
@@ -10,22 +10,14 @@ notes, no watchlist, no watch state, no activity.
 import re
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.auth.oauth2 import get_current_user
 from app.db.database import get_db
 from app.db.models import DbUser
-from app.db.models_sandbox import (
-    DbBook,
-    DbMovie,
-    DbTVShow,
-    DbUserBook,
-    DbUserMovie,
-    DbUserTVShow,
-    DbUserVideoGame,
-    DbVideoGame,
-)
 from app.schemas.model_schemas import InVisibilityUpdate, OutVisibility
+from app.services.shelves import SHELVES
 
 router = APIRouter(prefix='/v1', tags=['Visibility'])
 
@@ -44,13 +36,10 @@ RESERVED_HANDLES = {
     'www',
 }
 
-# (flag attribute, label, tracker model, catalog model, join column)
-_SHELVES = (
-    ('public_movies', 'Movies', DbUserMovie, DbMovie, 'movie_id'),
-    ('public_tv', 'TV', DbUserTVShow, DbTVShow, 'tv_show_id'),
-    ('public_books', 'Books', DbUserBook, DbBook, 'book_id'),
-    ('public_games', 'Video Games', DbUserVideoGame, DbVideoGame, 'game_id'),
-)
+# Ranked entries served per shelf on a public profile. The profile is the
+# shareable surface (every share-card click lands here), so it gets a bound
+# rather than the full ranked list it used to return.
+PROFILE_SHELF_LIMIT = 25
 
 
 @router.get('/users/me/visibility', response_model=OutVisibility)
@@ -97,11 +86,14 @@ def update_visibility(
                 )
         user.handle = handle
 
-    for flag, _, _, _, _ in _SHELVES:
+    for shelf in SHELVES:
+        flag = shelf.visibility_flag
         if flag in data and data[flag] is not None:
             setattr(user, flag, bool(data[flag]))
 
-    if not user.handle and any(getattr(user, flag) for flag, *_ in _SHELVES):
+    if not user.handle and any(
+        getattr(user, shelf.visibility_flag) for shelf in SHELVES
+    ):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail='Pick a handle before making a category public — it '
@@ -128,32 +120,46 @@ def public_profile(handle: str, db: Session = Depends(get_db)):
         raise not_found
 
     shelves = []
-    for flag, label, tracker_model, catalog_model, join_col in _SHELVES:
-        if not getattr(user, flag):
+    for shelf in SHELVES:
+        if not getattr(user, shelf.visibility_flag):
             continue
+        tracker_model, catalog_model = shelf.tracker_model, shelf.catalog_model
+        ranked = (
+            tracker_model.user_id == user.pk,
+            tracker_model.on_rankings.is_(True),
+            tracker_model.rank.isnot(None),
+        )
+        # ranked_count is the shelf total, so it comes from COUNT rather than
+        # len(rows) now that rows are capped at PROFILE_SHELF_LIMIT.
+        ranked_count = (
+            db.query(func.count())  # pylint: disable=not-callable
+            .select_from(tracker_model)
+            .filter(*ranked)
+            .scalar()
+        )
         rows = (
-            db.query(tracker_model, catalog_model)
-            .join(catalog_model, getattr(tracker_model, join_col) == catalog_model.pk)
-            .filter(
-                tracker_model.user_id == user.pk,
-                tracker_model.on_rankings.is_(True),
-                tracker_model.rank.isnot(None),
+            db.query(tracker_model.rank, catalog_model)
+            .join(
+                catalog_model,
+                getattr(tracker_model, shelf.join_col) == catalog_model.pk,
             )
+            .filter(*ranked)
             .order_by(tracker_model.rank)
+            .limit(PROFILE_SHELF_LIMIT)
             .all()
         )
         shelves.append(
             {
-                'category': label,
-                'ranked_count': len(rows),
+                'category': shelf.label,
+                'ranked_count': ranked_count,
                 'items': [
                     {
-                        'rank': tracker.rank,
+                        'rank': rank,
                         'title': item.title,
                         'year': item.year,
                         'poster_url': item.poster_url,
                     }
-                    for tracker, item in rows
+                    for rank, item in rows
                 ],
             }
         )

--- a/app/run.py
+++ b/app/run.py
@@ -5,6 +5,7 @@ This module contains the main application setup and routing.
 import asyncio
 import json
 import os
+import time
 
 import uvicorn
 from fastapi import FastAPI
@@ -29,6 +30,7 @@ from .router.v1 import (
     router_import,
     router_notifications,
     router_search,
+    router_summary,
     router_visibility,
     router_movies,
     router_games,
@@ -77,6 +79,10 @@ app = FastAPI(
         },
         {'name': 'Notifications', 'description': 'Per-user notification feed'},
         {'name': 'Search', 'description': 'Cross-domain global search'},
+        {
+            'name': 'Summary',
+            'description': 'Home summary — per-shelf Top 5 and counts',
+        },
     ],
     openapi_url='/openapi.json',
     servers=[
@@ -87,6 +93,36 @@ app = FastAPI(
         'url': 'https://www.gnu.org/licenses/gpl-3.0.html',
     },
 )
+
+
+@app.middleware('http')
+async def log_request_latency(request, call_next):
+    """
+    Emit a duration for every request so slow pages can be diagnosed from
+    Loki instead of inferred from the code. Uses the route template (not the
+    raw path) so per-endpoint latency aggregates cleanly.
+    """
+    started = time.perf_counter()
+    response = await call_next(request)
+    elapsed_ms = (time.perf_counter() - started) * 1000
+    route = request.scope.get('route')
+    logger.info(
+        'request %s %s -> %s in %.1fms',
+        request.method,
+        getattr(route, 'path', request.url.path),
+        response.status_code,
+        elapsed_ms,
+        extra={
+            'http_method': request.method,
+            'http_route': getattr(route, 'path', request.url.path),
+            'http_status': response.status_code,
+            'duration_ms': round(elapsed_ms, 1),
+        },
+    )
+    # Lets the browser's network panel attribute the time without a log dive.
+    response.headers['Server-Timing'] = f'app;dur={elapsed_ms:.1f}'
+    return response
+
 
 app.include_router(authentication.router, prefix='/v1/auth')
 app.include_router(user.router, prefix='/v1/users')
@@ -102,6 +138,7 @@ app.include_router(router_api_keys.router)
 app.include_router(router_export.router)
 app.include_router(router_import.router)
 app.include_router(router_visibility.router)
+app.include_router(router_summary.router)
 
 # Serve static files
 app.mount('/static', StaticFiles(directory='app/static'), name='static')

--- a/app/schemas/model_schemas.py
+++ b/app/schemas/model_schemas.py
@@ -124,3 +124,37 @@ class OutVisibility(BaseModel):
     public_games: Optional[bool] = False
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class OutSummaryEntry(BaseModel):
+    """One ranked entry on a shelf's Top 5."""
+
+    rank: int
+    id: str
+    title: str
+    year: Optional[int] = None
+    poster_url: Optional[str] = None
+
+
+class OutSummaryShelf(BaseModel):
+    """One domain's headline numbers plus its best-ranked entries."""
+
+    category: str
+    label: str
+    ranked_count: int
+    queued_count: int
+    public: bool
+    top: list[OutSummaryEntry]
+
+
+class OutSummary(BaseModel):
+    """
+    Everything the home page renders, in one bounded response — see
+    app/services/summary.py for why this endpoint exists.
+    """
+
+    handle: Optional[str] = None
+    display_name: Optional[str] = None
+    profile_public: bool = False
+    shelves: list[OutSummaryShelf]
+    total_ranked: int

--- a/app/services/shelves.py
+++ b/app/services/shelves.py
@@ -1,0 +1,52 @@
+"""
+The four tracked domains, described once.
+
+Movies, TV, Books and Games have identical tracker shapes: ``on_rankings`` /
+``on_watchlist`` / ``rank`` against a catalog row carrying a title, year and
+poster. Endpoints that work across all four — the public profile and the home
+summary — read this registry instead of repeating the tuple, so the shelf list
+stays in one place.
+"""
+
+from typing import NamedTuple, Tuple, Type
+
+from app.db.models_sandbox import (
+    DbBook,
+    DbMovie,
+    DbTVShow,
+    DbUserBook,
+    DbUserMovie,
+    DbUserTVShow,
+    DbUserVideoGame,
+    DbVideoGame,
+)
+
+
+class Shelf(NamedTuple):
+    """One tracked domain and the bits generic queries need to reach it."""
+
+    # URL/JSON slug ('movies'). Stable — clients key off this.
+    category: str
+    # Human label ('Video Games'), as it appears on profiles and share cards.
+    label: str
+    # Attribute on DbUser holding this shelf's public opt-in flag.
+    visibility_flag: str
+    tracker_model: Type
+    catalog_model: Type
+    # Tracker column joining to ``catalog_model.pk``.
+    join_col: str
+
+
+SHELVES: Tuple[Shelf, ...] = (
+    Shelf('movies', 'Movies', 'public_movies', DbUserMovie, DbMovie, 'movie_id'),
+    Shelf('tv', 'TV', 'public_tv', DbUserTVShow, DbTVShow, 'tv_show_id'),
+    Shelf('books', 'Books', 'public_books', DbUserBook, DbBook, 'book_id'),
+    Shelf(
+        'games',
+        'Video Games',
+        'public_games',
+        DbUserVideoGame,
+        DbVideoGame,
+        'game_id',
+    ),
+)

--- a/app/services/summary.py
+++ b/app/services/summary.py
@@ -1,0 +1,107 @@
+"""
+The home summary: everything the landing page needs, in bounded queries.
+
+The dashboard used to be assembled client-side from ``/v1/users/me/{movies,
+tv-shows,books,games}`` — four unpaginated collections (~1,400 movie rows
+alone) fetched, validated and shipped so the page could render eight counts
+and twenty titles. This module answers the same question with two small
+indexed queries per shelf, so page cost stops scaling with library size.
+"""
+
+from typing import List, Optional
+
+from sqlalchemy import case, func
+from sqlalchemy.orm import Session
+
+from app.db.models import DbUser
+from app.services.shelves import SHELVES, Shelf
+
+# Ranked entries returned per shelf. Five is the product ("your Top 5"), not
+# an arbitrary page size — callers may ask for fewer but not more, so this
+# endpoint can never become another unbounded collection.
+TOP_N = 5
+
+
+def _counts(db: Session, shelf: Shelf, user_pk: int):
+    """Ranked and queued totals for one shelf, in a single aggregate query."""
+    tracker = shelf.tracker_model
+    # count() ignores NULLs, so a CASE with no ELSE counts only the matches.
+    return (
+        db.query(
+            func.count(  # pylint: disable=not-callable
+                case((tracker.on_rankings.is_(True), 1))
+            ).label('ranked'),
+            func.count(  # pylint: disable=not-callable
+                case((tracker.on_watchlist.is_(True), 1))
+            ).label('queued'),
+        )
+        .filter(tracker.user_id == user_pk)
+        .one()
+    )
+
+
+def _top(db: Session, shelf: Shelf, user_pk: int, limit: int) -> List[dict]:
+    """The best-ranked entries for one shelf, best first."""
+    tracker, catalog = shelf.tracker_model, shelf.catalog_model
+    rows = (
+        db.query(tracker.rank, catalog)
+        .join(catalog, getattr(tracker, shelf.join_col) == catalog.pk)
+        .filter(
+            tracker.user_id == user_pk,
+            tracker.on_rankings.is_(True),
+            tracker.rank.isnot(None),
+        )
+        .order_by(tracker.rank)
+        .limit(limit)
+        .all()
+    )
+    return [
+        {
+            'rank': rank,
+            'id': item.id,
+            'title': item.title,
+            'year': item.year,
+            'poster_url': item.poster_url,
+        }
+        for rank, item in rows
+    ]
+
+
+def build_summary(db: Session, user: DbUser, top_n: int = TOP_N) -> dict:
+    """
+    Assemble the home summary for ``user``.
+
+    ``public`` per shelf and the account handle ride along so the share card
+    can print a profile URL that actually resolves — the card used to derive a
+    handle from the signed-in email, which is not the profile handle.
+    """
+    limit = max(1, min(top_n, TOP_N))
+    shelves = []
+    for shelf in SHELVES:
+        counts = _counts(db, shelf, user.pk)
+        shelves.append(
+            {
+                'category': shelf.category,
+                'label': shelf.label,
+                'ranked_count': counts.ranked,
+                'queued_count': counts.queued,
+                'public': bool(getattr(user, shelf.visibility_flag)),
+                'top': _top(db, shelf, user.pk, limit),
+            }
+        )
+
+    return {
+        'handle': user.handle,
+        'display_name': user.display_name,
+        # A profile only resolves once a handle exists AND a shelf is opted in
+        # (see router_visibility.public_profile, which 404s otherwise). The web
+        # reads this instead of re-deriving the rule.
+        'profile_public': bool(user.handle) and any(s['public'] for s in shelves),
+        'shelves': shelves,
+        'total_ranked': sum(s['ranked_count'] for s in shelves),
+    }
+
+
+def profile_path(handle: Optional[str]) -> Optional[str]:
+    """Canonical public-profile path for a handle (see DbUser.handle)."""
+    return f'/u/{handle}' if handle else None

--- a/app/services/tracker_query.py
+++ b/app/services/tracker_query.py
@@ -1,0 +1,68 @@
+"""
+Shared list-shaping for the per-user tracker collections.
+
+``/v1/users/me/{movies,tv-shows,books,games}`` returned every tracker a user
+owns with no ceiling — ~1,400 rows (≈400KB) for movies alone. Callers that
+only want one list ("what's ranked?") had to fetch everything and filter
+client-side. These helpers give all four endpoints the same filters, the same
+paging, and a real upper bound.
+"""
+
+from typing import Optional
+
+from fastapi import HTTPException, Query, status
+
+# Hard ceiling on any single tracker page. Set well above today's largest
+# library so nothing breaks, but low enough that the endpoint can no longer
+# return an unbounded result set.
+MAX_PAGE = 5000
+
+
+def list_params(
+    on_rankings: Optional[bool] = Query(
+        None, description='Only ranked entries (true) or only unranked (false)'
+    ),
+    on_watchlist: Optional[bool] = Query(
+        None, description='Only queued entries (true) or only unqueued (false)'
+    ),
+    limit: int = Query(
+        MAX_PAGE, ge=1, le=MAX_PAGE, description='Maximum entries to return'
+    ),
+    offset: int = Query(0, ge=0, description='Entries to skip'),
+) -> dict:
+    """FastAPI dependency supplying the shared tracker list query params."""
+    return {
+        'on_rankings': on_rankings,
+        'on_watchlist': on_watchlist,
+        'limit': limit,
+        'offset': offset,
+    }
+
+
+def apply_list_params(query, tracker, params: dict):
+    """Apply the shared filters and paging to a tracker query."""
+    if params['on_rankings'] is not None:
+        query = query.filter(tracker.on_rankings.is_(params['on_rankings']))
+    if params['on_watchlist'] is not None:
+        query = query.filter(tracker.on_watchlist.is_(params['on_watchlist']))
+    return query.offset(params['offset']).limit(params['limit'])
+
+
+def guard_truncation(rows, params: dict, label: str):
+    """
+    Refuse to silently truncate.
+
+    A caller that asked for the default page and got exactly ``MAX_PAGE`` rows
+    has outgrown the endpoint; returning a silently-clipped list would corrupt
+    a rankings board. Fail loudly instead so it surfaces as an error rather
+    than as missing entries.
+    """
+    if len(rows) == params['limit'] == MAX_PAGE:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=(
+                f'{label} library exceeds {MAX_PAGE} entries — '
+                'page it with limit/offset'
+            ),
+        )
+    return rows

--- a/openapi.json
+++ b/openapi.json
@@ -1164,27 +1164,102 @@
         ],
         "summary": "Get User Movies",
         "operationId": "get_user_movies_v1_users_me_movies_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "on_rankings",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only ranked entries (true) or only unranked (false)",
+              "title": "On Rankings"
+            },
+            "description": "Only ranked entries (true) or only unranked (false)"
+          },
+          {
+            "name": "on_watchlist",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only queued entries (true) or only unqueued (false)",
+              "title": "On Watchlist"
+            },
+            "description": "Only queued entries (true) or only unqueued (false)"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 5000,
+              "minimum": 1,
+              "description": "Maximum entries to return",
+              "default": 5000,
+              "title": "Limit"
+            },
+            "description": "Maximum entries to return"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Entries to skip",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Entries to skip"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
+                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/UserMovieResponse"
                   },
-                  "type": "array",
                   "title": "Response Get User Movies V1 Users Me Movies Get"
                 }
               }
             }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
           }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
+        }
       }
     },
     "/v1/users/me/movies/{movie_id}": {
@@ -1762,27 +1837,102 @@
         ],
         "summary": "Get User Games",
         "operationId": "get_user_games_v1_users_me_games_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "on_rankings",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only ranked entries (true) or only unranked (false)",
+              "title": "On Rankings"
+            },
+            "description": "Only ranked entries (true) or only unranked (false)"
+          },
+          {
+            "name": "on_watchlist",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only queued entries (true) or only unqueued (false)",
+              "title": "On Watchlist"
+            },
+            "description": "Only queued entries (true) or only unqueued (false)"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 5000,
+              "minimum": 1,
+              "description": "Maximum entries to return",
+              "default": 5000,
+              "title": "Limit"
+            },
+            "description": "Maximum entries to return"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Entries to skip",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Entries to skip"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
+                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/UserVideoGameResponse"
                   },
-                  "type": "array",
                   "title": "Response Get User Games V1 Users Me Games Get"
                 }
               }
             }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
           }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
+        }
       }
     },
     "/v1/users/me/games/rankings/order": {
@@ -2360,27 +2510,102 @@
         ],
         "summary": "Get User Books",
         "operationId": "get_user_books_v1_users_me_books_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "on_rankings",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only ranked entries (true) or only unranked (false)",
+              "title": "On Rankings"
+            },
+            "description": "Only ranked entries (true) or only unranked (false)"
+          },
+          {
+            "name": "on_watchlist",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only queued entries (true) or only unqueued (false)",
+              "title": "On Watchlist"
+            },
+            "description": "Only queued entries (true) or only unqueued (false)"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 5000,
+              "minimum": 1,
+              "description": "Maximum entries to return",
+              "default": 5000,
+              "title": "Limit"
+            },
+            "description": "Maximum entries to return"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Entries to skip",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Entries to skip"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
+                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/UserBookResponse"
                   },
-                  "type": "array",
                   "title": "Response Get User Books V1 Users Me Books Get"
                 }
               }
             }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
           }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
+        }
       }
     },
     "/v1/users/me/books/rankings/order": {
@@ -3206,27 +3431,102 @@
         ],
         "summary": "Get User Tv Shows",
         "operationId": "get_user_tv_shows_v1_users_me_tv_shows_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "on_rankings",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only ranked entries (true) or only unranked (false)",
+              "title": "On Rankings"
+            },
+            "description": "Only ranked entries (true) or only unranked (false)"
+          },
+          {
+            "name": "on_watchlist",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only queued entries (true) or only unqueued (false)",
+              "title": "On Watchlist"
+            },
+            "description": "Only queued entries (true) or only unqueued (false)"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 5000,
+              "minimum": 1,
+              "description": "Maximum entries to return",
+              "default": 5000,
+              "title": "Limit"
+            },
+            "description": "Maximum entries to return"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Entries to skip",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Entries to skip"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
+                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/UserTVShowWithStatus"
                   },
-                  "type": "array",
                   "title": "Response Get User Tv Shows V1 Users Me Tv Shows Get"
                 }
               }
             }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
           }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
+        }
       }
     },
     "/v1/users/me/schedule": {
@@ -4467,6 +4767,59 @@
         }
       }
     },
+    "/v1/users/me/summary": {
+      "get": {
+        "tags": [
+          "Summary"
+        ],
+        "summary": "Get Summary",
+        "description": "Per-shelf Top 5 plus ranked/queued counts for the signed-in user.\n\nReplaces the home page's four full-collection fetches; row count is\nindependent of library size.",
+        "operationId": "get_summary_v1_users_me_summary_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "top",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 5,
+              "minimum": 1,
+              "description": "Entries per shelf",
+              "default": 5,
+              "title": "Top"
+            },
+            "description": "Entries per shelf"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutSummary"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/": {
       "get": {
         "tags": [
@@ -4962,6 +5315,27 @@
               }
             ],
             "title": "Poster Url"
+          },
+          "on_watchlist": {
+            "type": "boolean",
+            "title": "On Watchlist",
+            "default": false
+          },
+          "on_rankings": {
+            "type": "boolean",
+            "title": "On Rankings",
+            "default": false
+          },
+          "rank": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rank"
           }
         },
         "type": "object",
@@ -5640,6 +6014,27 @@
               }
             ],
             "title": "Poster Url"
+          },
+          "on_watchlist": {
+            "type": "boolean",
+            "title": "On Watchlist",
+            "default": false
+          },
+          "on_rankings": {
+            "type": "boolean",
+            "title": "On Rankings",
+            "default": false
+          },
+          "rank": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rank"
           }
         },
         "type": "object",
@@ -6173,6 +6568,27 @@
               }
             ],
             "title": "Type"
+          },
+          "on_watchlist": {
+            "type": "boolean",
+            "title": "On Watchlist",
+            "default": false
+          },
+          "on_rankings": {
+            "type": "boolean",
+            "title": "On Rankings",
+            "default": false
+          },
+          "rank": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rank"
           }
         },
         "type": "object",
@@ -6682,6 +7098,143 @@
         ],
         "title": "OutResponseUserModel",
         "description": "Response format for user data."
+      },
+      "OutSummary": {
+        "properties": {
+          "handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Handle"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "profile_public": {
+            "type": "boolean",
+            "title": "Profile Public",
+            "default": false
+          },
+          "shelves": {
+            "items": {
+              "$ref": "#/components/schemas/OutSummaryShelf"
+            },
+            "type": "array",
+            "title": "Shelves"
+          },
+          "total_ranked": {
+            "type": "integer",
+            "title": "Total Ranked"
+          }
+        },
+        "type": "object",
+        "required": [
+          "shelves",
+          "total_ranked"
+        ],
+        "title": "OutSummary",
+        "description": "Everything the home page renders, in one bounded response \u2014 see\napp/services/summary.py for why this endpoint exists."
+      },
+      "OutSummaryEntry": {
+        "properties": {
+          "rank": {
+            "type": "integer",
+            "title": "Rank"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Year"
+          },
+          "poster_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Poster Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "rank",
+          "id",
+          "title"
+        ],
+        "title": "OutSummaryEntry",
+        "description": "One ranked entry on a shelf's Top 5."
+      },
+      "OutSummaryShelf": {
+        "properties": {
+          "category": {
+            "type": "string",
+            "title": "Category"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "ranked_count": {
+            "type": "integer",
+            "title": "Ranked Count"
+          },
+          "queued_count": {
+            "type": "integer",
+            "title": "Queued Count"
+          },
+          "public": {
+            "type": "boolean",
+            "title": "Public"
+          },
+          "top": {
+            "items": {
+              "$ref": "#/components/schemas/OutSummaryEntry"
+            },
+            "type": "array",
+            "title": "Top"
+          }
+        },
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "ranked_count",
+          "queued_count",
+          "public",
+          "top"
+        ],
+        "title": "OutSummaryShelf",
+        "description": "One domain's headline numbers plus its best-ranked entries."
       },
       "OutUserDisplay": {
         "properties": {
@@ -7533,6 +8086,27 @@
               }
             ],
             "title": "Poster Url"
+          },
+          "on_watchlist": {
+            "type": "boolean",
+            "title": "On Watchlist",
+            "default": false
+          },
+          "on_rankings": {
+            "type": "boolean",
+            "title": "On Rankings",
+            "default": false
+          },
+          "rank": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rank"
           }
         },
         "type": "object",
@@ -9907,6 +10481,10 @@
     {
       "name": "Search",
       "description": "Cross-domain global search"
+    },
+    {
+      "name": "Summary",
+      "description": "Home summary \u2014 per-shelf Top 5 and counts"
     }
   ]
 }

--- a/tests/integration/router_summary_test.py
+++ b/tests/integration/router_summary_test.py
@@ -1,0 +1,138 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+from fastapi.testclient import TestClient
+
+
+def _auth(token: str) -> dict:
+    return {'Authorization': f'Bearer {token}'}
+
+
+def _add_movie(test_client: TestClient, title: str, imdb: str, year: int = 1999) -> str:
+    return test_client.post(
+        '/v1/movies',
+        headers=_auth(test_client.admin_user.token),
+        json={'title': title, 'imdb': imdb, 'year': year},
+    ).json()['id']
+
+
+def _rank(test_client: TestClient, token: str, movie_id: str, position: int):
+    test_client.post(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(token),
+        json={'on_rankings': True},
+    )
+    test_client.put(
+        f'/v1/users/me/movies/{movie_id}/rank',
+        headers=_auth(token),
+        json={'position': position},
+    )
+
+
+def _queue(test_client: TestClient, token: str, movie_id: str):
+    test_client.post(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(token),
+        json={'on_watchlist': True},
+    )
+
+
+def _shelf(body: dict, category: str) -> dict:
+    return next(s for s in body['shelves'] if s['category'] == category)
+
+
+def test_summary_requires_auth(test_client: TestClient):
+    assert test_client.get('/v1/users/me/summary').status_code == 401
+
+
+def test_empty_summary_has_all_four_shelves(test_client: TestClient):
+    body = test_client.get(
+        '/v1/users/me/summary', headers=_auth(test_client.first_user.token)
+    ).json()
+    assert [s['category'] for s in body['shelves']] == [
+        'movies',
+        'tv',
+        'books',
+        'games',
+    ]
+    assert body['total_ranked'] == 0
+    assert body['profile_public'] is False
+    assert all(s['top'] == [] for s in body['shelves'])
+
+
+def test_top_is_ranked_order_and_counts_are_separate(test_client: TestClient):
+    token = test_client.first_user.token
+    # Rank three, queue two.
+    for i, title in enumerate(['Heat', 'Ronin', 'Sneakers'], start=1):
+        _rank(test_client, token, _add_movie(test_client, title, f'tt000{i}'), i)
+    for i, title in enumerate(['Alien', 'Aliens'], start=4):
+        _queue(test_client, token, _add_movie(test_client, title, f'tt000{i}'))
+
+    movies = _shelf(
+        test_client.get('/v1/users/me/summary', headers=_auth(token)).json(),
+        'movies',
+    )
+    assert [e['title'] for e in movies['top']] == ['Heat', 'Ronin', 'Sneakers']
+    assert [e['rank'] for e in movies['top']] == [1, 2, 3]
+    assert movies['ranked_count'] == 3
+    assert movies['queued_count'] == 2
+
+
+def test_top_is_capped_at_five(test_client: TestClient):
+    token = test_client.first_user.token
+    for i in range(1, 8):
+        _rank(test_client, token, _add_movie(test_client, f'Film {i}', f'tt10{i}'), i)
+
+    body = test_client.get('/v1/users/me/summary', headers=_auth(token)).json()
+    assert len(_shelf(body, 'movies')['top']) == 5
+    assert _shelf(body, 'movies')['ranked_count'] == 7
+    # The cap is a ceiling, not just a default.
+    assert (
+        test_client.get('/v1/users/me/summary?top=99', headers=_auth(token)).status_code
+        == 422
+    )
+    assert (
+        len(
+            _shelf(
+                test_client.get(
+                    '/v1/users/me/summary?top=2', headers=_auth(token)
+                ).json(),
+                'movies',
+            )['top']
+        )
+        == 2
+    )
+
+
+def test_summary_is_per_user(test_client: TestClient):
+    _rank(
+        test_client,
+        test_client.first_user.token,
+        _add_movie(test_client, 'Heat', 'tt0113277'),
+        1,
+    )
+    body = test_client.get(
+        '/v1/users/me/summary', headers=_auth(test_client.second_user.token)
+    ).json()
+    assert body['total_ranked'] == 0
+
+
+def test_profile_public_tracks_handle_and_flags(test_client: TestClient):
+    token = test_client.first_user.token
+    _rank(test_client, token, _add_movie(test_client, 'Heat', 'tt0113277'), 1)
+
+    # A handle alone doesn't make the profile resolve.
+    test_client.put(
+        '/v1/users/me/visibility', headers=_auth(token), json={'handle': 'avery'}
+    )
+    body = test_client.get('/v1/users/me/summary', headers=_auth(token)).json()
+    assert body['handle'] == 'avery'
+    assert body['profile_public'] is False
+
+    test_client.put(
+        '/v1/users/me/visibility', headers=_auth(token), json={'public_movies': True}
+    )
+    body = test_client.get('/v1/users/me/summary', headers=_auth(token)).json()
+    assert body['profile_public'] is True
+    assert _shelf(body, 'movies')['public'] is True
+    assert _shelf(body, 'tv')['public'] is False
+    # profile_public is the same rule the public endpoint enforces.
+    assert test_client.get('/v1/public/avery').status_code == 200

--- a/tests/integration/router_tracker_paging_test.py
+++ b/tests/integration/router_tracker_paging_test.py
@@ -1,0 +1,97 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+import pytest
+from fastapi.testclient import TestClient
+
+from app.services.tracker_query import MAX_PAGE
+
+# (list path, catalog path, catalog payload builder)
+DOMAINS = (
+    ('movies', '/v1/movies', lambda i: {'title': f'M{i}', 'imdb': f'tt50{i}'}),
+    ('books', '/v1/books', lambda i: {'title': f'B{i}', 'googleid': f'gid50{i}'}),
+    ('games', '/v1/games', lambda i: {'title': f'G{i}', 'igdb': 5000 + i}),
+)
+
+
+def _auth(token: str) -> dict:
+    return {'Authorization': f'Bearer {token}'}
+
+
+def _seed(test_client: TestClient, domain: str, catalog_path: str, payload, count: int):
+    """Create ``count`` catalog rows; rank the odd ones, queue the even ones."""
+    token = test_client.first_user.token
+    for i in range(count):
+        entity_id = test_client.post(
+            catalog_path, headers=_auth(test_client.admin_user.token), json=payload(i)
+        ).json()['id']
+        test_client.post(
+            f'/v1/users/me/{domain}/{entity_id}',
+            headers=_auth(token),
+            json=({'on_rankings': True} if i % 2 else {'on_watchlist': True}),
+        )
+
+
+@pytest.mark.parametrize('domain,catalog_path,payload', DOMAINS)
+def test_limit_and_offset_page_the_list(
+    test_client: TestClient, domain, catalog_path, payload
+):
+    token = test_client.first_user.token
+    _seed(test_client, domain, catalog_path, payload, 6)
+    path = f'/v1/users/me/{domain}'
+
+    assert len(test_client.get(path, headers=_auth(token)).json()) == 6
+    assert len(test_client.get(f'{path}?limit=2', headers=_auth(token)).json()) == 2
+    assert (
+        len(test_client.get(f'{path}?limit=10&offset=4', headers=_auth(token)).json())
+        == 2
+    )
+
+
+@pytest.mark.parametrize('domain,catalog_path,payload', DOMAINS)
+def test_list_filters(test_client: TestClient, domain, catalog_path, payload):
+    token = test_client.first_user.token
+    _seed(test_client, domain, catalog_path, payload, 6)
+    path = f'/v1/users/me/{domain}'
+
+    ranked = test_client.get(f'{path}?on_rankings=true', headers=_auth(token)).json()
+    queued = test_client.get(f'{path}?on_watchlist=true', headers=_auth(token)).json()
+    assert len(ranked) == 3
+    assert len(queued) == 3
+    assert all(r['on_rankings'] for r in ranked)
+    assert all(q['on_watchlist'] for q in queued)
+
+
+def test_limit_is_capped_at_max_page(test_client: TestClient):
+    response = test_client.get(
+        f'/v1/users/me/movies?limit={MAX_PAGE + 1}',
+        headers=_auth(test_client.first_user.token),
+    )
+    assert response.status_code == 422
+
+
+def test_tv_list_takes_the_same_params(test_client: TestClient):
+    token = test_client.first_user.token
+    show_id = test_client.post(
+        '/v1/tv-shows',
+        headers=_auth(test_client.admin_user.token),
+        json={'title': 'Show', 'tvmaze': 5001},
+    ).json()['id']
+    test_client.post(
+        f'/v1/users/me/tv-shows/{show_id}',
+        headers=_auth(token),
+        json={'on_watchlist': True},
+    )
+
+    assert (
+        len(
+            test_client.get(
+                '/v1/users/me/tv-shows?on_watchlist=true', headers=_auth(token)
+            ).json()
+        )
+        == 1
+    )
+    assert (
+        test_client.get(
+            '/v1/users/me/tv-shows?on_rankings=true', headers=_auth(token)
+        ).json()
+        == []
+    )

--- a/tests/unit/backfill_rank_base_test.py
+++ b/tests/unit/backfill_rank_base_test.py
@@ -1,0 +1,88 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+from app.db.models_sandbox import DbMovie, DbUserMovie
+from app.migration.backfill_rank_base import run_backfill
+from app.services.shelves import SHELVES
+
+
+def _rank_movies(session, user_pk, ranks):
+    """Give a user one ranked movie per entry in ``ranks``."""
+    for i, rank in enumerate(ranks):
+        movie = DbMovie(title=f'Film {i}', imdb=f'tt900{i}{user_pk}', year=2000)
+        session.add(movie)
+        session.flush()
+        session.add(
+            DbUserMovie(
+                user_id=user_pk,
+                movie_id=movie.pk,
+                rank=rank,
+                on_rankings=True,
+                on_watchlist=False,
+            )
+        )
+    session.commit()
+
+
+def _ranks(session, user_pk):
+    return sorted(
+        r.rank
+        for r in session.query(DbUserMovie).filter(DbUserMovie.user_id == user_pk).all()
+    )
+
+
+def test_shelf_registry_covers_the_four_domains():
+    assert [s.category for s in SHELVES] == ['movies', 'tv', 'books', 'games']
+
+
+def test_zero_based_ranks_are_rebased(test_client):
+    session = test_client.test_db_session
+    user = test_client.first_user
+    _rank_movies(session, user.pk, [0, 1, 2, 3])
+
+    changed = run_backfill(session, email=user.email)
+
+    assert changed == 4
+    assert _ranks(session, user.pk) == [1, 2, 3, 4]
+
+
+def test_backfill_is_idempotent(test_client):
+    session = test_client.test_db_session
+    user = test_client.first_user
+    _rank_movies(session, user.pk, [0, 1, 2])
+
+    run_backfill(session, email=user.email)
+    second = run_backfill(session, email=user.email)
+
+    assert second == 0
+    assert _ranks(session, user.pk) == [1, 2, 3]
+
+
+def test_already_one_based_shelf_is_untouched(test_client):
+    session = test_client.test_db_session
+    user = test_client.first_user
+    _rank_movies(session, user.pk, [1, 2, 3])
+
+    assert run_backfill(session, email=user.email) == 0
+
+    assert _ranks(session, user.pk) == [1, 2, 3]
+
+
+def test_dry_run_changes_nothing(test_client):
+    session = test_client.test_db_session
+    user = test_client.first_user
+    _rank_movies(session, user.pk, [0, 1])
+
+    assert run_backfill(session, email=user.email, dry_run=True) == 2
+
+    assert _ranks(session, user.pk) == [0, 1]
+
+
+def test_only_the_named_user_is_rebased(test_client):
+    session = test_client.test_db_session
+    first, second = test_client.first_user, test_client.second_user
+    _rank_movies(session, first.pk, [0, 1])
+    _rank_movies(session, second.pk, [0, 1])
+
+    run_backfill(session, email=first.email)
+
+    assert _ranks(session, first.pk) == [1, 2]
+    assert _ranks(session, second.pk) == [0, 1]


### PR DESCRIPTION
Backend half of the Top 5 landing page (web PR to follow). Closes the deferred "unpaginated list endpoints" row from `druthers-infra/docs/DATA-STRATEGY.md` §2.

## What & why

Signing in took 5–6s to land on home. The page assembled itself from four **unpaginated** collections — `/v1/users/me/{movies,tv-shows,books,games}`, ~1,400 movie rows ≈400KB per the audit — fetched, Pydantic-validated and shipped so it could render eight counts and twenty titles. The audit had deferred this "until real pressure"; the home page was the pressure.

- **`GET /v1/users/me/summary`** — per-shelf Top 5 + ranked/queued counts in two small indexed queries per shelf. Row count is independent of library size. Carries the account handle and per-shelf `public` flags so the share card can print a URL that actually resolves (see the web PR — the card was 404ing).
- **`app/services/shelves.py`** — the four domains described once; `router_visibility` now reads it instead of its own private tuple.
- **Tracker lists** take `on_rankings` / `on_watchlist` / `limit` / `offset` with a hard `MAX_PAGE` ceiling, and return **413 rather than silently truncating** — a clipped rankings board would look like missing entries.
- **Public profile** shelves bounded to 25 with a `COUNT` for the true total; it's the surface every share-card click lands on.
- **Pool sizing** — explicit `pool_size`/`max_overflow`/`pool_timeout`. SQLAlchemy's implied default of 5 serialised the tail of a fan-out render.
- **Per-request latency logging** + a `Server-Timing` header, so the next round of this is measured rather than inferred.

### Rank re-basing (separate bug, found while building the Top 5)

`orion_import` gives TV's 0-based legacy ranks a `+1`; **movies were imported unadjusted**. A migrated user's best movie is stored as rank `0` and renders as "0" on the public profile and the Top 5, while the API writes 1-based ranks everywhere (`reorder_rankings` enumerates from 1; `RankPlacement` documents a 1-based position).

- Fixes the importer.
- Adds `app/migration/backfill_rank_base.py` for rows already in prod: idempotent, shifts only shelves whose ranks actually start at 0, `--dry-run` undoes its own writes via SAVEPOINT rather than rolling back the caller's transaction.

⚠️ **The backfill mutates prod data — run supervised**, `--dry-run` first.

## How verified

- New `tests/integration/router_summary_test.py` (6) — shelf shape, rank order, counts, the top cap as a ceiling not just a default, per-user isolation, and that `profile_public` matches the rule `/v1/public/{handle}` actually enforces.
- New `tests/integration/router_tracker_paging_test.py` (8, parametrised across movies/books/games + TV) — paging, filters, and the `MAX_PAGE` cap.
- New `tests/unit/backfill_rank_base_test.py` (6) — re-base, idempotency, already-1-based left alone, dry run, per-user scoping.
- Full suite: 269 passed. Black + pylint 10.00. `openapi.json` regenerated.

## Checklist

- [x] Branch named `feat/…`, `fix/…`, or `chore/…`
- [x] CI green (lint + tests)
- [x] No secrets committed
- [x] Docs/README updated if behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)