### PR TITLE
backfill_rank_base: report the target DB and every shelf

### DIFF
--- a/app/migration/backfill_rank_base.py
+++ b/app/migration/backfill_rank_base.py
@@ -28,25 +28,58 @@ import sys
 
 from sqlalchemy import func
 
-from app.db.database import SessionLocal
+from app.config import get_settings
+from app.db.database import SQLALCHEMY_DATABASE_URL, SessionLocal
 from app.db.models import DbUser
 from app.services.shelves import SHELVES
+
+
+def target_description() -> str:
+    """The database this run will touch, with any password masked."""
+    url = SQLALCHEMY_DATABASE_URL
+    if '@' in url:
+        head, tail = url.split('@', 1)
+        url = f'{head.rsplit(":", 1)[0]}:***@{tail}'
+    return f'ENV={get_settings().env}  DB={url}'
+
+
+def _ranked_filter(tracker, user_pk):
+    """The rows a re-base considers: on the rankings list with a position."""
+    return (
+        tracker.user_id == user_pk,
+        tracker.on_rankings.is_(True),
+        tracker.rank.isnot(None),
+    )
+
+
+def shelf_stats(db, shelf, user_pk):
+    """``(lowest_rank, ranked_row_count)`` for one user's shelf."""
+    return (
+        db.query(
+            func.min(shelf.tracker_model.rank),
+            func.count(),  # pylint: disable=not-callable
+        )
+        .select_from(shelf.tracker_model)
+        .filter(*_ranked_filter(shelf.tracker_model, user_pk))
+        .one()
+    )
 
 
 def _shift_shelf(db, shelf, user) -> int:
     """Shift one user's ranks on one shelf up by 1. Returns rows changed."""
     tracker = shelf.tracker_model
-    ranked = (
-        tracker.user_id == user.pk,
-        tracker.on_rankings.is_(True),
-        tracker.rank.isnot(None),
+    lowest, count = shelf_stats(db, shelf, user.pk)
+    # Report every shelf, not just the ones that move — a bare "0 rows" can't
+    # distinguish "already 1-based" from "wrong database" or "no data here".
+    print(
+        f'  {shelf.category:7} ranked={count:5} lowest_rank={lowest} '
+        f'{"-> re-basing" if lowest == 0 else "-> no change"}'
     )
-    lowest = db.query(func.min(tracker.rank)).filter(*ranked).scalar()
     if lowest != 0:
         return 0
     return (
         db.query(tracker)
-        .filter(*ranked)
+        .filter(*_ranked_filter(tracker, user.pk))
         .update({tracker.rank: tracker.rank + 1}, synchronize_session=False)
     )
 
@@ -59,22 +92,21 @@ def run_backfill(db, email: str = None, dry_run: bool = False) -> int:
     the whole transaction, so it can't discard anything the caller had
     pending.
     """
+    print(target_description())
     users = db.query(DbUser)
     if email:
         users = users.filter(DbUser.email == email)
     users = users.all()
     if email and not users:
-        print(f'No user with email {email}', file=sys.stderr)
+        print(f'No user with email {email} on this database', file=sys.stderr)
         return 0
 
     changed = 0
     savepoint = db.begin_nested()
     for user in users:
+        print(f'{user.email} (pk={user.pk}):')
         for shelf in SHELVES:
-            rows = _shift_shelf(db, shelf, user)
-            if rows:
-                changed += rows
-                print(f'{user.email}: {shelf.category} re-based 0 -> 1 ({rows} rows)')
+            changed += _shift_shelf(db, shelf, user)
 
     if dry_run:
         savepoint.rollback()

--- a/tests/unit/backfill_rank_base_test.py
+++ b/tests/unit/backfill_rank_base_test.py
@@ -86,3 +86,26 @@ def test_only_the_named_user_is_rebased(test_client):
 
     assert _ranks(session, first.pk) == [1, 2]
     assert _ranks(session, second.pk) == [0, 1]
+
+
+def test_reports_every_shelf_and_the_target_database(test_client, capsys):
+    """A bare '0 rows' can't be diagnosed — the run must say where it looked."""
+    session = test_client.test_db_session
+    user = test_client.first_user
+    _rank_movies(session, user.pk, [0, 1])
+
+    run_backfill(session, email=user.email, dry_run=True)
+    out = capsys.readouterr().out
+
+    assert 'ENV=' in out and 'DB=' in out
+    assert user.email in out
+    # Every shelf is accounted for, moved or not.
+    for category in ('movies', 'tv', 'books', 'games'):
+        assert category in out
+    assert 'lowest_rank=0 -> re-basing' in out
+    assert 'lowest_rank=None -> no change' in out
+
+
+def test_missing_user_says_so(test_client, capsys):
+    assert run_backfill(test_client.test_db_session, email='nobody@example.com') == 0
+    assert 'No user with email' in capsys.readouterr().err


### PR DESCRIPTION
## What & why

Running the rank re-base against QA printed only `DRY RUN — 0 rows would change`. That single line can't distinguish:

- ranks are already 1-based (nothing to do),
- the process resolved a **different database** than intended (`ENV=local` silently falls back to the local SQLite file even when `DATABASE_URL` is set),
- the `--email` user doesn't exist on that database,
- or nothing is ranked there at all.

A separate read-only probe against the same target showed `movies … min=0` with 1,304 ranked rows — i.e. the condition the backfill exists to catch — so the two runs were almost certainly looking at different databases. The script should have been able to say that itself.

Now it prints the resolved `ENV` and the connection URL (password masked) before doing anything, then one line per shelf with its ranked count and lowest rank, whether or not it moves:

```
ENV=prod  DB=postgresql://phoenix:***@ep-xxx.neon.tech/phoenix
adamleonard9@gmail.com (pk=25):
  movies  ranked= 1304 lowest_rank=0 -> re-basing
  tv      ranked=  249 lowest_rank=1 -> no change
  books   ranked=  194 lowest_rank=1 -> no change
  games   ranked=  156 lowest_rank=1 -> no change
DRY RUN — 1304 rows would change
```

No behaviour change to the re-basing itself — same filters, same idempotency, same SAVEPOINT dry run.

## How verified

- Two new tests in `tests/unit/backfill_rank_base_test.py`: the run names its target database and accounts for all four shelves (moved or not), and a missing user says so on stderr.
- Full suite: 276 passed. Black + pylint 10.00.

## Checklist

- [x] Branch named `feat/…`, `fix/…`, or `chore/…`
- [x] CI green (lint + tests)
- [x] No secrets committed
- [x] Docs/README updated if behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)