### PR TITLE
chore: rebrand refs aleonard.us-* -> druthers-*

### DIFF
--- a/.github/workflows/deploy_cloud_run.yaml
+++ b/.github/workflows/deploy_cloud_run.yaml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       id-token: write
     env:
-      IMAGE: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/druthers/aleonard.us-api:${{ github.event.release.tag_name }}
+      IMAGE: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/druthers/druthers-api:${{ github.event.release.tag_name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/deploy_qa.yaml
+++ b/.github/workflows/deploy_qa.yaml
@@ -1,4 +1,4 @@
-# TEMPLATE — copy to aleonard.us-api/.github/workflows/deploy_qa.yaml
+# TEMPLATE — copy to druthers-api/.github/workflows/deploy_qa.yaml
 name: Deploy to QA
 
 # QA deploys are main-driven (see druthers-infra/docs/PROMOTION.md): every
@@ -24,7 +24,7 @@ jobs:
       contents: read
       id-token: write
     env:
-      IMAGE: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID_QA }}/druthers/aleonard.us-api:main-${{ github.sha }}
+      IMAGE: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID_QA }}/druthers/druthers-api:main-${{ github.sha }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Pylint](https://github.com/ALeonard9/aleonard.us-api/actions/workflows/lint.yaml/badge.svg?branch=main)](https://github.com/ALeonard9/aleonard.us-api/actions/workflows/lint.yaml)
-[![Pytest](https://github.com/ALeonard9/aleonard.us-api/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/ALeonard9/aleonard.us-api/actions/workflows/test.yaml)
-[![Snyk SCA & SAST](https://github.com/ALeonard9/aleonard.us-api/actions/workflows/security_main.yaml/badge.svg?branch=main)](https://github.com/ALeonard9/aleonard.us-api/actions/workflows/security_main.yaml)
+[![Pylint](https://github.com/ALeonard9/druthers-api/actions/workflows/lint.yaml/badge.svg?branch=main)](https://github.com/ALeonard9/druthers-api/actions/workflows/lint.yaml)
+[![Pytest](https://github.com/ALeonard9/druthers-api/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/ALeonard9/druthers-api/actions/workflows/test.yaml)
+[![Snyk SCA & SAST](https://github.com/ALeonard9/druthers-api/actions/workflows/security_main.yaml/badge.svg?branch=main)](https://github.com/ALeonard9/druthers-api/actions/workflows/security_main.yaml)
 
 # aleonard.us API
 
@@ -32,8 +32,8 @@ Personal API for [aleonard.us](https://www.aleonard.us) — a JWT-authenticated 
 ### Local
 
 ```bash
-git clone https://github.com/ALeonard9/aleonard.us-api.git
-cd aleonard.us-api
+git clone https://github.com/ALeonard9/druthers-api.git
+cd druthers-api
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements/dev.txt
 uvicorn app.run:app --reload

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,7 +1,7 @@
 # aleonard.us SDLC (canonical)
 
 Shared software-development lifecycle for all aleonard.us services
-(`aleonard.us-api`, `aleonard.us-web`, `aleonard.us-mcp`, `www.aleonard.us-docker`).
+(`druthers-api`, `druthers-web`, `druthers-mcp`, `www.aleonard.us-docker`).
 Other repos link here instead of duplicating it.
 
 ## Branching — trunk-based

--- a/app/router/v1/router_export.py
+++ b/app/router/v1/router_export.py
@@ -33,7 +33,7 @@ from app.schemas.schemas_sandbox import (
 router = APIRouter(prefix='/v1/users/me/export', tags=['Export'])
 
 # Data-source licenses ride along so exports stay attributable
-# (see aleonard.us-web docs/DATA-SOURCES.md).
+# (see druthers-web docs/DATA-SOURCES.md).
 LICENSES = {
     'movies': 'Movie data from the OMDb API, CC BY-NC 4.0',
     'tv': 'TV data from TVmaze, CC BY-SA 4.0',

--- a/app/services/tracker_rules.py
+++ b/app/services/tracker_rules.py
@@ -1,7 +1,7 @@
 """
 Shared rules for per-user tracker list membership.
 
-The one-home rule (2026-07-18 product decision, aleonard.us-api#145): an item
+The one-home rule (2026-07-18 product decision, druthers-api#145): an item
 lives on exactly one list — Watchlist, To-be-ranked, or Ranked. Moving it to
 one removes it from the others. "To-be-ranked" and "Ranked" are both
 ``on_rankings``; the difference is whether ``rank`` is set.

--- a/dc-prod.yml
+++ b/dc-prod.yml
@@ -13,7 +13,7 @@ services:
       - local_network
   api-prod:
     container_name: ${LZ}_phoenix_api_${ENV}
-    image: ghcr.io/aleonard9/aleonard.us-api:latest
+    image: ghcr.io/aleonard9/druthers-api:latest
     restart: unless-stopped
     env_file:
       - env/${ENV}.env

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -81,7 +81,7 @@ tasks:
   gh:
     desc: "Open project repository in GitHub"
     cmds:
-      - open https://github.com/aleonard9/aleonard.us-api
+      - open https://github.com/aleonard9/druthers-api
     silent: true
 
   test:
@@ -118,12 +118,12 @@ tasks:
           EXTRA_ARG=""
         fi
         # Build the image with the appropriate platform argument
-        docker build $EXTRA_ARG -t ghcr.io/aleonard9/aleonard.us-api:test .
+        docker build $EXTRA_ARG -t ghcr.io/aleonard9/druthers-api:test .
         # Run Snyk container test (no need to pass EXTRA_ARG here)
-        snyk container test ghcr.io/aleonard9/aleonard.us-api:test \
+        snyk container test ghcr.io/aleonard9/druthers-api:test \
           --file=Dockerfile \
           --severity-threshold=high
-        docker rmi ghcr.io/aleonard9/aleonard.us-api:test
+        docker rmi ghcr.io/aleonard9/druthers-api:test
   lz:
     desc: "Echos current landing zone"
     platforms: [darwin]


### PR DESCRIPTION
Mechanical follow-up to the repo rename (`aleonard.us-{api,web,mcp}` -> `druthers-*`). Only the repo/image tokens were replaced; the legacy `www.aleonard.us` domain is left as-is. Non-breaking — image-name changes are internally consistent and WIF bindings for the new names were pre-added in prod + qa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)