### PR TITLE
chore(dx): tests to pre-push, changed-only (testmon)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,6 @@ cython_debug/
 cron/log/*
 database/backup/log/*
 database/data/*
+
+# pytest-testmon (pre-push changed-tests DB)
+.testmondata

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 fail_fast: true
+default_stages: [pre-commit]   # existing hooks run per-commit; tests run pre-push (below)
 
 repos:
 - repo: https://github.com/gitleaks/gitleaks
@@ -38,10 +39,12 @@ repos:
     language: system
     types: [python]
     args: [--ignore=.venv, --disable=too-few-public-methods]
-  - id: pytest
-    name: pytest
-    entry: ./.venv/bin/pytest tests --cov=./ --cov-report=html:.reports/coverage --cov-report=term --html=.reports/junit/test-results.html
+  # Tests run at PRE-PUSH (not per-commit) and only for what changed
+  # (testmon maps coverage -> affected tests). CI runs the full suite.
+  - id: pytest-changed
+    name: pytest (changed only, pre-push)
+    entry: ./.venv/bin/pytest --testmon -q
     language: system
-    types: [python]
+    stages: [pre-push]
     pass_filenames: false
     always_run: true

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,6 +4,7 @@ pytest-asyncio==1.4.0
 pytest-cov==7.1.0
 pytest-html==4.2.0
 pytest-metadata==3.1.1
+pytest-testmon==2.2.0  # pre-push: run only tests affected by changes
 Faker==40.35.0
 httpx==0.28.1
 coverage==7.15.2


### PR DESCRIPTION
pytest off per-commit; runs at pre-push on affected tests only. CI = full-suite gate. Generated with Claude Code