### PR TITLE
Fix API docs: add production server and remove personal contact info

### DIFF
--- a/app/run.py
+++ b/app/run.py
@@ -57,9 +57,8 @@ app = FastAPI(
     ),
     version='0.0.1',
     contact={
-        'name': 'Adam',
+        'name': 'Druthers',
         'url': 'https://www.druthers.io',
-        'email': 'aleonard9@hotmail.com',
     },
     openapi_tags=[
         {'name': 'intro', 'description': 'Welcome message'},
@@ -86,6 +85,7 @@ app = FastAPI(
     ],
     openapi_url='/openapi.json',
     servers=[
+        {'url': 'https://api.druthers.io', 'description': 'Production server'},
         {'url': 'http://localhost:8000', 'description': 'Local server'},
     ],
     license_info={


### PR DESCRIPTION
## Summary
Fixes the API docs at api.druthers.io/docs to include the production server URL and remove personal contact information from the OpenAPI metadata.

## Changes
- Add `https://api.druthers.io` as the primary server in the OpenAPI spec, so "Try it out" works against production from the hosted docs
- Keep `http://localhost:8000` as a secondary entry for local development
- Replace personal contact name "Adam" with "Druthers" and remove the personal email address

## Closes
Closes #176

## Test plan
- [ ] API docs at https://api.druthers.io/docs now show the production server as the default option in the servers dropdown
- [ ] "Try it out" requests work against https://api.druthers.io (requires deployment; manual verification after merge)
- [ ] Localhost server remains available as an alternative for local testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)