### PR TITLE
Cap global search to top 5 per domain, rank best match first

### DIFF
--- a/app/router/v1/router_search.py
+++ b/app/router/v1/router_search.py
@@ -22,6 +22,7 @@ from app.services.book_search import search_books
 from app.services.game_search import search_games
 from app.services.movie_search import search_movies
 from app.services.search_correction import correct_query
+from app.services.search_ranking import rank_and_cap
 from app.services.tracked_status import attach_tracked_status
 from app.services.tv_search import search_tv_shows
 
@@ -67,6 +68,9 @@ def global_search(
 ):
     results = _fan_out(q)
     corrected = None
+    # Track which query actually produced each domain's hits, so ranking
+    # (below) scores against the right string.
+    query_by_domain = dict.fromkeys(results, q)
     # Some providers fuzzy-match and some don't, so retry only the domains
     # that came back empty with a spell-corrected query.
     empty = [name for name, hits in results.items() if not hits]
@@ -77,6 +81,16 @@ def global_search(
             if any(retried.values()):
                 corrected = respelled
                 results.update(retried)
+                for name in empty:
+                    query_by_domain[name] = respelled
+    # Cap to the top DEFAULT_DOMAIN_CAP per domain, best match first (see
+    # search_ranking for the exact/starts-with/contains/provider-order
+    # heuristic), before the tracked-status lookup so it only does DB work
+    # for the results that are actually shown.
+    results = {
+        domain: rank_and_cap(query_by_domain[domain], hits)
+        for domain, hits in results.items()
+    }
     user_pk = current_user[0].pk
     for domain, hits in results.items():
         attach_tracked_status(db, user_pk, hits, domain)

--- a/app/services/search_ranking.py
+++ b/app/services/search_ranking.py
@@ -1,0 +1,73 @@
+"""
+Search-result ranking: cap each domain's hits and surface the best match
+first.
+
+Providers already filter to items relevant to the query, but not
+necessarily in an order that puts the *best* match first — searching
+"Titanic" can bury the 1997 movie under lesser-known or same-named titles,
+same for "Zelda" and incidental matches. We re-rank locally with a simple
+tiered heuristic instead of pulling in a fuzzy-matching library:
+
+    1. exact / near-exact title match (case- and punctuation-insensitive)
+    2. title starts with the query
+    3. title contains the query
+    4. anything else (the provider matched on something other than the
+       title, e.g. an alternate title, author, or its own fuzzy search)
+
+Within a tier, ties are broken by each provider's own result order, which
+doubles as its relevance/popularity signal (TVMaze scores its matches,
+Open Library and IGDB both sort search hits by relevance by default, and
+OMDB returns its closest matches first) — Python's ``sorted`` is stable, so
+that order is preserved automatically. The tiered list is then capped to
+``limit`` per domain so the UI shows a short, best-first list instead of a
+long unranked one.
+"""
+
+import re
+from typing import List
+
+_NORMALIZE_RE = re.compile(r'[^a-z0-9]+')
+
+DEFAULT_DOMAIN_CAP = 5
+
+# Higher is better; see module docstring for what each tier means.
+_TIER_EXACT = 3
+_TIER_STARTS_WITH = 2
+_TIER_CONTAINS = 1
+_TIER_OTHER = 0
+
+
+def _normalize(text: str) -> str:
+    """Lowercase and strip everything but alphanumerics, so 'Spider-Man'
+    and 'spider man' (or 'Spider Man!') compare equal."""
+    return _NORMALIZE_RE.sub('', (text or '').lower())
+
+
+def _tier(query: str, title: str) -> int:
+    """Score how closely ``title`` matches ``query``; see module docstring."""
+    q = _normalize(query)
+    t = _normalize(title)
+    if not q or not t:
+        return _TIER_OTHER
+    if q == t:
+        return _TIER_EXACT
+    if t.startswith(q):
+        return _TIER_STARTS_WITH
+    if q in t:
+        return _TIER_CONTAINS
+    return _TIER_OTHER
+
+
+def rank_and_cap(
+    query: str, results: List[dict], limit: int = DEFAULT_DOMAIN_CAP
+) -> List[dict]:
+    """
+    Sort ``results`` best-match-first (see module docstring for the tiers)
+    and truncate to ``limit``. Safe to call with an empty list.
+    """
+    ranked = sorted(
+        results,
+        key=lambda item: _tier(query, item.get('title') or ''),
+        reverse=True,
+    )
+    return ranked[:limit]

--- a/tests/integration/router_search_test.py
+++ b/tests/integration/router_search_test.py
@@ -60,3 +60,30 @@ def test_failing_provider_does_not_break_search(
     assert resp.status_code == 200
     assert resp.json()['movies'][0]['title'] == 'Jurassic Park'
     assert resp.json()['books'] == []
+
+
+TITANIC_HITS = [
+    {'imdb': 'tt0000001', 'title': 'Raise the Titanic', 'year': '1980'},
+    {'imdb': 'tt0000002', 'title': 'Titanic II', 'year': '2010'},
+    {'imdb': 'tt0000003', 'title': 'The Legend of the Titanic', 'year': '1999'},
+    {'imdb': 'tt0000004', 'title': 'Titanic', 'year': '1997'},
+    {'imdb': 'tt0000005', 'title': 'Titanica', 'year': '1992'},
+    {'imdb': 'tt0000006', 'title': 'Titanic: Blood and Steel', 'year': '2012'},
+]
+
+
+@patch('app.router.v1.router_search.search_books', return_value=[])
+@patch('app.router.v1.router_search.search_games', return_value=[])
+@patch('app.router.v1.router_search.search_tv_shows', return_value=[])
+@patch('app.router.v1.router_search.search_movies', return_value=TITANIC_HITS)
+def test_global_search_ranks_best_match_first_and_caps_to_five(
+    _movies, _tv, _games, _books, test_client: TestClient
+):
+    headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
+    resp = test_client.get('/v1/search?q=Titanic', headers=headers)
+    assert resp.status_code == 200
+    movies = resp.json()['movies']
+    # 6 hits came back from the provider; only the top 5 are returned.
+    assert len(movies) == 5
+    # The exact title match ("Titanic") outranks every partial match.
+    assert movies[0]['title'] == 'Titanic'

--- a/tests/unit/search_ranking_test.py
+++ b/tests/unit/search_ranking_test.py
@@ -1,0 +1,62 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+from app.services.search_ranking import rank_and_cap
+
+
+def test_exact_match_beats_partial_matches():
+    hits = [
+        {'title': 'Titanic II'},
+        {'title': 'Titanic'},
+        {'title': 'Raise the Titanic'},
+    ]
+    ranked = rank_and_cap('Titanic', hits)
+    assert ranked[0]['title'] == 'Titanic'
+
+
+def test_starts_with_beats_contains():
+    hits = [
+        {'title': 'The Legend of Zelda: Anniversary Edition'},
+        {'title': 'Zelda II: The Adventure of Link'},
+    ]
+    ranked = rank_and_cap('Zelda', hits)
+    assert ranked[0]['title'] == 'Zelda II: The Adventure of Link'
+
+
+def test_match_is_case_and_punctuation_insensitive():
+    hits = [{'title': 'Spider-Man'}]
+    ranked = rank_and_cap('spider man', hits)
+    assert ranked[0]['title'] == 'Spider-Man'
+
+
+def test_ties_preserve_provider_order():
+    # Same tier (both "contains") for every item, so the provider's own
+    # relevance/popularity order should be the tiebreaker and survive
+    # unchanged.
+    hits = [
+        {'title': 'Something Else Entirely'},
+        {'title': 'A Whole New World'},
+        {'title': 'Yet Another Unrelated Title'},
+    ]
+    ranked = rank_and_cap('e', hits)
+    assert [r['title'] for r in ranked] == [r['title'] for r in hits]
+
+
+def test_caps_to_limit():
+    hits = [{'title': f'Match {i}'} for i in range(10)]
+    ranked = rank_and_cap('Match', hits)
+    assert len(ranked) == 5
+
+
+def test_caps_to_custom_limit():
+    hits = [{'title': f'Match {i}'} for i in range(10)]
+    ranked = rank_and_cap('Match', hits, limit=3)
+    assert len(ranked) == 3
+
+
+def test_empty_results():
+    assert rank_and_cap('anything', []) == []
+
+
+def test_missing_title_does_not_crash():
+    hits = [{'imdb': 'tt1'}, {'title': 'Real Title', 'imdb': 'tt2'}]
+    ranked = rank_and_cap('Real Title', hits)
+    assert ranked[0]['title'] == 'Real Title'


### PR DESCRIPTION
Closes #177

## Summary
Global search (`GET /v1/search`) now caps each domain (movies, TV, books, games) to at most 5 results and re-ranks them so the most likely match for the query is surfaced first, instead of returning a long, unranked list straight from the provider.

## Ranking heuristic
Implemented in `app/services/search_ranking.py` (`rank_and_cap`), applied per-domain in the router before the tracked-status DB lookup runs (so that lookup only pays for the results actually shown). The heuristic is a simple tiered score, documented inline — no fuzzy-matching library needed:

1. **Exact / near-exact title match** (case- and punctuation-insensitive, e.g. "Spider-Man" == "spider man") — highest tier
2. **Title starts with the query**
3. **Title contains the query**
4. Anything else (provider matched on something other than the title)

Within a tier, ties are broken by the provider's own original result order — that order is each provider's own relevance/popularity signal (TVMaze scores its search matches, Open Library and IGDB both sort search hits by relevance by default, OMDB returns closest matches first), and Python's stable sort preserves it automatically without needing to plumb an extra score field through.

The retry-with-spelling-correction path is also handled correctly: each domain is ranked against whichever query actually produced its hits (the original query, or the corrected one if that domain was retried).

## Testing
- New unit tests in `tests/unit/search_ranking_test.py` covering exact/starts-with/contains tiering, case/punctuation insensitivity, tie-break-by-provider-order, capping (default and custom limit), empty input, and missing-title safety.
- New integration test in `tests/integration/router_search_test.py` verifying `/v1/search` caps a 6-hit movie response to 5 and surfaces the exact "Titanic" match first.
- Full existing test suite passes (285 tests), `black` and `pylint` clean on all changed files.
- Confirmed against `druthers-web`'s `src/app/search/page.tsx` (read-only) that the response shape (`movies`/`tv_shows`/`games`/`books` lists of the same per-item fields) is unchanged — no web changes needed. Note: druthers-web already does its own client-side re-ranking (`lib/similarity.ts`) but doesn't cap the list length, so this server-side cap is what actually bounds the UI to 5 per section.