### PR TITLE
Restrict login to admin and disable new-member signup

### DIFF
--- a/app/auth/authentication.py
+++ b/app/auth/authentication.py
@@ -111,6 +111,20 @@ def google_login(request: GoogleAuthRequest, db: Session = Depends(get_db)):
             detail='Google account email not verified',
         )
 
+    allowlist = settings.oauth_allowlist_emails
+    if allowlist is not None and email.lower() not in allowlist:
+        # Applies to new AND existing accounts — during invite-only phases
+        # (#183) the allowlist is the single source of truth for who may
+        # sign in, not just who may register.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                'This app is invite-only right now. Your Google account '
+                'isn’t on the access list — contact the administrator '
+                'if you believe this is a mistake.'
+            ),
+        )
+
     user = db.query(models.DbUser).filter(models.DbUser.email == email).first()
     if user is None:
         user = models.DbUser(

--- a/app/config.py
+++ b/app/config.py
@@ -7,7 +7,7 @@ All environment-driven settings are read here through a single Pydantic
 """
 
 from functools import lru_cache
-from typing import List, Optional
+from typing import FrozenSet, List, Optional
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -54,6 +54,18 @@ class Settings(BaseSettings):
     rate_limit_search: int = 60  # search-proxy calls per user per minute
     catalog_add_daily_cap: int = 200  # catalog creations per user per day
 
+    # --- Invite-only access (#183) ---
+    # Kill switch for POST /v1/users: closes open password self-registration.
+    # Off by default so local/CI (and any pre-existing deployment) keep
+    # working until an operator opts in per environment.
+    disable_signup: bool = False
+    # Comma-separated email allowlist. Unset = no-op (today's open-Google
+    # behavior). Set = only these addresses may complete ANY Google sign-in
+    # (new account or existing) — everyone else gets a clear invite-only
+    # rejection. Intended for QA/pre-launch: set to just the operator's own
+    # Google account.
+    oauth_allowlist: Optional[str] = None
+
     # --- Observability ---
     loki_url: Optional[str] = None
 
@@ -99,6 +111,24 @@ class Settings(BaseSettings):
     def is_ci(self) -> bool:
         """True when running inside CI (GitHub Actions)."""
         return self.env == 'github'
+
+    @property
+    def oauth_allowlist_emails(self) -> Optional[FrozenSet[str]]:
+        """
+        Parsed, lowercased allowlist, or ``None`` when the feature is off.
+
+        ``None`` (rather than an empty set) is the "not configured" sentinel
+        so callers can distinguish "no restriction" from "restricted to
+        nobody" (an empty/blank ``OAUTH_ALLOWLIST`` is treated as unset).
+        """
+        if not self.oauth_allowlist:
+            return None
+        emails = frozenset(
+            email.strip().lower()
+            for email in self.oauth_allowlist.split(',')
+            if email.strip()
+        )
+        return emails or None
 
 
 @lru_cache

--- a/app/router/v1/user.py
+++ b/app/router/v1/user.py
@@ -2,10 +2,11 @@
 This module contains the API routes for user-related operations.
 """
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.auth.oauth2 import get_current_user
+from app.config import get_settings
 from app.db import db_user
 from app.db.database import get_db
 from app.schemas.model_schemas import InUserBase, OutResponseUserModel
@@ -84,6 +85,14 @@ def create_user(request: InUserBase, db: Session = Depends(get_db)):
     Returns:
         List: OutUserDisplay: The newly created user data.
     """
+    if get_settings().disable_signup:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                'New account registration is closed. This app is '
+                'invite-only — contact the administrator for access.'
+            ),
+        )
     user = db_user.create_user(db, request)
     return OutResponseUserModel(data=user, message='User created')
 

--- a/tests/integration/router_auth_test.py
+++ b/tests/integration/router_auth_test.py
@@ -45,6 +45,85 @@ def test_google_login_rejects_invalid_token(
     assert response.status_code == 401
 
 
+@patch('app.auth.authentication.get_settings')
+@patch('app.auth.authentication.google_id_token.verify_oauth2_token')
+def test_google_login_allows_allowlisted_email(
+    mock_verify, mock_settings, test_client: TestClient
+):
+    """An allowlisted email signs in normally (new-account creation)."""
+    email = f'{fake.user_name()}@gmail.com'
+    mock_settings.return_value = Settings(
+        google_client_id='client-123', env='github', oauth_allowlist=email.upper()
+    )
+    mock_verify.return_value = {
+        'email': email,
+        'email_verified': True,
+        'name': 'Allowed User',
+    }
+    response = test_client.post(
+        '/v1/auth/google', json={'credential': 'fake-google-id-token'}
+    )
+    assert response.status_code == 200
+    assert response.json()['email'] == email
+
+
+@patch('app.auth.authentication.get_settings')
+@patch('app.auth.authentication.google_id_token.verify_oauth2_token')
+def test_google_login_rejects_non_allowlisted_email(
+    mock_verify, mock_settings, test_client: TestClient
+):
+    """
+    #183: when OAUTH_ALLOWLIST is configured, a valid-but-unlisted Google
+    account is rejected with a clear invite-only message rather than being
+    silently signed up — this is the "restrict login / disable new-member
+    signup" gate.
+    """
+    email = f'{fake.user_name()}@gmail.com'
+    mock_settings.return_value = Settings(
+        google_client_id='client-123',
+        env='github',
+        oauth_allowlist='someone-else@example.com',
+    )
+    mock_verify.return_value = {
+        'email': email,
+        'email_verified': True,
+        'name': 'Uninvited User',
+    }
+    response = test_client.post(
+        '/v1/auth/google', json={'credential': 'fake-google-id-token'}
+    )
+    assert response.status_code == 403
+    detail = response.json()['message']
+    assert 'invite-only' in detail.lower()
+
+
+@patch('app.auth.authentication.get_settings')
+@patch('app.auth.authentication.google_id_token.verify_oauth2_token')
+def test_google_login_allowlist_also_blocks_existing_unlisted_account(
+    mock_verify, mock_settings, test_client: TestClient
+):
+    """
+    The allowlist gates sign-in outright, not just first-time registration —
+    an account that already exists in the DB but has since fallen off the
+    allowlist is rejected too.
+    """
+    email = test_client.first_user.email
+    mock_settings.return_value = Settings(
+        google_client_id='client-123',
+        env='github',
+        oauth_allowlist='someone-else@example.com',
+    )
+    mock_verify.return_value = {
+        'email': email,
+        'email_verified': True,
+        'name': 'Existing But Unlisted',
+    }
+    response = test_client.post(
+        '/v1/auth/google', json={'credential': 'fake-google-id-token'}
+    )
+    assert response.status_code == 403
+
+
 def test_api_user_get_token(
     test_client: TestClient,
 ):

--- a/tests/integration/router_user_test.py
+++ b/tests/integration/router_user_test.py
@@ -3,9 +3,12 @@ Tests the user API calls
 """
 
 from typing import Callable
+from unittest.mock import patch
 
 from faker import Faker
 from fastapi.testclient import TestClient
+
+from app.config import Settings
 
 fake = Faker()
 
@@ -35,6 +38,32 @@ def test_api_create_user(
     assert response_data['data'][0]['display_name'] == test_user_data.display_name
     assert response_data['data'][0]['user_group'] == 'user'
     test_assert_timestamps(response_data['data'][0])
+
+
+@patch('app.router.v1.user.get_settings')
+def test_api_create_user_disabled_returns_clear_message(
+    mock_settings,
+    test_client: TestClient,
+    test_user_data_generator: Callable[..., list],
+):
+    """
+    #183: with DISABLE_SIGNUP set, self-registration is rejected with a
+    clear invite-only message instead of silently creating the account.
+    """
+    mock_settings.return_value = Settings(disable_signup=True)
+    user_data_list = test_user_data_generator(num_users=1)
+    test_user_data = user_data_list[0]
+    user_data = {
+        'display_name': test_user_data.display_name,
+        'email': test_user_data.email,
+        'password': test_user_data.password,
+    }
+    response = test_client.post('/v1/users/', json=user_data)
+
+    assert response.status_code == 403
+    response_data = response.json()
+    assert response_data['success'] is False
+    assert 'invite-only' in response_data['message'].lower()
 
 
 def test_api_user_get_user(

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -1,0 +1,27 @@
+'''
+Unit tests for app.config.Settings — focused on the invite-only allowlist
+parsing added for #183 (the rest of Settings is exercised indirectly by
+every other test that calls get_settings()).
+'''
+
+from app.config import Settings
+
+
+def test_oauth_allowlist_emails_unset_is_none():
+    """Unset (default) allowlist means the feature is a no-op."""
+    settings = Settings(oauth_allowlist=None)
+    assert settings.oauth_allowlist_emails is None
+
+
+def test_oauth_allowlist_emails_blank_is_none():
+    """A blank/whitespace-only value is treated the same as unset."""
+    settings = Settings(oauth_allowlist='   ')
+    assert settings.oauth_allowlist_emails is None
+
+
+def test_oauth_allowlist_emails_parses_and_normalizes():
+    """Entries are trimmed and lowercased so comparisons are case-insensitive."""
+    settings = Settings(oauth_allowlist=' Adam@Example.com, second@example.com ,')
+    assert settings.oauth_allowlist_emails == frozenset(
+        {'adam@example.com', 'second@example.com'}
+    )


### PR DESCRIPTION
Closes #183

## Summary

QA/pre-launch is currently open: `POST /v1/users` lets anyone create a password account with no auth at all, and Google sign-in (`POST /v1/auth/google`) auto-creates a new user for *any* verified Google account on first login. This closes both paths behind explicit, off-by-default kill switches:

- **`DISABLE_SIGNUP`** (bool, default `false`) — when `true`, `POST /v1/users` returns `403` with `"New account registration is closed. This app is invite-only — contact the administrator for access."` instead of creating the account.
- **`OAUTH_ALLOWLIST`** (comma-separated emails, default unset) — when set, `POST /v1/auth/google` checks the verified email against the list *before* the find-or-create logic. Anyone not on the list gets a `403` with a clear invite-only message — this applies to brand-new signups **and** to any already-existing account that isn't (or is no longer) on the list, which is what "restrict login to admin" in the issue title actually calls for, not just blocking new registrations.

Both flags default to their current (open) behavior, so local dev, CI, and any environment that doesn't set them are unaffected. Nothing changes until an operator explicitly configures them per environment (same pattern the repo already uses for `DISABLE_PASSWORD_LOGIN` / `RATE_LIMITS_ENABLED`).

## Decision: admin credential mechanism

The issue flagged this as needing a product decision. I did **not** add a new credential system. The repo already has one:

- `create_admin_user()` (`app/db/db_user.py`) seeds a password-based admin account from `ADMIN_DISPLAY_NAME` / `ADMIN_EMAIL` / `ADMIN_PASSWORD` on every startup (`app/run.py`), and
- `POST /v1/auth/token` (`app/auth/authentication.py`) already authenticates that account with a plain email/password — Adam picks the password, so it's already "easy to type."
- The web frontend already renders this as a collapsed "Developer sign-in (local)" form on the login page whenever `NEXT_PUBLIC_APP_ENV !== 'prod'` (`druthers-web/src/app/login/page.tsx`), i.e. it's already visible in QA today. **No druthers-web changes were needed** — I read through the login/signup UI to confirm there's no self-registration form at all (only this password login fallback and the Google button), so the whole "signup path" is a backend-only concern.

Rejected alternative: inventing a second, QA-only auth mechanism (e.g. HTTP basic auth in front of the app). That would add a second credential surface and a second place for Adam to manage secrets, for no real benefit over the admin account that already exists and is already wired end-to-end (token issuance, `require_admin`, frontend form).

## Why the allowlist blocks existing accounts too, not just new signups

The issue title says "restrict login to admin," and the story says "the QA/pre-launch environment isn't open to strangers" — broader than just new-member signup. If I only gated *new* account creation, anyone who happened to sign in via Google before this PR shipped would keep working indefinitely. Gating all Google sign-in against the allowlist means QA access is deterministically "only these emails," full stop, and is trivially auditable by reading one env var.

## What Adam should verify / configure

This can't be exercised against the live QA env from here, so please check:

1. **Set `OAUTH_ALLOWLIST=<your Google account email>` on the QA Cloud Run service.** Until this is set, Google sign-in stays open (today's behavior) — the flag is a no-op unset.
2. **Set `DISABLE_SIGNUP=true` on the QA Cloud Run service** to close `POST /v1/users`.
3. **Do NOT set `DISABLE_PASSWORD_LOGIN=true` on QA** — that would also lock out the admin password login this PR relies on for "easy to type" access. Leave it unset/false there (it's already presumably reserved for prod's Google+API-key-only posture per the existing #148 comment in `app/config.py`).
4. **Confirm `ADMIN_EMAIL`/`ADMIN_PASSWORD`/`ADMIN_DISPLAY_NAME` are set on the QA service** and that `ADMIN_EMAIL` is a password you're comfortable typing — that's your admin login.
5. **Check the QA user table for any pre-existing self-registered accounts.** `POST /v1/users` has been open with no auth since before this PR, so if QA has ever been publicly reachable there could already be rogue accounts in the DB. This PR stops *new* ones but doesn't retroactively clean up existing ones.
6. Once (1) is set, confirm your own Google account is included exactly as it appears in the verified ID token (case doesn't matter — comparison is lowercased) — a typo here would lock you out too.

## Testing

- `pylint` (matching the repo's pre-commit config, `--disable=too-few-public-methods`): 10.00/10 on all changed files.
- `black --skip-string-normalization --check`: clean.
- Full `pytest` suite: 283 passed (added 7 new tests — allowlist allow/deny/existing-account cases, signup-disabled case, and allowlist-parsing unit tests).
- Pre-commit and pre-push hooks (gitleaks, pylint, black, pytest-changed) all passed on commit/push.

## Files changed

- `app/config.py` — `disable_signup`, `oauth_allowlist` settings + `oauth_allowlist_emails` parsed property.
- `app/auth/authentication.py` — allowlist check in `google_login`.
- `app/router/v1/user.py` — `disable_signup` check in `create_user`.
- `tests/unit/config_test.py` (new), `tests/integration/router_auth_test.py`, `tests/integration/router_user_test.py` — coverage for the above.