### PR TITLE
Customer-facing API docs: Postman collection + MCP usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ All endpoints are prefixed with `/v1`; protected routes require `Authorization: 
 | **TV episodes** | `…/tv-shows/{id}/episodes` · `…/users/me/episodes` |
 | **Docs** | `/docs` (Swagger) · `/redoc` · `/openapi.json` |
 
+## Customer-facing docs
+
+- **Postman collection:** [`docs/druthers-api.postman_collection.json`](docs/druthers-api.postman_collection.json)
+  — every route as a ready-to-run request, generated from `openapi.json` by
+  [`scripts/generate_postman_collection.py`](scripts/generate_postman_collection.py).
+  Import it into Postman and set the `apiToken` variable to a personal API key.
+- **MCP usage guide:** [`docs/mcp-usage.md`](docs/mcp-usage.md) — connect
+  Claude Desktop/Code to your Druthers library.
+
+Both are also linked from [druthers.io/developers](https://www.druthers.io/developers).
+
 ## Development
 
 ```bash

--- a/docs/druthers-api.postman_collection.json
+++ b/docs/druthers-api.postman_collection.json
@@ -1,0 +1,3286 @@
+{
+  "info": {
+    "name": "Druthers API",
+    "description": "API for druthers.io \u2014 track and rank the movies, TV, books, and games you actually care about.\n\n---\n\n**Auth:** most requests use the collection-level bearer token \u2014 set the `apiToken` variable to a personal API key (`drk_\u2026`), minted at https://www.druthers.io/settings, or a JWT from `POST /v1/auth/token`. `POST /v1/auth/token` and `POST /v1/users` are marked \"No Auth\" since you don't have a token yet when calling them.\n\n**Base URL:** the `baseUrl` variable defaults to production (`https://api.druthers.io`) \u2014 override it in a Postman environment to point at localhost (`http://localhost:8000`) or QA (`https://api-qa.druthers.io`) instead.\n\nGenerated from the checked-in OpenAPI schema by `scripts/generate_postman_collection.py` \u2014 see `docs/mcp-usage.md` for the MCP (Claude) integration instead of raw HTTP calls.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{apiToken}}",
+        "type": "string"
+      }
+    ]
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "https://api.druthers.io",
+      "type": "string"
+    },
+    {
+      "key": "apiToken",
+      "value": "",
+      "type": "string"
+    }
+  ],
+  "item": [
+    {
+      "name": "API keys",
+      "description": "",
+      "item": [
+        {
+          "name": "Create Api Key",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/api-keys",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "api-keys"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"string\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Mint a new key. The plaintext secret is in this response and nowhere\nelse \u2014 it is never stored or shown again."
+          }
+        },
+        {
+          "name": "List Api Keys",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/api-keys",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "api-keys"
+              ]
+            },
+            "description": "List Api Keys"
+          }
+        },
+        {
+          "name": "Revoke Api Key",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/api-keys/:key_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "api-keys",
+                ":key_id"
+              ],
+              "variable": [
+                {
+                  "key": "key_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Revocation is deletion \u2014 the hash is gone, the key can never auth again."
+          }
+        }
+      ]
+    },
+    {
+      "name": "Activity",
+      "description": "Cross-domain activity log and \"I'm bored\" recommendation",
+      "item": [
+        {
+          "name": "Get Activity",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/activity?category=&limit=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "activity"
+              ],
+              "query": [
+                {
+                  "key": "category",
+                  "value": "",
+                  "description": "",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "Cross-domain \"what have I been up to\" feed, newest first."
+          }
+        },
+        {
+          "name": "Get Bored Pick",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/bored?exclude=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "bored"
+              ],
+              "query": [
+                {
+                  "key": "exclude",
+                  "value": "",
+                  "description": "",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "Randomly pick one item off the user's watchlists/bucket lists, across\nevery domain. ``exclude`` (comma-separated entity ids) lets the client\nre-roll without repeating the item(s) it's already shown."
+          }
+        }
+      ]
+    },
+    {
+      "name": "Books",
+      "description": "Book catalog and per-user tracker",
+      "item": [
+        {
+          "name": "Create Book",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/books",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "books"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"string\",\n  \"isbn\": \"string\",\n  \"googleid\": \"string\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Create Book"
+          }
+        },
+        {
+          "name": "Delete Book",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/books/:book_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "books",
+                ":book_id"
+              ],
+              "variable": [
+                {
+                  "key": "book_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Delete Book"
+          }
+        },
+        {
+          "name": "Get All Books",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/books",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "books"
+              ]
+            },
+            "description": "Get All Books"
+          }
+        },
+        {
+          "name": "Get Book",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/books/:book_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "books",
+                ":book_id"
+              ],
+              "variable": [
+                {
+                  "key": "book_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Return one book's full detail, enriching from Open Library on first view."
+          }
+        },
+        {
+          "name": "Get User Book",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/books/:book_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "books",
+                ":book_id"
+              ],
+              "variable": [
+                {
+                  "key": "book_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Return the current user's tracker for one book (404 if not tracked)."
+          }
+        },
+        {
+          "name": "Get User Books",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/books?on_rankings=&on_watchlist=&limit=&offset=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "books"
+              ],
+              "query": [
+                {
+                  "key": "on_rankings",
+                  "value": "",
+                  "description": "Only ranked entries (true) or only unranked (false)",
+                  "disabled": true
+                },
+                {
+                  "key": "on_watchlist",
+                  "value": "",
+                  "description": "Only queued entries (true) or only unqueued (false)",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "Maximum entries to return",
+                  "disabled": true
+                },
+                {
+                  "key": "offset",
+                  "value": "",
+                  "description": "Entries to skip",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "Get User Books"
+          }
+        },
+        {
+          "name": "Mark Book",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/books/:book_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "books",
+                ":book_id"
+              ],
+              "variable": [
+                {
+                  "key": "book_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"on_watchlist\": true,\n  \"on_rankings\": true,\n  \"rank\": 0,\n  \"completed\": 0,\n  \"notes\": \"string\",\n  \"completed_at\": \"2026-01-01\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Add a book to the user's lists (idempotent \u2014 merges list membership)."
+          }
+        },
+        {
+          "name": "Reorder Rankings",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/books/rankings/order",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "books",
+                "rankings",
+                "order"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"book_ids\": [\n    \"string\"\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Persist a new ranking order (drag-and-drop). Rank = position in the list."
+          }
+        },
+        {
+          "name": "Search Books Endpoint",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/books/search?q=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "books",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "q",
+                  "value": "",
+                  "description": "",
+                  "disabled": false
+                }
+              ]
+            },
+            "description": "Search Books Endpoint"
+          }
+        },
+        {
+          "name": "Set Book Rank",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/books/:book_id/rank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "books",
+                ":book_id",
+                "rank"
+              ],
+              "variable": [
+                {
+                  "key": "book_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"position\": 0\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Place a book at an exact 1-based position in the ranked list, shifting the\nbooks at and below that position down by one. Works for a not-yet-ranked\nbook (jump it in) or an already-ranked one (move it)."
+          }
+        },
+        {
+          "name": "Unmark Book",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/books/:book_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "books",
+                ":book_id"
+              ],
+              "variable": [
+                {
+                  "key": "book_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Unmark Book"
+          }
+        },
+        {
+          "name": "Update Book",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/books/:book_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "books",
+                ":book_id"
+              ],
+              "variable": [
+                {
+                  "key": "book_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"string\",\n  \"isbn\": \"string\",\n  \"googleid\": \"string\",\n  \"poster_url\": \"string\",\n  \"authors\": \"string\",\n  \"year\": 0,\n  \"genre\": \"string\",\n  \"description\": \"string\",\n  \"page_count\": 0,\n  \"rating\": 0,\n  \"language\": \"string\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Update Book"
+          }
+        },
+        {
+          "name": "Update User Book",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/books/:book_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "books",
+                ":book_id"
+              ],
+              "variable": [
+                {
+                  "key": "book_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"on_watchlist\": true,\n  \"on_rankings\": true,\n  \"rank\": 0,\n  \"completed\": 0,\n  \"notes\": \"string\",\n  \"completed_at\": \"2026-01-01\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Update list membership, rank, or notes for a tracked book."
+          }
+        }
+      ]
+    },
+    {
+      "name": "Countries",
+      "description": "Country catalog and per-user tracker",
+      "item": [
+        {
+          "name": "Create Country",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/countries",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "countries"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"string\",\n  \"country_code\": \"string\",\n  \"region\": \"string\",\n  \"subregion\": \"string\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Create Country"
+          }
+        },
+        {
+          "name": "Delete Country",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/countries/:country_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "countries",
+                ":country_id"
+              ],
+              "variable": [
+                {
+                  "key": "country_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Delete Country"
+          }
+        },
+        {
+          "name": "Get All Countries",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/countries",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "countries"
+              ]
+            },
+            "description": "Get All Countries"
+          }
+        },
+        {
+          "name": "Get Country",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/countries/:country_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "countries",
+                ":country_id"
+              ],
+              "variable": [
+                {
+                  "key": "country_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Return one country's detail, enriching from REST Countries on first view."
+          }
+        },
+        {
+          "name": "Get User Countries",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/countries",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "countries"
+              ]
+            },
+            "description": "Get User Countries"
+          }
+        },
+        {
+          "name": "Get User Country",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/countries/:country_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "countries",
+                ":country_id"
+              ],
+              "variable": [
+                {
+                  "key": "country_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Return the current user's tracker for one country (404 if not tracked)."
+          }
+        },
+        {
+          "name": "Mark Country",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/countries/:country_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "countries",
+                ":country_id"
+              ],
+              "variable": [
+                {
+                  "key": "country_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"on_watchlist\": true,\n  \"on_rankings\": true,\n  \"rank\": 0,\n  \"completed\": 0,\n  \"notes\": \"string\",\n  \"first_visited\": \"2026-01-01T00:00:00Z\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Add a country to the user's lists (idempotent \u2014 merges list membership)."
+          }
+        },
+        {
+          "name": "Reorder Rankings",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/countries/rankings/order",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "countries",
+                "rankings",
+                "order"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"country_ids\": [\n    \"string\"\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Persist a new ranking order (drag-and-drop). Rank = position in the list."
+          }
+        },
+        {
+          "name": "Set Country Rank",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/countries/:country_id/rank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "countries",
+                ":country_id",
+                "rank"
+              ],
+              "variable": [
+                {
+                  "key": "country_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"position\": 0\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Place a country at an exact 1-based position in the visited ranking,\nshifting the countries at and below that position down by one."
+          }
+        },
+        {
+          "name": "Sync Countries",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/countries/sync",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "countries",
+                "sync"
+              ]
+            },
+            "description": "Seed/refresh the full world catalog from REST Countries."
+          }
+        },
+        {
+          "name": "Unmark Country",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/countries/:country_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "countries",
+                ":country_id"
+              ],
+              "variable": [
+                {
+                  "key": "country_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Unmark Country"
+          }
+        },
+        {
+          "name": "Update Country",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/countries/:country_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "countries",
+                ":country_id"
+              ],
+              "variable": [
+                {
+                  "key": "country_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"string\",\n  \"country_code\": \"string\",\n  \"region\": \"string\",\n  \"subregion\": \"string\",\n  \"capital\": \"string\",\n  \"population\": 0,\n  \"flag_emoji\": \"string\",\n  \"flag_url\": \"string\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Update Country"
+          }
+        },
+        {
+          "name": "Update User Country",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/countries/:country_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "countries",
+                ":country_id"
+              ],
+              "variable": [
+                {
+                  "key": "country_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"on_watchlist\": true,\n  \"on_rankings\": true,\n  \"rank\": 0,\n  \"completed\": 0,\n  \"notes\": \"string\",\n  \"first_visited\": \"2026-01-01T00:00:00Z\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Update list membership, rank, notes, or first-visited for a country."
+          }
+        }
+      ]
+    },
+    {
+      "name": "Export",
+      "description": "",
+      "item": [
+        {
+          "name": "Export Csv",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/export/{domain}.csv",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "export",
+                "{domain}.csv"
+              ],
+              "variable": [
+                {
+                  "key": "domain",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Spreadsheet-friendly CSV for one domain:\n``movies`` | ``tv-shows`` | ``tv-episodes`` | ``books`` | ``games``."
+          }
+        },
+        {
+          "name": "Export Json",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/export",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "export"
+              ]
+            },
+            "description": "Full-fidelity JSON export of every domain, using the same schemas the\nAPI serves \u2014 anything the UI can show is in here."
+          }
+        }
+      ]
+    },
+    {
+      "name": "Import",
+      "description": "",
+      "item": [
+        {
+          "name": "Import Goodreads",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/import/goodreads",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "import",
+                "goodreads"
+              ]
+            },
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "file",
+                  "value": "string",
+                  "type": "text"
+                }
+              ]
+            },
+            "description": "Upload the standard Goodreads library export CSV. Idempotent \u2014 re-running\nthe same file updates rather than duplicates. Returns counts plus any\nskipped rows with reasons (nothing is dropped silently)."
+          }
+        }
+      ]
+    },
+    {
+      "name": "Movies",
+      "description": "Movie catalog, search, and per-user tracker",
+      "item": [
+        {
+          "name": "Create Movie",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/movies",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "movies"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"string\",\n  \"imdb\": \"string\",\n  \"release_date\": \"2026-01-01T00:00:00Z\",\n  \"rating_imdb\": 0\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Create Movie"
+          }
+        },
+        {
+          "name": "Delete Movie",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/movies/:movie_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "movies",
+                ":movie_id"
+              ],
+              "variable": [
+                {
+                  "key": "movie_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Delete Movie"
+          }
+        },
+        {
+          "name": "Get All Movies",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/movies",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "movies"
+              ]
+            },
+            "description": "Get All Movies"
+          }
+        },
+        {
+          "name": "Get Movie",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/movies/:movie_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "movies",
+                ":movie_id"
+              ],
+              "variable": [
+                {
+                  "key": "movie_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Return one movie's full detail, enriching from OMDB on first view."
+          }
+        },
+        {
+          "name": "Get User Movie",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/movies/:movie_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "movies",
+                ":movie_id"
+              ],
+              "variable": [
+                {
+                  "key": "movie_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Return the current user's tracker for one movie (404 if not tracked)."
+          }
+        },
+        {
+          "name": "Get User Movies",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/movies?on_rankings=&on_watchlist=&limit=&offset=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "movies"
+              ],
+              "query": [
+                {
+                  "key": "on_rankings",
+                  "value": "",
+                  "description": "Only ranked entries (true) or only unranked (false)",
+                  "disabled": true
+                },
+                {
+                  "key": "on_watchlist",
+                  "value": "",
+                  "description": "Only queued entries (true) or only unqueued (false)",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "Maximum entries to return",
+                  "disabled": true
+                },
+                {
+                  "key": "offset",
+                  "value": "",
+                  "description": "Entries to skip",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "Get User Movies"
+          }
+        },
+        {
+          "name": "Mark Movie",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/movies/:movie_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "movies",
+                ":movie_id"
+              ],
+              "variable": [
+                {
+                  "key": "movie_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"on_watchlist\": true,\n  \"on_rankings\": true,\n  \"rank\": 0,\n  \"completed\": 0,\n  \"notes\": \"string\",\n  \"completed_at\": \"2026-01-01\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Add a movie to the user's lists (idempotent \u2014 merges list membership)."
+          }
+        },
+        {
+          "name": "Reorder Rankings",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/movies/rankings/order",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "movies",
+                "rankings",
+                "order"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"movie_ids\": [\n    \"string\"\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Persist a new ranking order (drag-and-drop). Rank = position in the list."
+          }
+        },
+        {
+          "name": "Search Movies Endpoint",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/movies/search?q=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "movies",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "q",
+                  "value": "",
+                  "description": "",
+                  "disabled": false
+                }
+              ]
+            },
+            "description": "Search Movies Endpoint"
+          }
+        },
+        {
+          "name": "Set Movie Rank",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/movies/:movie_id/rank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "movies",
+                ":movie_id",
+                "rank"
+              ],
+              "variable": [
+                {
+                  "key": "movie_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"position\": 0\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Place a movie at an exact 1-based position in the ranked list, shifting the\nmovies at and below that position down by one. Works for a not-yet-ranked\nmovie (jump it in) or an already-ranked one (move it)."
+          }
+        },
+        {
+          "name": "Unmark Movie",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/movies/:movie_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "movies",
+                ":movie_id"
+              ],
+              "variable": [
+                {
+                  "key": "movie_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Unmark Movie"
+          }
+        },
+        {
+          "name": "Update Movie",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/movies/:movie_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "movies",
+                ":movie_id"
+              ],
+              "variable": [
+                {
+                  "key": "movie_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"string\",\n  \"imdb\": \"string\",\n  \"release_date\": \"2026-01-01T00:00:00Z\",\n  \"rating_imdb\": 0,\n  \"runtime\": 0,\n  \"language\": \"string\",\n  \"rated\": \"string\",\n  \"poster_url\": \"string\",\n  \"year\": 0,\n  \"genre\": \"string\",\n  \"director\": \"string\",\n  \"actors\": \"string\",\n  \"plot\": \"string\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Update Movie"
+          }
+        },
+        {
+          "name": "Update User Movie",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/movies/:movie_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "movies",
+                ":movie_id"
+              ],
+              "variable": [
+                {
+                  "key": "movie_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"on_watchlist\": true,\n  \"on_rankings\": true,\n  \"rank\": 0,\n  \"completed\": 0,\n  \"notes\": \"string\",\n  \"completed_at\": \"2026-01-01\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Update list membership, rank, or notes for a tracked movie."
+          }
+        }
+      ]
+    },
+    {
+      "name": "Notifications",
+      "description": "Per-user notification feed",
+      "item": [
+        {
+          "name": "Get Notifications",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/notifications?unread_only=&limit=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "notifications"
+              ],
+              "query": [
+                {
+                  "key": "unread_only",
+                  "value": "",
+                  "description": "",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "Get Notifications"
+          }
+        },
+        {
+          "name": "Get Unread Count",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/notifications/unread-count",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "notifications",
+                "unread-count"
+              ]
+            },
+            "description": "Get Unread Count"
+          }
+        },
+        {
+          "name": "Mark All Read",
+          "request": {
+            "method": "PUT",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/notifications/read-all",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "notifications",
+                "read-all"
+              ]
+            },
+            "description": "Mark All Read"
+          }
+        },
+        {
+          "name": "Mark Read",
+          "request": {
+            "method": "PUT",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/notifications/:notification_id/read",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "notifications",
+                ":notification_id",
+                "read"
+              ],
+              "variable": [
+                {
+                  "key": "notification_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Mark Read"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Search",
+      "description": "Cross-domain global search",
+      "item": [
+        {
+          "name": "Global Search",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/search?q=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "q",
+                  "value": "",
+                  "description": "",
+                  "disabled": false
+                }
+              ]
+            },
+            "description": "Global Search"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Summary",
+      "description": "Home summary \u2014 per-shelf Top 5 and counts",
+      "item": [
+        {
+          "name": "Get Summary",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/summary?top=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "summary"
+              ],
+              "query": [
+                {
+                  "key": "top",
+                  "value": "",
+                  "description": "Entries per shelf",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "Per-shelf Top 5 plus ranked/queued counts for the signed-in user.\n\nReplaces the home page's four full-collection fetches; row count is\nindependent of library size."
+          }
+        }
+      ]
+    },
+    {
+      "name": "TV",
+      "description": "TV shows, episodes, and per-user tracker",
+      "item": [
+        {
+          "name": "Create Episode",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/tv-shows/:show_id/episodes",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "tv-shows",
+                ":show_id",
+                "episodes"
+              ],
+              "variable": [
+                {
+                  "key": "show_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"string\",\n  \"tvmaze\": 0,\n  \"airdate\": \"2026-01-01T00:00:00Z\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Create Episode"
+          }
+        },
+        {
+          "name": "Create Tv Show",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/tv-shows",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "tv-shows"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"string\",\n  \"imdb\": \"string\",\n  \"tvmaze\": 0\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Create Tv Show"
+          }
+        },
+        {
+          "name": "Delete Episode",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/episodes/:episode_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "episodes",
+                ":episode_id"
+              ],
+              "variable": [
+                {
+                  "key": "episode_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Delete Episode"
+          }
+        },
+        {
+          "name": "Delete Tv Show",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/tv-shows/:show_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "tv-shows",
+                ":show_id"
+              ],
+              "variable": [
+                {
+                  "key": "show_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Delete Tv Show"
+          }
+        },
+        {
+          "name": "Get All Episodes",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/tv-shows/:show_id/episodes",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "tv-shows",
+                ":show_id",
+                "episodes"
+              ],
+              "variable": [
+                {
+                  "key": "show_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Get All Episodes"
+          }
+        },
+        {
+          "name": "Get All Tv Shows",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/tv-shows",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "tv-shows"
+              ]
+            },
+            "description": "Get All Tv Shows"
+          }
+        },
+        {
+          "name": "Get Schedule",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/schedule?window_days=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "schedule"
+              ],
+              "query": [
+                {
+                  "key": "window_days",
+                  "value": "",
+                  "description": "",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "What to watch: unwatched episodes airing within +/- ``window_days`` of\ntoday, everything overdue and unwatched (catch-up), and shows the user\nhas frozen (paused tracking on, so they're excluded from both)."
+          }
+        },
+        {
+          "name": "Get Tv Show",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/tv-shows/:show_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "tv-shows",
+                ":show_id"
+              ],
+              "variable": [
+                {
+                  "key": "show_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Return one show's full detail, enriching from TVMaze on first view."
+          }
+        },
+        {
+          "name": "Get User Episodes",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/tv-shows/:show_id/episodes",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "tv-shows",
+                ":show_id",
+                "episodes"
+              ],
+              "variable": [
+                {
+                  "key": "show_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "The current user's episode watch marks for one show."
+          }
+        },
+        {
+          "name": "Get User Tv Show",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/tv-shows/:show_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "tv-shows",
+                ":show_id"
+              ],
+              "variable": [
+                {
+                  "key": "show_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Return the current user's tracker for one show (404 if not tracked)."
+          }
+        },
+        {
+          "name": "Get User Tv Shows",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/tv-shows?on_rankings=&on_watchlist=&limit=&offset=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "tv-shows"
+              ],
+              "query": [
+                {
+                  "key": "on_rankings",
+                  "value": "",
+                  "description": "Only ranked entries (true) or only unranked (false)",
+                  "disabled": true
+                },
+                {
+                  "key": "on_watchlist",
+                  "value": "",
+                  "description": "Only queued entries (true) or only unqueued (false)",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "Maximum entries to return",
+                  "disabled": true
+                },
+                {
+                  "key": "offset",
+                  "value": "",
+                  "description": "Entries to skip",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "Get User Tv Shows"
+          }
+        },
+        {
+          "name": "Mark All Episodes Watched",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/tv-shows/:show_id/episodes/watch-all?season=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "tv-shows",
+                ":show_id",
+                "episodes",
+                "watch-all"
+              ],
+              "query": [
+                {
+                  "key": "season",
+                  "value": "",
+                  "description": "",
+                  "disabled": true
+                }
+              ],
+              "variable": [
+                {
+                  "key": "show_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Mark every episode of a show watched (idempotent), or with ``season``\njust that one season's episodes."
+          }
+        },
+        {
+          "name": "Mark Episode Watched",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/episodes/:episode_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "episodes",
+                ":episode_id"
+              ],
+              "variable": [
+                {
+                  "key": "episode_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Mark an episode watched (idempotent)."
+          }
+        },
+        {
+          "name": "Mark Tv Show",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/tv-shows/:show_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "tv-shows",
+                ":show_id"
+              ],
+              "variable": [
+                {
+                  "key": "show_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"on_watchlist\": true,\n  \"on_rankings\": true,\n  \"rank\": 0,\n  \"notes\": \"string\",\n  \"completed_at\": \"2026-01-01\",\n  \"status\": \"string\",\n  \"freeze\": 0\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Add a show to the user's lists (idempotent \u2014 merges list membership)."
+          }
+        },
+        {
+          "name": "Reorder Rankings",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/tv-shows/rankings/order",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "tv-shows",
+                "rankings",
+                "order"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"show_ids\": [\n    \"string\"\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Persist a new ranking order (drag-and-drop). Rank = position in the list."
+          }
+        },
+        {
+          "name": "Search Tv Shows Endpoint",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/tv-shows/search?q=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "tv-shows",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "q",
+                  "value": "",
+                  "description": "",
+                  "disabled": false
+                }
+              ]
+            },
+            "description": "Search Tv Shows Endpoint"
+          }
+        },
+        {
+          "name": "Set Show Rank",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/tv-shows/:show_id/rank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "tv-shows",
+                ":show_id",
+                "rank"
+              ],
+              "variable": [
+                {
+                  "key": "show_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"position\": 0\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Place a show at an exact 1-based position in the ranked list, shifting the\nshows at and below that position down by one. Works for a not-yet-ranked\nshow (jump it in) or an already-ranked one (move it)."
+          }
+        },
+        {
+          "name": "Sync Show Episodes",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/tv-shows/:show_id/episodes/sync",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "tv-shows",
+                ":show_id",
+                "episodes",
+                "sync"
+              ],
+              "variable": [
+                {
+                  "key": "show_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Refresh the episode list from TVMaze (for ongoing shows)."
+          }
+        },
+        {
+          "name": "Unmark Episode Watched",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/episodes/:episode_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "episodes",
+                ":episode_id"
+              ],
+              "variable": [
+                {
+                  "key": "episode_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Unmark Episode Watched"
+          }
+        },
+        {
+          "name": "Unmark Tv Show",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/tv-shows/:show_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "tv-shows",
+                ":show_id"
+              ],
+              "variable": [
+                {
+                  "key": "show_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Unmark Tv Show"
+          }
+        },
+        {
+          "name": "Update Episode",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/episodes/:episode_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "episodes",
+                ":episode_id"
+              ],
+              "variable": [
+                {
+                  "key": "episode_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"string\",\n  \"tvmaze\": 0,\n  \"airdate\": \"2026-01-01T00:00:00Z\",\n  \"season\": 0,\n  \"season_number\": 0\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Update Episode"
+          }
+        },
+        {
+          "name": "Update Tv Show",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/tv-shows/:show_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "tv-shows",
+                ":show_id"
+              ],
+              "variable": [
+                {
+                  "key": "show_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"string\",\n  \"imdb\": \"string\",\n  \"tvmaze\": 0,\n  \"status\": \"string\",\n  \"poster_url\": \"string\",\n  \"premiered\": \"2026-01-01T00:00:00Z\",\n  \"year\": 0,\n  \"genre\": \"string\",\n  \"network\": \"string\",\n  \"runtime\": 0,\n  \"language\": \"string\",\n  \"rating\": 0,\n  \"summary\": \"string\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Update Tv Show"
+          }
+        },
+        {
+          "name": "Update User Tv Show",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/tv-shows/:show_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "tv-shows",
+                ":show_id"
+              ],
+              "variable": [
+                {
+                  "key": "show_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"on_watchlist\": true,\n  \"on_rankings\": true,\n  \"rank\": 0,\n  \"notes\": \"string\",\n  \"completed_at\": \"2026-01-01\",\n  \"status\": \"string\",\n  \"freeze\": 0\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Update list membership, rank, or notes for a tracked show."
+          }
+        }
+      ]
+    },
+    {
+      "name": "Video Games",
+      "description": "",
+      "item": [
+        {
+          "name": "Create Game",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/games",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "games"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"string\",\n  \"igdb\": 0,\n  \"poster_url\": \"string\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Create Game"
+          }
+        },
+        {
+          "name": "Delete Game",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/games/:game_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "games",
+                ":game_id"
+              ],
+              "variable": [
+                {
+                  "key": "game_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Delete Game"
+          }
+        },
+        {
+          "name": "Get All Games",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/games",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "games"
+              ]
+            },
+            "description": "Get All Games"
+          }
+        },
+        {
+          "name": "Get Game",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/games/:game_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "games",
+                ":game_id"
+              ],
+              "variable": [
+                {
+                  "key": "game_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Return one game's full detail, enriching from IGDB on first view."
+          }
+        },
+        {
+          "name": "Get User Game",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/games/:game_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "games",
+                ":game_id"
+              ],
+              "variable": [
+                {
+                  "key": "game_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Return the current user's tracker for one game (404 if not tracked)."
+          }
+        },
+        {
+          "name": "Get User Games",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/games?on_rankings=&on_watchlist=&limit=&offset=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "games"
+              ],
+              "query": [
+                {
+                  "key": "on_rankings",
+                  "value": "",
+                  "description": "Only ranked entries (true) or only unranked (false)",
+                  "disabled": true
+                },
+                {
+                  "key": "on_watchlist",
+                  "value": "",
+                  "description": "Only queued entries (true) or only unqueued (false)",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "Maximum entries to return",
+                  "disabled": true
+                },
+                {
+                  "key": "offset",
+                  "value": "",
+                  "description": "Entries to skip",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "Get User Games"
+          }
+        },
+        {
+          "name": "Mark Game",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/games/:game_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "games",
+                ":game_id"
+              ],
+              "variable": [
+                {
+                  "key": "game_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"on_watchlist\": true,\n  \"on_rankings\": true,\n  \"rank\": 0,\n  \"completed\": 0,\n  \"notes\": \"string\",\n  \"completed_at\": \"2026-01-01\",\n  \"is_100_percent\": true\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Add a game to the user's lists (idempotent \u2014 merges list membership)."
+          }
+        },
+        {
+          "name": "Reorder Rankings",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/games/rankings/order",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "games",
+                "rankings",
+                "order"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"game_ids\": [\n    \"string\"\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Persist a new ranking order (drag-and-drop). Rank = position in the list."
+          }
+        },
+        {
+          "name": "Search Games Endpoint",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/games/search?q=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "games",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "q",
+                  "value": "",
+                  "description": "",
+                  "disabled": false
+                }
+              ]
+            },
+            "description": "Search Games Endpoint"
+          }
+        },
+        {
+          "name": "Set Game Rank",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/games/:game_id/rank",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "games",
+                ":game_id",
+                "rank"
+              ],
+              "variable": [
+                {
+                  "key": "game_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"position\": 0\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Place a game at an exact 1-based position in the ranked list, shifting the\ngames at and below that position down by one. Works for a not-yet-ranked\ngame (jump it in) or an already-ranked one (move it)."
+          }
+        },
+        {
+          "name": "Unmark Game",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/games/:game_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "games",
+                ":game_id"
+              ],
+              "variable": [
+                {
+                  "key": "game_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Unmark Game"
+          }
+        },
+        {
+          "name": "Update Game",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/games/:game_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "games",
+                ":game_id"
+              ],
+              "variable": [
+                {
+                  "key": "game_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"string\",\n  \"igdb\": 0,\n  \"poster_url\": \"string\",\n  \"release_date\": \"2026-01-01T00:00:00Z\",\n  \"rating\": 0,\n  \"time_to_beat\": 0,\n  \"igdb_last_update\": \"2026-01-01T00:00:00Z\",\n  \"slug\": \"string\",\n  \"year\": 0,\n  \"genre\": \"string\",\n  \"platforms\": \"string\",\n  \"summary\": \"string\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Update Game"
+          }
+        },
+        {
+          "name": "Update User Game",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/games/:game_id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "games",
+                ":game_id"
+              ],
+              "variable": [
+                {
+                  "key": "game_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"on_watchlist\": true,\n  \"on_rankings\": true,\n  \"rank\": 0,\n  \"completed\": 0,\n  \"notes\": \"string\",\n  \"completed_at\": \"2026-01-01\",\n  \"is_100_percent\": true\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Update list membership, rank, notes, or 100% flag for a tracked game."
+          }
+        }
+      ]
+    },
+    {
+      "name": "Visibility",
+      "description": "",
+      "item": [
+        {
+          "name": "Get Visibility",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/visibility",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "visibility"
+              ]
+            },
+            "description": "Get Visibility"
+          }
+        },
+        {
+          "name": "Public Profile",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/public/:handle",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "public",
+                ":handle"
+              ],
+              "variable": [
+                {
+                  "key": "handle",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Read-only public profile: ranked lists of the categories the owner has\nopted in, best first. Fully private profiles (and unknown handles) 404\nidentically, so the endpoint never confirms a private account exists."
+          }
+        },
+        {
+          "name": "Update Visibility",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/me/visibility",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                "me",
+                "visibility"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"handle\": \"string\",\n  \"public_movies\": true,\n  \"public_tv\": true,\n  \"public_books\": true,\n  \"public_games\": true\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Update the handle and/or per-category public flags. Opening any category\nto the public requires a handle (that's the profile URL)."
+          }
+        }
+      ]
+    },
+    {
+      "name": "authentication",
+      "description": "Auth operations",
+      "item": [
+        {
+          "name": "Get Token",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/auth/token",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "auth",
+                "token"
+              ]
+            },
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "grant_type",
+                  "value": "string",
+                  "type": "text"
+                },
+                {
+                  "key": "username",
+                  "value": "string",
+                  "type": "text"
+                },
+                {
+                  "key": "password",
+                  "value": "string",
+                  "type": "text"
+                },
+                {
+                  "key": "scope",
+                  "value": "",
+                  "type": "text"
+                }
+              ]
+            },
+            "description": "Retrieves a JWT token if username (email) and password match\n\nArgs:\n    username: The email of the user\n    password: The password of the user\n\nReturns:\n    Access token",
+            "auth": {
+              "type": "noauth"
+            }
+          }
+        },
+        {
+          "name": "Google Login",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/auth/google",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "auth",
+                "google"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"credential\": \"string\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Sign in with a Google Identity Services ID token.\n\nVerifies the token against the configured Google client id, then upserts the\nuser (creating one on first sign-in) and returns a JWT \u2014 the same shape as\nthe password flow.",
+            "auth": {
+              "type": "noauth"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "intro",
+      "description": "Welcome message",
+      "item": [
+        {
+          "name": "Index",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                ""
+              ]
+            },
+            "description": "Index endpoint that returns a welcome message.",
+            "auth": {
+              "type": "noauth"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "users",
+      "description": "User operations",
+      "item": [
+        {
+          "name": "Create User",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"display_name\": \"string\",\n  \"email\": \"string\",\n  \"password\": \"string\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Create a new user in the database.\n\nArgs:\n    request (InUserBase): Must include email,\n    display_name (max length 16 characters), and password.\n    db (Session): The database session.\n\nReturns:\n    List: OutUserDisplay: The newly created user data.",
+            "auth": {
+              "type": "noauth"
+            }
+          }
+        },
+        {
+          "name": "Delete User",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/:uuid",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                ":uuid"
+              ],
+              "variable": [
+                {
+                  "key": "uuid",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Delete a user by ID from the database.\nAdmins can delete any user, while users can only delete their own account.\n\nArgs:\n    uuid (str): The ID of the user.\n    db (Session): The database session.\n    current_user (dict): The current authenticated user.\n\nReturns:\n    List: OutUserDisplay: The deleted user data."
+          }
+        },
+        {
+          "name": "Get All Users",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users"
+              ]
+            },
+            "description": "Retrieve all users from the database. Must be an admin to view all users.\n\nArgs:\n    db (Session): The database session.\n\nReturns:\n    List: OutUserDisplay: A list of users."
+          }
+        },
+        {
+          "name": "Get User",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/:uuid",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                ":uuid"
+              ],
+              "variable": [
+                {
+                  "key": "uuid",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Retrieve a user by ID from the database.\nAdmins can view all users, while users can only view their own account.\n\nArgs:\n    uuid (str): The ID of the user.\n    db (Session): The database session.\n\nReturns:\n    List: OutUserDisplay: The user data."
+          }
+        },
+        {
+          "name": "Update User",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/users/:uuid",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                ":uuid"
+              ],
+              "variable": [
+                {
+                  "key": "uuid",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"display_name\": \"string\",\n  \"email\": \"string\",\n  \"password\": \"string\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Update a user's information in the database.\nAdmins can update any user, while users can only update their own account.\n\nArgs:\n    uuid (str): The ID of the user.\n    request (InUserBase): The updated user data.\n    db (Session): The database session.\n\nReturns:\n    List: OutUserDisplay: The updated user data."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/docs/mcp-usage.md
+++ b/docs/mcp-usage.md
@@ -1,0 +1,155 @@
+# Using Druthers with Claude (MCP)
+
+[Druthers](https://www.druthers.io) — track and rank the movies, TV shows,
+books, and games you actually care about — has a
+[Model Context Protocol](https://modelcontextprotocol.io) (MCP) server, so you
+can talk to your library from **Claude Desktop** or **Claude Code** instead of
+opening the site: *"add Dune to my watchlist," "mark episode 3 of Severance
+watched," "what have I 100%'d this year?"*
+
+This page is for **end users** connecting their own Druthers account to
+Claude. If you're contributing to the server itself, see the
+[druthers-mcp README](https://github.com/ALeonard9/druthers-mcp) instead.
+
+## What you need
+
+1. A [druthers.io](https://www.druthers.io) account.
+2. A personal **API key** (looks like `drk_…`) — mint one at
+   [www.druthers.io/settings](https://www.druthers.io/settings) → **API
+   keys**, give it a name (e.g. "laptop mcp"), and click **Mint key**. Copy
+   it now; it's shown once.
+3. [Python 3.13+](https://www.python.org/downloads/) installed locally (the
+   MCP server runs on your machine and talks to the Druthers API over HTTPS —
+   your credentials never touch Anthropic's servers).
+4. Claude Desktop or Claude Code.
+
+## 1. Install the server
+
+```bash
+git clone https://github.com/ALeonard9/druthers-mcp.git
+cd druthers-mcp
+python3.13 -m venv .venv && source .venv/bin/activate
+pip install -r requirements/dev.txt
+```
+
+## 2. Connect it to Claude
+
+The server runs over stdio and reads its configuration from environment
+variables — `API_BASE_URL` (the Druthers API) and `API_TOKEN` (your API key).
+
+### Claude Code
+
+```bash
+claude mcp add druthers \
+  -e API_BASE_URL=https://api.druthers.io \
+  -e API_TOKEN=drk_your_key_here \
+  --scope user \
+  -- python -m aleonard_mcp.server
+```
+
+Verify it connected:
+
+```bash
+claude mcp get druthers   # expect "✔ Connected"
+```
+
+### Claude Desktop
+
+Edit your MCP config file:
+
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add a `druthers` entry under `mcpServers` (merge with whatever's already
+there):
+
+```json
+{
+  "mcpServers": {
+    "druthers": {
+      "command": "/absolute/path/to/druthers-mcp/.venv/bin/python",
+      "args": ["-m", "aleonard_mcp.server"],
+      "env": {
+        "API_BASE_URL": "https://api.druthers.io",
+        "API_TOKEN": "drk_your_key_here"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. You should see a small MCP/plug icon indicating
+`druthers` is connected, and Claude will have access to tools named
+`mcp__druthers__*` (or just `druthers` tools, depending on your client's UI).
+
+> Keep your API key out of version control and don't share it — it acts as
+> your Druthers login for API purposes. Revoke a leaked key any time from
+> **Settings → API keys** and mint a fresh one.
+
+## What the tools do
+
+The server exposes a consistent set of verbs across every domain it tracks —
+**movies, TV, books, games** (plus a legacy countries/travel tracker):
+
+| Verb pattern | Example | What it does |
+|---|---|---|
+| `search_*` | `search_movies("dune")` | Look up titles in the external catalog (OMDb/TMDB, TVmaze, Open Library, IGDB) to find the id you need to add something |
+| `add_*` | `add_book(isbn, title)` | Add an item to your library (watchlist/backlog) |
+| `list_my_*` | `list_my_games()` | List everything you're tracking in a domain, with status, rank, and notes |
+| `*_detail` | `movie_detail(id)` | Full metadata for one item — plot, cast, genre, rating, etc. |
+| `mark_*` | `mark_watched(id)` · `mark_episode_watched(id)` · `mark_game_100_percent(id)` | Flip a status (watched, episode watched, 100%-completed) |
+| `set_*_note` | `set_note(id, "loved this")` | Set or replace your personal note on a tracked item |
+| `set_*_completed_date` | `set_completed_date(id, "2026-03-01")` | Set (or clear) the date you finished something |
+
+Full tool list by domain:
+
+- **Movies:** `search_movies`, `list_my_movies`, `movie_detail`, `add_movie`,
+  `mark_watched`, `set_note`, `set_completed_date`
+- **TV:** `search_tv_shows`, `list_my_tv_shows`, `tv_show_detail`,
+  `add_tv_show`, `set_tv_note`, `show_episodes`, `mark_episode_watched`,
+  `set_tv_completed_date`
+- **Books:** `search_books`, `list_my_books`, `book_detail`, `add_book`,
+  `set_book_note`, `set_book_completed_date`
+- **Games:** `search_games`, `list_my_games`, `game_detail`, `add_game`,
+  `set_game_note`, `mark_game_100_percent`, `set_game_completed_date`
+- **Countries** (legacy travel tracker, not part of the current product
+  focus): `list_my_countries`, `mark_country`, `set_country_note`
+
+Every tool acts on **your** account — the API key you configured is the
+authorization for all of it, so there's no separate per-request login step.
+
+## Example prompts
+
+Once connected, you can just talk to Claude naturally:
+
+- *"Search for Dune 2021 and add it to my watchlist."*
+- *"What's on my TV watchlist right now?"*
+- *"Mark Severance season 1 episode 3 as watched."*
+- *"Give Oppenheimer a note: 'best sound design I've heard in a theater.'"*
+- *"What games have I 100%'d?"*
+- *"I finished reading Project Hail Mary yesterday — mark it done."*
+
+Claude will call the relevant tools, ask for confirmation on writes if it's
+unsure which item you mean (there's often a `search_*` step first to resolve
+a title to an id), and report back in plain language.
+
+## Troubleshooting
+
+- **Not connecting:** confirm the `python` path in your config is the venv's
+  interpreter (`.venv/bin/python`), not a system Python missing the
+  dependencies from `pip install -r requirements/dev.txt`.
+- **401 / auth errors:** your `API_TOKEN` is wrong, expired, or was revoked —
+  mint a new one at **Settings → API keys**.
+- **503 on a `search_*` call:** that catalog's external API key isn't
+  configured on the server side (rare — this is a Druthers-side config
+  issue, not yours).
+- **Pointing at a different environment:** set `API_BASE_URL` to
+  `http://127.0.0.1:8000` for a local `druthers-api` checkout, or leave it at
+  `https://api.druthers.io` for production.
+
+## Related
+
+- [Postman collection](./druthers-api.postman_collection.json) — call the
+  same API directly over HTTP, outside of Claude.
+- [druthers-mcp source](https://github.com/ALeonard9/druthers-mcp)
+- [druthers-api source](https://github.com/ALeonard9/druthers-api) (this repo)

--- a/scripts/generate_postman_collection.py
+++ b/scripts/generate_postman_collection.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""
+Generate a Postman Collection v2.1 JSON file from the repo's OpenAPI schema.
+
+Why a hand-rolled converter instead of a third-party package: this is a
+one-off, occasionally-run doc-generation step (not a runtime dependency), and
+the OpenAPI surface here is simple enough (JSON bodies, bearer auth, path/
+query params) that a ~300-line script covers it without adding a new
+dependency to `requirements/`.
+
+Usage:
+    python scripts/generate_postman_collection.py \\
+        [--openapi openapi.json] [--out docs/druthers-api.postman_collection.json]
+
+Re-run this after any change to the API surface (new/changed routes) and
+commit the regenerated file — it is a static, versioned artifact, not
+generated at request time.
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+# Production is the default so the collection works out of the box for a
+# customer who has never run the API locally. Override `baseUrl` in a
+# Postman environment to point at localhost or QA instead.
+DEFAULT_BASE_URL = 'https://api.druthers.io'
+
+# Endpoints that must NOT inherit the collection's bearer-token auth (you
+# don't have a token yet when calling them).
+NO_AUTH_OPERATIONS = {
+    ('post', '/v1/auth/token'),
+    ('post', '/v1/auth/google'),
+    ('post', '/v1/users'),
+    ('get', '/'),
+}
+
+
+def load_schema(path: Path) -> dict:
+    """Load and parse the OpenAPI JSON schema from disk."""
+    with path.open(encoding='utf-8') as f:
+        return json.load(f)
+
+
+def resolve_ref(schema: dict, ref: str) -> dict:
+    """Resolve a local ``#/components/...`` JSON reference."""
+    node: Any = schema
+    for part in ref.lstrip('#/').split('/'):
+        node = node[part]
+    return node
+
+
+# A schema-to-example walker necessarily branches on every JSON Schema/
+# OpenAPI construct it supports (object/array/string/enum/anyOf/$ref/...) —
+# splitting it up would scatter one cohesive concept across several
+# functions for no readability gain.
+# pylint: disable=too-many-return-statements,too-many-branches
+def example_for_schema(
+    schema: dict, root: dict, depth: int = 0, seen: Optional[set] = None
+) -> Any:
+    """
+    Build a small illustrative example value for an OpenAPI schema node.
+
+    Depth-limited and cycle-guarded (via `seen` ref names) so self-referential
+    or deeply nested schemas degrade to `{}`/`null` instead of recursing
+    forever — this only needs to be "good enough to show request shape", not
+    a full example generator.
+    """
+    if seen is None:
+        seen = set()
+    if depth > 6:
+        return None
+
+    if '$ref' in schema:
+        ref = schema['$ref']
+        if ref in seen:
+            return None
+        resolved = resolve_ref(root, ref)
+        return example_for_schema(resolved, root, depth + 1, seen | {ref})
+
+    if 'example' in schema:
+        return schema['example']
+    if schema.get('default') is not None:
+        return schema['default']
+    if 'enum' in schema and schema['enum']:
+        return schema['enum'][0]
+
+    # anyOf/oneOf (commonly Optional[...] in FastAPI) -> first non-null branch
+    for combiner in ('anyOf', 'oneOf'):
+        if combiner in schema:
+            for sub in schema[combiner]:
+                if sub.get('type') == 'null':
+                    continue
+                return example_for_schema(sub, root, depth + 1, seen)
+            return None
+
+    schema_type = schema.get('type')
+    fmt = schema.get('format')
+
+    if schema_type == 'object' or 'properties' in schema:
+        props = schema.get('properties', {})
+        required = set(schema.get('required', []))
+        out = {}
+        for name, sub in props.items():
+            # Keep bodies short and focused: required fields always, a couple
+            # of optional ones for context, so the request is still readable.
+            if required and name not in required and len(out) >= len(required) + 2:
+                continue
+            out[name] = example_for_schema(sub, root, depth + 1, seen)
+        return out
+
+    if schema_type == 'array':
+        item_schema = schema.get('items', {})
+        return [example_for_schema(item_schema, root, depth + 1, seen)]
+
+    if schema_type == 'string':
+        if fmt == 'date-time':
+            return '2026-01-01T00:00:00Z'
+        if fmt == 'date':
+            return '2026-01-01'
+        if fmt == 'email':
+            return 'you@example.com'
+        return 'string'
+    if schema_type == 'integer':
+        return 0
+    if schema_type == 'number':
+        return 0
+    if schema_type == 'boolean':
+        return True
+
+    return None
+
+
+def split_path(path: str) -> list[str]:
+    """``/v1/movies/{movie_id}`` -> ``['v1', 'movies', ':movie_id']``."""
+    segments = []
+    for seg in path.strip('/').split('/'):
+        if seg.startswith('{') and seg.endswith('}'):
+            segments.append(':' + seg[1:-1])
+        else:
+            segments.append(seg)
+    return segments
+
+
+def build_url(path: str, params: list[dict]) -> dict:
+    """Build a Postman `url` object (raw + path segments + variables/query)."""
+    segments = split_path(path)
+    path_params = [p for p in params if p.get('in') == 'path']
+    query_params = [p for p in params if p.get('in') == 'query']
+
+    raw = '{{baseUrl}}/' + '/'.join(segments)
+    query = [
+        {
+            'key': p['name'],
+            'value': str(p.get('schema', {}).get('example', '')),
+            'description': p.get('description', ''),
+            'disabled': not p.get('required', False),
+        }
+        for p in query_params
+    ]
+    if query:
+        raw += '?' + '&'.join(f'{q["key"]}={q["value"]}' for q in query)
+
+    url: dict = {
+        'raw': raw,
+        'host': ['{{baseUrl}}'],
+        'path': segments,
+    }
+    if query:
+        url['query'] = query
+    if path_params:
+        url['variable'] = [
+            {
+                'key': p['name'],
+                'value': '',
+                'description': p.get('description', ''),
+            }
+            for p in path_params
+        ]
+    return url
+
+
+def build_request_body(operation: dict, root: dict) -> Optional[dict]:
+    """Build a Postman `body` object from an operation's requestBody, if any."""
+    request_body = operation.get('requestBody')
+    if not request_body:
+        return None
+    content = request_body.get('content', {})
+
+    if 'application/json' in content:
+        schema = content['application/json'].get('schema', {})
+        example = example_for_schema(schema, root)
+        return {
+            'mode': 'raw',
+            'raw': json.dumps(example, indent=2),
+            'options': {'raw': {'language': 'json'}},
+        }
+
+    if 'application/x-www-form-urlencoded' in content:
+        schema = content['application/x-www-form-urlencoded'].get('schema', {})
+        example = example_for_schema(schema, root) or {}
+        return {
+            'mode': 'urlencoded',
+            'urlencoded': [
+                {'key': k, 'value': str(v) if v is not None else '', 'type': 'text'}
+                for k, v in example.items()
+            ],
+        }
+
+    if 'multipart/form-data' in content:
+        schema = content['multipart/form-data'].get('schema', {})
+        example = example_for_schema(schema, root) or {}
+        return {
+            'mode': 'formdata',
+            'formdata': [
+                {'key': k, 'value': str(v) if v is not None else '', 'type': 'text'}
+                for k, v in example.items()
+            ],
+        }
+
+    return None
+
+
+def build_request(method: str, path: str, operation: dict, root: dict) -> dict:
+    """Build a single Postman collection `item` (one request) for an operation."""
+    params = operation.get('parameters', [])
+    headers = []
+    body = build_request_body(operation, root)
+    if body and body['mode'] == 'raw':
+        headers.append({'key': 'Content-Type', 'value': 'application/json'})
+
+    request: dict = {
+        'method': method.upper(),
+        'header': headers,
+        'url': build_url(path, params),
+    }
+    if body:
+        request['body'] = body
+    if operation.get('description') or operation.get('summary'):
+        request['description'] = operation.get('description') or operation['summary']
+
+    if (method.lower(), path) in NO_AUTH_OPERATIONS:
+        request['auth'] = {'type': 'noauth'}
+
+    item: dict = {
+        'name': operation.get('summary')
+        or operation.get('operationId')
+        or f'{method.upper()} {path}',
+        'request': request,
+    }
+    return item
+
+
+def build_collection(schema: dict) -> dict:
+    """Build the full Postman Collection v2.1 document from an OpenAPI schema."""
+    info = schema.get('info', {})
+    tag_descriptions = {
+        t['name']: t.get('description', '') for t in schema.get('tags', [])
+    }
+
+    folders: dict[str, list[dict]] = {}
+    untagged: list[dict] = []
+
+    for path, methods in schema.get('paths', {}).items():
+        for method, operation in methods.items():
+            if method.lower() not in (
+                'get',
+                'post',
+                'put',
+                'patch',
+                'delete',
+                'options',
+                'head',
+            ):
+                continue
+            item = build_request(method, path, operation, schema)
+            tags = operation.get('tags') or []
+            if tags:
+                folders.setdefault(tags[0], []).append(item)
+            else:
+                untagged.append(item)
+
+    items = []
+    for tag_name in sorted(folders):
+        folder_items = sorted(folders[tag_name], key=lambda it: it['name'])
+        items.append(
+            {
+                'name': tag_name,
+                'description': tag_descriptions.get(tag_name, ''),
+                'item': folder_items,
+            }
+        )
+    items.extend(sorted(untagged, key=lambda it: it['name']))
+
+    description = (
+        (info.get('description') or '')
+        + '\n\n---\n\n'
+        + '**Auth:** most requests use the collection-level bearer token — set '
+        'the `apiToken` variable to a personal API key (`drk_…`), minted at '
+        'https://www.druthers.io/settings, or a JWT from `POST /v1/auth/token`. '
+        '`POST /v1/auth/token` and `POST /v1/users` are marked "No Auth" since '
+        "you don't have a token yet when calling them.\n\n"
+        '**Base URL:** the `baseUrl` variable defaults to production '
+        f'(`{DEFAULT_BASE_URL}`) — override it in a Postman environment to '
+        'point at localhost (`http://localhost:8000`) or QA '
+        '(`https://api-qa.druthers.io`) instead.\n\n'
+        'Generated from the checked-in OpenAPI schema by '
+        '`scripts/generate_postman_collection.py` — see `docs/mcp-usage.md` '
+        'for the MCP (Claude) integration instead of raw HTTP calls.'
+    )
+
+    return {
+        'info': {
+            'name': 'Druthers API',
+            'description': description,
+            'schema': (
+                'https://schema.getpostman.com/json/collection/v2.1.0/'
+                'collection.json'
+            ),
+        },
+        'auth': {
+            'type': 'bearer',
+            'bearer': [{'key': 'token', 'value': '{{apiToken}}', 'type': 'string'}],
+        },
+        'variable': [
+            {'key': 'baseUrl', 'value': DEFAULT_BASE_URL, 'type': 'string'},
+            {'key': 'apiToken', 'value': '', 'type': 'string'},
+        ],
+        'item': items,
+    }
+
+
+def main() -> None:
+    """CLI entry point: read the OpenAPI schema, write the Postman collection."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--openapi', default='openapi.json', type=Path)
+    parser.add_argument(
+        '--out', default='docs/druthers-api.postman_collection.json', type=Path
+    )
+    args = parser.parse_args()
+
+    schema = load_schema(args.openapi)
+    collection = build_collection(schema)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open('w', encoding='utf-8') as f:
+        json.dump(collection, f, indent=2)
+        f.write('\n')
+
+    total_requests = sum(
+        len(folder['item']) if 'item' in folder else 1 for folder in collection['item']
+    )
+    print(
+        f'Wrote {args.out} ({total_requests} requests across {len(collection["item"])} folders)'
+    )
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Closes #166

## Summary

- **Postman collection** (`docs/druthers-api.postman_collection.json`) — Collection v2.1 generated from the live OpenAPI schema (`openapi.json`) by a new one-off script, `scripts/generate_postman_collection.py`. 100 requests grouped into 16 folders by OpenAPI tag, with collection-level bearer auth (`{{apiToken}}`) and a `baseUrl` variable defaulting to production (`https://api.druthers.io`). Two auth-bootstrap endpoints (`POST /v1/auth/token`, `POST /v1/auth/google`) and account creation are marked "No Auth" since you don't have a token yet when calling them.
- **MCP usage guide** (`docs/mcp-usage.md`) — end-user walkthrough for connecting Claude Desktop/Code to the `druthers-mcp` server against production: minting an API key from Settings, registering the server in each client's config, and a tool-by-tool summary across movies/TV/books/games. Distinct from the `druthers-mcp` repo's contributor-facing README.
- **README.md** — new "Customer-facing docs" section linking both, plus the `/developers` page on druthers.io ([druthers-web PR](#) — see below).

## Publishing-location decision

The issue flagged an open question: hosted Postman workspace vs. a static file. I went with **a static, versioned JSON file committed to this repo** rather than standing up a Postman account/workspace:

- No new external dependency (Postman account, team, sync) to keep alive or credential.
- It's regenerable and diffable — re-run the script after any route change and commit the result; drift from the live API is visible in review instead of silently stale in a hosted workspace.
- It's mirrored into `druthers-web/public/downloads/` so it's served directly from `druthers.io` (a stable, first-party URL) rather than depending on a GitHub raw link. That repo's copy is a manual re-sync step, called out in both PRs' descriptions — this repo stays the source of truth.

Tradeoff: no live "Run in Postman" web workspace, and the web-repo copy can drift if someone forgets to re-sync after regenerating. Acceptable for a single-maintainer API at this stage; revisit if the collection needs to be kept current by more than one person.

## Testing

- `pytest -q` — 276 passed
- `pylint` (10.00/10 on the new script) + full `pre-commit run` — all hooks pass
- Verified the regenerated `openapi.json` is byte-identical to the committed one (no drift)
- Spot-checked generated requests (JSON body examples, path variables, form-encoded login, no-auth overrides) by hand