### PR TITLE
Support searching books by ISBN

### DIFF
--- a/app/services/book_search.py
+++ b/app/services/book_search.py
@@ -28,6 +28,10 @@ _SEARCH_FIELDS = (
     'number_of_pages_median,subject,ratings_average,language'
 )
 
+# ISBN-10 (last check digit may be 'X') or ISBN-13, after stripping any
+# hyphens/spaces a user may have typed.
+_ISBN_RE = re.compile(r'^(?:\d{13}|\d{9}[\dXx])$')
+
 
 def _cover(cover_i: Optional[int]) -> Optional[str]:
     return f'{COVERS_URL}/b/id/{cover_i}-L.jpg' if cover_i else None
@@ -52,6 +56,82 @@ def _genre(doc: dict) -> Optional[str]:
     return ', '.join(subjects[:3]) if subjects else None
 
 
+def _bibkeys_authors(data: dict) -> Optional[str]:
+    authors = data.get('authors') or []
+    names = [a.get('name') for a in authors if a.get('name')]
+    return ', '.join(names) if names else None
+
+
+def _bibkeys_year(data: dict) -> Optional[str]:
+    publish_date = data.get('publish_date')
+    if not publish_date:
+        return None
+    match = re.search(r'\d{4}', publish_date)
+    return match.group(0) if match else None
+
+
+def _bibkeys_poster(data: dict) -> Optional[str]:
+    cover = data.get('cover') or {}
+    return cover.get('large') or cover.get('medium') or cover.get('small')
+
+
+def _bibkeys_isbn(data: dict, requested: str) -> str:
+    """Prefer an ISBN-13 from the record's identifiers, falling back to
+    whatever the caller searched for."""
+    identifiers = data.get('identifiers') or {}
+    isbn_13 = identifiers.get('isbn_13') or []
+    isbn_10 = identifiers.get('isbn_10') or []
+    if isbn_13:
+        return isbn_13[0]
+    if isbn_10:
+        return isbn_10[0]
+    return requested
+
+
+def _search_by_isbn(isbn: str) -> List[dict]:
+    """
+    Resolve a single ISBN via Open Library's bibkeys API, which returns
+    title/authors/publish_date/cover in one call (avoiding a second
+    round-trip to resolve author names from a work reference, unlike the
+    ``/isbn/{isbn}.json`` edition endpoint).
+
+    Returns ``[]`` when the ISBN doesn't resolve to a known edition — the
+    same "no matches" shape a title search produces, not an error.
+    """
+    try:
+        response = requests.get(
+            f'{OPENLIBRARY_URL}/api/books',
+            params={
+                'bibkeys': f'ISBN:{isbn}',
+                'format': 'json',
+                'jscmd': 'data',
+            },
+            timeout=REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except (requests.RequestException, ValueError) as exc:
+        logger.error('Open Library ISBN lookup failed for %r: %s', isbn, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Upstream book search failed',
+        ) from exc
+
+    data = payload.get(f'ISBN:{isbn}')
+    if not data:
+        return []
+
+    return [
+        {
+            'isbn': _bibkeys_isbn(data, isbn),
+            'title': data.get('title'),
+            'authors': _bibkeys_authors(data),
+            'year': _bibkeys_year(data),
+            'poster_url': _bibkeys_poster(data),
+        }
+    ]
+
+
 def search_books(query: str) -> List[dict]:
     """
     Search Open Library for books matching ``query``.
@@ -59,6 +139,10 @@ def search_books(query: str) -> List[dict]:
     Returns a list of normalized dicts (``isbn``, ``title``, ``authors``,
     ``year``, ``poster_url``). Raises 400 on an empty query and 502 when the
     upstream call fails.
+
+    When ``query`` looks like an ISBN (10 or 13 digits, optionally
+    hyphenated), it's resolved directly via Open Library's ISBN lookup
+    instead of a title search.
     """
     query = (query or '').strip()
     if not query:
@@ -66,6 +150,10 @@ def search_books(query: str) -> List[dict]:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail='Search query must not be empty',
         )
+
+    normalized_isbn = re.sub(r'[-\s]', '', query)
+    if _ISBN_RE.match(normalized_isbn):
+        return _search_by_isbn(normalized_isbn)
 
     try:
         response = requests.get(

--- a/tests/unit/book_search_test.py
+++ b/tests/unit/book_search_test.py
@@ -88,3 +88,101 @@ def test_work_description_unwraps_dict():
         mock_get.return_value = resp
         assert book_search._work_description('/works/OL1W') == 'Nested text.'
     assert book_search._work_description(None) is None
+
+
+_BIBKEYS_PAYLOAD = {
+    'ISBN:9780441172719': {
+        'title': 'Dune',
+        'authors': [{'name': 'Frank Herbert'}],
+        'publish_date': 'August 3, 1990',
+        'identifiers': {
+            'isbn_10': ['0441172717'],
+            'isbn_13': ['9780441172719'],
+        },
+        'cover': {
+            'small': 'https://covers.openlibrary.org/b/id/1-S.jpg',
+            'medium': 'https://covers.openlibrary.org/b/id/1-M.jpg',
+            'large': 'https://covers.openlibrary.org/b/id/1-L.jpg',
+        },
+    }
+}
+
+
+@patch('app.services.book_search.requests.get')
+def test_search_books_hyphenated_isbn_resolves_via_bibkeys(mock_get):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = _BIBKEYS_PAYLOAD
+    mock_get.return_value = resp
+
+    results = book_search.search_books('978-0-441-17271-9')
+
+    assert results == [
+        {
+            'isbn': '9780441172719',
+            'title': 'Dune',
+            'authors': 'Frank Herbert',
+            'year': '1990',
+            'poster_url': 'https://covers.openlibrary.org/b/id/1-L.jpg',
+        }
+    ]
+    args, kwargs = mock_get.call_args
+    assert args[0] == 'https://openlibrary.org/api/books'
+    assert kwargs['params']['bibkeys'] == 'ISBN:9780441172719'
+
+
+@patch('app.services.book_search.requests.get')
+def test_search_books_bare_isbn_resolves_via_bibkeys(mock_get):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = _BIBKEYS_PAYLOAD
+    mock_get.return_value = resp
+
+    results = book_search.search_books('9780441172719')
+
+    assert len(results) == 1
+    assert results[0]['isbn'] == '9780441172719'
+    assert results[0]['title'] == 'Dune'
+
+
+@patch('app.services.book_search.requests.get')
+def test_search_books_unknown_isbn_returns_empty_list(mock_get):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {}
+    mock_get.return_value = resp
+
+    assert not book_search.search_books('0000000000')
+
+
+@patch('app.services.book_search.requests.get')
+def test_search_books_title_query_unaffected(mock_get):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {
+        'docs': [
+            {
+                'title': 'Dune',
+                'author_name': ['Frank Herbert'],
+                'first_publish_year': 1965,
+                'isbn': ['9780441172719'],
+                'cover_i': 11481354,
+            }
+        ]
+    }
+    mock_get.return_value = resp
+
+    results = book_search.search_books('Dune')
+
+    assert results == [
+        {
+            'isbn': '9780441172719',
+            'title': 'Dune',
+            'authors': 'Frank Herbert',
+            'year': '1965',
+            'poster_url': 'https://covers.openlibrary.org/b/id/11481354-L.jpg',
+        }
+    ]
+    args, kwargs = mock_get.call_args
+    assert args[0] == 'https://openlibrary.org/search.json'
+    assert kwargs['params']['q'] == 'Dune'


### PR DESCRIPTION
Closes #212

Adds ISBN-aware search to `search_books`: when the query looks like an ISBN (10 or 13 digits, optionally hyphenated, with ISBN-10 allowed to end in `X`), it's resolved directly via Open Library's bibkeys API (`GET /api/books?bibkeys=ISBN:{isbn}&format=json&jscmd=data`) rather than a title search.

**Why bibkeys over `/isbn/{isbn}.json`:** the bibkeys endpoint returns title, authors, publish_date, and cover in a single response, whereas the edition endpoint (`/isbn/{isbn}.json`) only gives a `works` reference and would need a second round-trip to resolve author names.

The resolved record is normalized into the exact same shape a title-search hit produces (`isbn`, `title`, `authors`, `year`, `poster_url`), so it flows through the existing add-book UI unchanged. An ISBN with no match returns `[]`, matching how a no-results title search behaves — no error surfaced to the caller. Ordinary title queries are untouched; only the new ISBN-shaped branch changes behavior.

## Testing
- Added unit tests: hyphenated ISBN query, bare-digit ISBN query, unknown ISBN → `[]`, and a regression test confirming ordinary title queries still hit `search.json` unaffected.
- `pytest` (full suite): 280 passed
- `pylint`: 10.00/10
- `black --skip-string-normalization --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxmbQ24fx8uW4wnRotTw6w