### PR TITLE
Support searching TV shows by IMDb ID or TheTVDB ID

### DIFF
--- a/app/services/tv_search.py
+++ b/app/services/tv_search.py
@@ -50,9 +50,68 @@ def _network_name(show: dict) -> Optional[str]:
     return network.get('name')
 
 
+def _normalize_show(show: dict) -> dict:
+    """Map a raw TVMaze show object to the shape callers expect."""
+    premiered = show.get('premiered') or ''
+    return {
+        'tvmaze': show.get('id'),
+        'imdb': (show.get('externals') or {}).get('imdb'),
+        'title': show.get('name'),
+        'year': premiered[:4] or None,
+        'status': show.get('status'),
+        'network': _network_name(show),
+        'poster_url': _poster(show),
+    }
+
+
+# Bare-digit query -> IMDb-style ``tt1234567`` is unambiguous, but a run of
+# plain digits is not: it could be a TheTVDB id or a numeric show title
+# ("1923", "24", "9-1-1" minus the dashes). TheTVDB ids for anything catalogued
+# in roughly the last decade run 5+ digits, so we only treat a 5+ digit query
+# as an id lookup; shorter numeric queries fall through to a normal title
+# search. This is a heuristic, not a guarantee -- see #210.
+_IMDB_ID_RE = re.compile(r'tt\d+', re.IGNORECASE)
+_MIN_THETVDB_ID_DIGITS = 5
+
+
+def _lookup_show(params: dict) -> List[dict]:
+    """
+    Resolve a single show via TVMaze's ``/lookup/shows`` endpoint (exact
+    match by external id). Returns ``[]`` when TVMaze has no match (404)
+    rather than treating that as an error; raises 502 on other upstream
+    failures.
+    """
+    try:
+        response = requests.get(
+            f'{TVMAZE_URL}/lookup/shows',
+            params=params,
+            timeout=REQUEST_TIMEOUT,
+        )
+        if response.status_code == 404:
+            return []
+        response.raise_for_status()
+        payload = response.json()
+    except (requests.RequestException, ValueError) as exc:
+        logger.error('TVMaze lookup failed for %r: %s', params, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Upstream TV search failed',
+        ) from exc
+
+    if not payload:
+        return []
+    return [_normalize_show(payload)]
+
+
 def search_tv_shows(query: str) -> List[dict]:
     """
     Search TVMaze for shows matching ``query``.
+
+    A query shaped like an IMDb id (``tt`` + digits) or a run of 5+ digits
+    (treated as a TheTVDB id) resolves directly via TVMaze's
+    ``/lookup/shows`` endpoint instead of a title search; an id-shaped query
+    that doesn't resolve returns ``[]`` rather than raising. Ordinary title
+    queries are unaffected.
 
     Returns a list of normalized dicts (``tvmaze``, ``imdb``, ``title``,
     ``year``, ``status``, ``network``, ``poster_url``). Raises 400 on an
@@ -64,6 +123,12 @@ def search_tv_shows(query: str) -> List[dict]:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail='Search query must not be empty',
         )
+
+    if _IMDB_ID_RE.fullmatch(query):
+        return _lookup_show({'imdb': query.lower()})
+
+    if query.isdigit() and len(query) >= _MIN_THETVDB_ID_DIGITS:
+        return _lookup_show({'thetvdb': query})
 
     try:
         response = requests.get(
@@ -83,18 +148,7 @@ def search_tv_shows(query: str) -> List[dict]:
     results = []
     for item in payload or []:
         show = item.get('show') or {}
-        premiered = show.get('premiered') or ''
-        results.append(
-            {
-                'tvmaze': show.get('id'),
-                'imdb': (show.get('externals') or {}).get('imdb'),
-                'title': show.get('name'),
-                'year': premiered[:4] or None,
-                'status': show.get('status'),
-                'network': _network_name(show),
-                'poster_url': _poster(show),
-            }
-        )
+        results.append(_normalize_show(show))
     return results
 
 

--- a/tests/unit/tv_search_test.py
+++ b/tests/unit/tv_search_test.py
@@ -100,3 +100,127 @@ def test_get_show_episodes_normalizes(mock_get):
 
 def test_get_show_episodes_without_id_returns_empty():
     assert not tv_search.get_show_episodes(None)
+
+
+def _tvmaze_show(**overrides):
+    show = {
+        'id': 44932,
+        'name': 'Severance',
+        'status': 'Running',
+        'premiered': '2022-02-18',
+        'network': {'name': 'Apple TV+'},
+        'externals': {'imdb': 'tt11280740'},
+        'image': {'medium': 'https://x/m.jpg', 'original': 'https://x/o.jpg'},
+    }
+    show.update(overrides)
+    return show
+
+
+@patch('app.services.tv_search.requests.get')
+def test_search_tv_shows_imdb_id_uses_lookup(mock_get):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = _tvmaze_show()
+    mock_get.return_value = resp
+
+    results = tv_search.search_tv_shows('tt11280740')
+
+    mock_get.assert_called_once_with(
+        'https://api.tvmaze.com/lookup/shows',
+        params={'imdb': 'tt11280740'},
+        timeout=tv_search.REQUEST_TIMEOUT,
+    )
+    assert len(results) == 1
+    assert results[0] == {
+        'tvmaze': 44932,
+        'imdb': 'tt11280740',
+        'title': 'Severance',
+        'year': '2022',
+        'status': 'Running',
+        'network': 'Apple TV+',
+        'poster_url': 'https://x/o.jpg',
+    }
+
+
+@patch('app.services.tv_search.requests.get')
+def test_search_tv_shows_imdb_id_is_case_insensitive(mock_get):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = _tvmaze_show()
+    mock_get.return_value = resp
+
+    tv_search.search_tv_shows('TT11280740')
+
+    mock_get.assert_called_once_with(
+        'https://api.tvmaze.com/lookup/shows',
+        params={'imdb': 'tt11280740'},
+        timeout=tv_search.REQUEST_TIMEOUT,
+    )
+
+
+@patch('app.services.tv_search.requests.get')
+def test_search_tv_shows_thetvdb_id_uses_lookup(mock_get):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = _tvmaze_show()
+    mock_get.return_value = resp
+
+    results = tv_search.search_tv_shows('281588')
+
+    mock_get.assert_called_once_with(
+        'https://api.tvmaze.com/lookup/shows',
+        params={'thetvdb': '281588'},
+        timeout=tv_search.REQUEST_TIMEOUT,
+    )
+    assert results[0]['title'] == 'Severance'
+
+
+@patch('app.services.tv_search.requests.get')
+def test_search_tv_shows_unknown_id_returns_empty_list(mock_get):
+    resp = MagicMock()
+    resp.status_code = 404
+    mock_get.return_value = resp
+
+    assert not tv_search.search_tv_shows('tt00000000')
+    assert not tv_search.search_tv_shows('999999')
+
+
+@patch('app.services.tv_search.requests.get')
+def test_search_tv_shows_short_numeric_query_falls_back_to_title_search(
+    mock_get,
+):
+    """A 4-digit numeric query (e.g. the show "1923") is treated as a title,
+    not a TheTVDB id -- avoids the common short-numeric-title collision."""
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = [{'show': _tvmaze_show(name='1923')}]
+    mock_get.return_value = resp
+
+    results = tv_search.search_tv_shows('1923')
+
+    mock_get.assert_called_once_with(
+        'https://api.tvmaze.com/search/shows',
+        params={'q': '1923'},
+        timeout=tv_search.REQUEST_TIMEOUT,
+    )
+    assert results[0]['title'] == '1923'
+
+
+@patch('app.services.tv_search.requests.get')
+def test_search_tv_shows_ordinary_title_query_unaffected(mock_get):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = [{'show': _tvmaze_show()}]
+    mock_get.return_value = resp
+
+    results = tv_search.search_tv_shows('Severance')
+
+    mock_get.assert_called_once_with(
+        'https://api.tvmaze.com/search/shows',
+        params={'q': 'Severance'},
+        timeout=tv_search.REQUEST_TIMEOUT,
+    )
+    assert results[0]['title'] == 'Severance'


### PR DESCRIPTION
Closes #210

## Summary
`search_tv_shows(query)` now detects id-shaped queries and resolves them directly via TVMaze's `/lookup/shows` endpoint instead of a title search:

- **IMDb ID** — a query matching `tt\d+` (case-insensitive) resolves via `/lookup/shows?imdb=<id>`.
- **TheTVDB ID** — a bare numeric query resolves via `/lookup/shows?thetvdb=<id>`, but only when it's 5+ digits (see disambiguation note below).
- Both paths reuse the same `_normalize_show` mapping as the existing `/search/shows` path, so lookup hits come back with the identical dict shape (`tvmaze`, `imdb`, `title`, `year`, `status`, `network`, `poster_url`) and flow through the add-show UI unchanged.
- A 404 from `/lookup/shows` (id doesn't resolve) returns `[]`, not an error; other upstream failures still raise 502, matching the existing title-search behavior.
- Ordinary title queries (including short numeric titles) are untouched and still hit `/search/shows`.

## Numeric-TheTVDB-id vs numeric-title ambiguity
IMDb ids are unambiguous (`tt` prefix), but a bare numeric TheTVDB id is indistinguishable from a numeric show title (e.g. "1923", "24") by shape alone. TheTVDB ids for anything catalogued in roughly the last decade run 5+ digits, so this PR only treats a **5+ digit** all-numeric query as an id lookup; anything shorter (1-4 digits) falls through to the normal title search. This means:
- A search for "1923" or "24" still does a title search, as expected.
- A very old/low-numbered TheTVDB id (fewer than 5 digits) won't be picked up as an id — it'll instead be treated as a (likely fruitless) title search. This is an accepted, documented tradeoff per the issue rather than a blocker; the threshold is a single named constant (`_MIN_THETVDB_ID_DIGITS`) if it ever needs tuning.

## Tests
Added to `tests/unit/tv_search_test.py`:
- IMDb-ID query resolves via `/lookup/shows?imdb=` (including case-insensitivity)
- TheTVDB-ID query resolves via `/lookup/shows?thetvdb=`
- Unknown/unresolvable id (404) returns `[]` for both id shapes
- Short numeric query ("1923") still falls back to title search
- Ordinary title query is unaffected

## Verification
- `pytest` — full suite passes (282 passed)
- `pylint` — 10.00/10 on changed files
- `black --skip-string-normalization --check` — clean