### PR TITLE
feat(games): support searching by IGDB id

### DIFF
--- a/app/services/game_search.py
+++ b/app/services/game_search.py
@@ -125,13 +125,55 @@ def _names(game: dict, key: str, name_key: str = 'name') -> Optional[str]:
     return ', '.join(names) if names else None
 
 
+_SEARCH_FIELDS = 'name,slug,first_release_date,platforms.abbreviation,cover.image_id'
+
+
+def _search_hit(game: dict) -> dict:
+    """Normalize a raw IGDB game record into the search-hit shape."""
+    release = _release(game)
+    return {
+        'igdb': game.get('id'),
+        'title': game.get('name'),
+        'slug': game.get('slug'),
+        'year': str(release.year) if release else None,
+        'platforms': _names(game, 'platforms', 'abbreviation'),
+        'poster_url': _cover(game),
+    }
+
+
+def _search_games_by_id(igdb_id: int) -> List[dict]:
+    """
+    Look up a single game by IGDB id and return it in the search-hit shape.
+
+    Returns an empty list when the id doesn't resolve to a game, matching
+    the empty-result behavior of a title search with no matches.
+    """
+    try:
+        payload = _igdb_query(
+            'games',
+            f'fields {_SEARCH_FIELDS}; where id = {igdb_id};',
+        )
+    except (requests.RequestException, ValueError) as exc:
+        logger.error('IGDB id lookup failed for %s: %s', igdb_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Upstream game search failed',
+        ) from exc
+
+    if not payload:
+        return []
+    return [_search_hit(payload[0])]
+
+
 def search_games(query: str) -> List[dict]:
     """
     Search IGDB for games matching ``query``.
 
-    Returns a list of normalized dicts (``igdb``, ``title``, ``year``,
-    ``platforms``, ``poster_url``). Raises 400 on an empty query, 503 when
-    unconfigured, and 502 when the upstream call fails.
+    A bare-numeric query is treated as an IGDB id and resolved directly via
+    ``where id = <id>`` instead of a fuzzy title search. Returns a list of
+    normalized dicts (``igdb``, ``title``, ``year``, ``platforms``,
+    ``poster_url``). Raises 400 on an empty query, 503 when unconfigured,
+    and 502 when the upstream call fails.
     """
     query = (query or '').strip()
     if not query:
@@ -140,14 +182,16 @@ def search_games(query: str) -> List[dict]:
             detail='Search query must not be empty',
         )
 
+    if query.isdigit():
+        return _search_games_by_id(int(query))
+
     # Escape backslashes first, then quotes — otherwise a trailing backslash
     # (or crafted \" sequence) breaks out of the APIcalypse string literal.
     escaped = query.replace('\\', '\\\\').replace('"', '\\"')
     try:
         payload = _igdb_query(
             'games',
-            f'search "{escaped}"; fields name,slug,first_release_date,'
-            'platforms.abbreviation,cover.image_id; limit 20;',
+            f'search "{escaped}"; fields {_SEARCH_FIELDS}; limit 20;',
         )
     except (requests.RequestException, ValueError) as exc:
         # HTTPExceptions from _igdb_query (503 unconfigured / 502 auth)
@@ -158,20 +202,7 @@ def search_games(query: str) -> List[dict]:
             detail='Upstream game search failed',
         ) from exc
 
-    results = []
-    for game in payload:
-        release = _release(game)
-        results.append(
-            {
-                'igdb': game.get('id'),
-                'title': game.get('name'),
-                'slug': game.get('slug'),
-                'year': str(release.year) if release else None,
-                'platforms': _names(game, 'platforms', 'abbreviation'),
-                'poster_url': _cover(game),
-            }
-        )
-    return results
+    return [_search_hit(game) for game in payload]
 
 
 # Max lengths for the bounded catalog columns (see models_sandbox.DbVideoGame).

--- a/tests/unit/game_search_test.py
+++ b/tests/unit/game_search_test.py
@@ -102,6 +102,89 @@ def test_search_games_returns_results(mock_post, mock_settings):
 
 @patch('app.services.game_search.get_settings')
 @patch('app.services.game_search.requests.post')
+def test_search_games_numeric_query_resolves_by_id(mock_post, mock_settings):
+    _reset_token_cache()
+    mock_settings.return_value = Settings(
+        twitch_client_id='cid', twitch_client_secret='secret', env='github'
+    )
+    token_resp = MagicMock()
+    token_resp.raise_for_status.return_value = None
+    token_resp.json.return_value = {'access_token': 'tok', 'expires_in': 5000000}
+    id_resp = MagicMock()
+    id_resp.raise_for_status.return_value = None
+    id_resp.json.return_value = [
+        {
+            'id': 1234,
+            'name': 'The Legend of Zelda: Breath of the Wild',
+            'slug': 'the-legend-of-zelda-breath-of-the-wild',
+            'first_release_date': 1488499200,
+            'platforms': [{'abbreviation': 'Switch'}, {'abbreviation': 'WiiU'}],
+            'cover': {'image_id': 'co3p2d'},
+        }
+    ]
+    mock_post.side_effect = [token_resp, id_resp]
+
+    results = game_search.search_games('1234')
+
+    assert len(results) == 1
+    assert results[0]['igdb'] == 1234
+    assert results[0]['title'] == 'The Legend of Zelda: Breath of the Wild'
+    assert results[0]['slug'] == 'the-legend-of-zelda-breath-of-the-wild'
+    assert results[0]['year'] == '2017'
+    assert results[0]['platforms'] == 'Switch, WiiU'
+    assert results[0]['poster_url'].endswith('/co3p2d.jpg')
+
+    # The games query used a direct id lookup, not a fuzzy title search.
+    games_call = mock_post.call_args_list[1]
+    assert 'where id = 1234' in games_call.kwargs['data']
+    assert 'search ' not in games_call.kwargs['data']
+    _reset_token_cache()
+
+
+@patch('app.services.game_search.get_settings')
+@patch('app.services.game_search.requests.post')
+def test_search_games_numeric_query_unknown_id_returns_empty(mock_post, mock_settings):
+    _reset_token_cache()
+    mock_settings.return_value = Settings(
+        twitch_client_id='cid', twitch_client_secret='secret', env='github'
+    )
+    token_resp = MagicMock()
+    token_resp.raise_for_status.return_value = None
+    token_resp.json.return_value = {'access_token': 'tok', 'expires_in': 5000000}
+    id_resp = MagicMock()
+    id_resp.raise_for_status.return_value = None
+    id_resp.json.return_value = []
+    mock_post.side_effect = [token_resp, id_resp]
+
+    assert game_search.search_games('999999999') == []
+    _reset_token_cache()
+
+
+@patch('app.services.game_search.get_settings')
+@patch('app.services.game_search.requests.post')
+def test_search_games_title_query_still_uses_fuzzy_search(mock_post, mock_settings):
+    _reset_token_cache()
+    mock_settings.return_value = Settings(
+        twitch_client_id='cid', twitch_client_secret='secret', env='github'
+    )
+    token_resp = MagicMock()
+    token_resp.raise_for_status.return_value = None
+    token_resp.json.return_value = {'access_token': 'tok', 'expires_in': 5000000}
+    games_resp = MagicMock()
+    games_resp.raise_for_status.return_value = None
+    games_resp.json.return_value = []
+    mock_post.side_effect = [token_resp, games_resp]
+
+    game_search.search_games('zelda')
+
+    games_call = mock_post.call_args_list[1]
+    assert 'search "zelda"' in games_call.kwargs['data']
+    assert 'where id' not in games_call.kwargs['data']
+    _reset_token_cache()
+
+
+@patch('app.services.game_search.get_settings')
+@patch('app.services.game_search.requests.post')
 def test_get_game_detail_maps_fields_and_caches_token(mock_post, mock_settings):
     _reset_token_cache()
     mock_settings.return_value = Settings(


### PR DESCRIPTION
Closes #211

## Summary
- `search_games(query)` now detects a bare-numeric query and resolves it directly via an IGDB `where id = <id>` lookup instead of the fuzzy `search "..."` title query.
- The result is normalized into the same search-hit shape produced by title search (`igdb`, `title`, `slug`, `year`, `platforms`, `poster_url` — no `popularity` key currently exists in `search_games`'s output on `main`, so none was added), via a shared `_search_hit` helper used by both code paths.
- An id that doesn't resolve (empty IGDB response) returns `[]`, matching the existing empty-title-match behavior.
- Ordinary title queries are unaffected — still uses the `search "..."` fuzzy query, not `where id =`.

## Testing
- Added unit tests: numeric-query resolves to a single-item list in search-hit shape; unknown id returns `[]`; title query still uses fuzzy search (asserts the query body).
- `pytest` — full suite passes (279 passed).
- `pylint` — 10.00/10 on changed files.
- `black --skip-string-normalization --check` — clean.