### PR TITLE
Support searching movies by IMDb ID

### DIFF
--- a/app/services/movie_search.py
+++ b/app/services/movie_search.py
@@ -6,6 +6,7 @@ web and MCP frontends can look up movies by title without holding the API key.
 Results are normalized into the shape the ``/v1/movies`` create endpoint expects.
 """
 
+import re
 from typing import List, Optional
 
 import requests
@@ -16,6 +17,8 @@ from app.log.logging_config import logger
 
 OMDB_URL = 'https://www.omdbapi.com/'
 REQUEST_TIMEOUT = 10
+
+_IMDB_ID_RE = re.compile(r'^tt\d+$', re.IGNORECASE)
 
 
 def search_movies(query: str) -> List[dict]:
@@ -39,6 +42,9 @@ def search_movies(query: str) -> List[dict]:
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail='Movie search is not configured (OMDB_API_KEY missing)',
         )
+
+    if _IMDB_ID_RE.match(query):
+        return _search_by_imdb_id(query, settings.omdb_api_key)
 
     try:
         response = requests.get(
@@ -78,6 +84,45 @@ def search_movies(query: str) -> List[dict]:
             }
         )
     return results
+
+
+def _search_by_imdb_id(imdb_id: str, api_key: str) -> List[dict]:
+    """
+    Resolve a query that looks like an IMDb id via OMDB's ``i=`` lookup and
+    map the result into the same search-hit shape ``search_movies`` returns
+    for title matches. Returns ``[]`` when the id doesn't resolve or the
+    upstream call fails, mirroring the "not found" behavior of title search.
+    """
+    try:
+        response = requests.get(
+            OMDB_URL,
+            params={'apikey': api_key, 'i': imdb_id},
+            timeout=REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        logger.error('OMDB id lookup failed for %r: %s', imdb_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Upstream movie search failed',
+        ) from exc
+
+    payload = response.json()
+    if payload.get('Response') == 'False':
+        return []
+
+    poster = payload.get('Poster')
+    if poster in (None, 'N/A'):
+        poster = None
+    return [
+        {
+            'imdb': payload.get('imdbID'),
+            'title': payload.get('Title'),
+            'year': payload.get('Year'),
+            'poster_url': poster,
+            'type': payload.get('Type'),
+        }
+    ]
 
 
 def _na(value):

--- a/tests/unit/movie_search_test.py
+++ b/tests/unit/movie_search_test.py
@@ -64,3 +64,98 @@ def test_get_movie_detail_maps_fields(mock_get, mock_settings):
 def test_get_movie_detail_unconfigured_returns_none(mock_settings):
     mock_settings.return_value = Settings(omdb_api_key=None, env='github')
     assert movie_search.get_movie_detail('tt1') is None
+
+
+@patch('app.services.movie_search.get_settings')
+@patch('app.services.movie_search.requests.get')
+def test_search_movies_by_imdb_id_returns_search_hit_shape(mock_get, mock_settings):
+    mock_settings.return_value = Settings(omdb_api_key='k', env='github')
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {
+        'Response': 'True',
+        'imdbID': 'tt0120338',
+        'Title': 'Titanic',
+        'Year': '1997',
+        'Poster': 'https://x/p.jpg',
+        'Type': 'movie',
+    }
+    mock_get.return_value = resp
+
+    results = movie_search.search_movies('tt0120338')
+
+    assert results == [
+        {
+            'imdb': 'tt0120338',
+            'title': 'Titanic',
+            'year': '1997',
+            'poster_url': 'https://x/p.jpg',
+            'type': 'movie',
+        }
+    ]
+    # Called OMDB's i= lookup, not the s= title search.
+    _, kwargs = mock_get.call_args
+    assert kwargs['params']['i'] == 'tt0120338'
+    assert 's' not in kwargs['params']
+
+
+@patch('app.services.movie_search.get_settings')
+@patch('app.services.movie_search.requests.get')
+def test_search_movies_by_imdb_id_case_insensitive(mock_get, mock_settings):
+    mock_settings.return_value = Settings(omdb_api_key='k', env='github')
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {
+        'Response': 'True',
+        'imdbID': 'tt0120338',
+        'Title': 'Titanic',
+        'Year': '1997',
+        'Poster': 'N/A',
+        'Type': 'movie',
+    }
+    mock_get.return_value = resp
+
+    results = movie_search.search_movies('TT0120338')
+
+    assert len(results) == 1
+    assert results[0]['poster_url'] is None
+
+
+@patch('app.services.movie_search.get_settings')
+@patch('app.services.movie_search.requests.get')
+def test_search_movies_by_unknown_imdb_id_returns_empty(mock_get, mock_settings):
+    mock_settings.return_value = Settings(omdb_api_key='k', env='github')
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {'Response': 'False', 'Error': 'Incorrect IMDb ID.'}
+    mock_get.return_value = resp
+
+    assert not movie_search.search_movies('tt9999999')
+
+
+@patch('app.services.movie_search.get_settings')
+@patch('app.services.movie_search.requests.get')
+def test_search_movies_title_query_still_uses_title_search(mock_get, mock_settings):
+    mock_settings.return_value = Settings(omdb_api_key='k', env='github')
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {
+        'Response': 'True',
+        'Search': [
+            {
+                'imdbID': 'tt0120338',
+                'Title': 'Titanic',
+                'Year': '1997',
+                'Poster': 'https://x/p.jpg',
+                'Type': 'movie',
+            }
+        ],
+    }
+    mock_get.return_value = resp
+
+    results = movie_search.search_movies('Titanic')
+
+    assert results[0]['title'] == 'Titanic'
+    _, kwargs = mock_get.call_args
+    assert kwargs['params']['s'] == 'Titanic'
+    assert 'i' not in kwargs['params']


### PR DESCRIPTION
Closes #208

## Summary
- `search_movies` now detects an ID-shaped query (`^tt\d+$`, case-insensitive) and resolves it directly via OMDB's `i=` lookup instead of running a title search (`s=`).
- The `i=` response is mapped into the same search-hit shape as a title-search match (`imdb`, `title`, `year`, `poster_url`, `type`), so it flows through the existing add-movie UI unchanged.
- A query that looks like an ID but doesn't resolve (`Response: False`) returns `[]`, mirroring the existing "not found" behavior for title search.
- Ordinary title queries are unaffected — they still hit `s=`.

## Testing
- Added unit tests covering: ID query resolves to a single search-hit-shaped result, case-insensitive ID matching, unknown ID returns `[]`, and ordinary title queries still use `s=` (not `i=`).
- `pytest` — 280 passed
- `pylint` — 10.00/10
- `black --skip-string-normalization --check` — clean (only unrelated pre-existing file flagged)