### PR TITLE
Upgrade IGDB game cover images to higher resolution

### DIFF
--- a/app/services/game_search.py
+++ b/app/services/game_search.py
@@ -24,7 +24,7 @@ from app.log.logging_config import logger
 
 TWITCH_OAUTH_URL = 'https://id.twitch.tv/oauth2/token'
 IGDB_URL = 'https://api.igdb.com/v4'
-COVER_URL = 'https://images.igdb.com/igdb/image/upload/t_cover_big'
+COVER_URL = 'https://images.igdb.com/igdb/image/upload/t_cover_big_2x'
 REQUEST_TIMEOUT = 10
 
 _DETAIL_FIELDS = (

--- a/tests/unit/game_search_test.py
+++ b/tests/unit/game_search_test.py
@@ -15,7 +15,7 @@ def _reset_token_cache():
 
 def test_helpers():
     assert game_search._cover({'cover': {'image_id': 'abc'}}) == (
-        'https://images.igdb.com/igdb/image/upload/t_cover_big/abc.jpg'
+        'https://images.igdb.com/igdb/image/upload/t_cover_big_2x/abc.jpg'
     )
     assert game_search._cover({}) is None
     assert game_search._release({'first_release_date': 1496275200}).year == 2017


### PR DESCRIPTION
## Summary
Swap IGDB image transform from `t_cover_big` to `t_cover_big_2x` (retina 2x variant) to improve cover art display quality in search results and detail pages, making game covers match the fidelity of movie and TV posters.

## Changes
- Updated `COVER_URL` constant in `app/services/game_search.py` from `t_cover_big` to `t_cover_big_2x`
- Updated test assertion in `tests/unit/game_search_test.py` to expect the new URL format
- All existing tests pass (276 passed)
- Pylint and black formatting verified

## Acceptance Criteria
- [x] Game cover images use higher-resolution IGDB image size (t_cover_big_2x)
- [x] New fetches will use the higher-res URL automatically through the constant
- [x] No broken images (falls back the same way as before if cover not available at higher resolution)

Closes #209