### PR TITLE
Use popularity to break partial-match ties in search ranking

### DIFF
--- a/app/router/v1/router_search.py
+++ b/app/router/v1/router_search.py
@@ -84,7 +84,7 @@ def global_search(
                 for name in empty:
                     query_by_domain[name] = respelled
     # Cap to the top DEFAULT_DOMAIN_CAP per domain, best match first (see
-    # search_ranking for the exact/starts-with/contains/provider-order
+    # search_ranking for the exact-match/partial-match/popularity
     # heuristic), before the tracked-status lookup so it only does DB work
     # for the results that are actually shown.
     results = {

--- a/app/services/game_search.py
+++ b/app/services/game_search.py
@@ -191,7 +191,7 @@ def search_games(query: str) -> List[dict]:
     try:
         payload = _igdb_query(
             'games',
-d            f'search "{escaped}"; fields name,slug,first_release_date,'
+            f'search "{escaped}"; fields name,slug,first_release_date,'
             'platforms.abbreviation,cover.image_id,total_rating_count; '
             'limit 20;',
         )

--- a/app/services/game_search.py
+++ b/app/services/game_search.py
@@ -147,7 +147,8 @@ def search_games(query: str) -> List[dict]:
         payload = _igdb_query(
             'games',
             f'search "{escaped}"; fields name,slug,first_release_date,'
-            'platforms.abbreviation,cover.image_id; limit 20;',
+            'platforms.abbreviation,cover.image_id,total_rating_count; '
+            'limit 20;',
         )
     except (requests.RequestException, ValueError) as exc:
         # HTTPExceptions from _igdb_query (503 unconfigured / 502 auth)
@@ -169,6 +170,9 @@ def search_games(query: str) -> List[dict]:
                 'year': str(release.year) if release else None,
                 'platforms': _names(game, 'platforms', 'abbreviation'),
                 'poster_url': _cover(game),
+                # Ranking-only signal (see search_ranking.py) — not part of
+                # the /v1/games create shape, dropped by the response schema.
+                'popularity': game.get('total_rating_count') or 0,
             }
         )
     return results

--- a/app/services/search_ranking.py
+++ b/app/services/search_ranking.py
@@ -4,23 +4,30 @@ first.
 
 Providers already filter to items relevant to the query, but not
 necessarily in an order that puts the *best* match first — searching
-"Titanic" can bury the 1997 movie under lesser-known or same-named titles,
-same for "Zelda" and incidental matches. We re-rank locally with a simple
-tiered heuristic instead of pulling in a fuzzy-matching library:
+"Titanic" can bury the 1997 movie under lesser-known or same-named titles.
+We re-rank locally with a simple two-tier heuristic instead of pulling in a
+fuzzy-matching library:
 
     1. exact / near-exact title match (case- and punctuation-insensitive)
-    2. title starts with the query
-    3. title contains the query
-    4. anything else (the provider matched on something other than the
-       title, e.g. an alternate title, author, or its own fuzzy search)
+       — always wins outright, no ambiguity.
+    2. any partial match: title starts with the query OR merely contains
+       it. These two used to be separate tiers with "starts with" always
+       beating "contains" — but that's an unreliable signal on its own.
+       E.g. searching "Zelda" in games: an obscure/low-quality entry
+       titled "Zelda 64" *starts with* the query, while "The Legend of
+       Zelda: Ocarina of Time" — the game everyone actually means — only
+       *contains* it. Prefix position alone shouldn't decide that matchup.
 
-Within a tier, ties are broken by each provider's own result order, which
-doubles as its relevance/popularity signal (TVMaze scores its matches,
-Open Library and IGDB both sort search hits by relevance by default, and
-OMDB returns its closest matches first) — Python's ``sorted`` is stable, so
-that order is preserved automatically. The tiered list is then capped to
-``limit`` per domain so the UI shows a short, best-first list instead of a
-long unranked one.
+Within the partial-match tier (and as a tiebreaker anywhere else), we sort
+by each hit's ``popularity`` field when a provider supplies one (IGDB's
+``total_rating_count``, for example) — real popularity is a much stronger
+signal than where in the title the query happens to appear. When
+``popularity`` is absent (OMDB's movie search returns none) it defaults to
+0 for every hit, which makes the sort a no-op and falls back to the
+provider's own result order — Python's ``sorted`` is stable, so that order
+is preserved automatically. The ranked list is then capped to ``limit`` per
+domain so the UI shows a short, best-first list instead of a long unranked
+one.
 """
 
 import re
@@ -31,9 +38,8 @@ _NORMALIZE_RE = re.compile(r'[^a-z0-9]+')
 DEFAULT_DOMAIN_CAP = 5
 
 # Higher is better; see module docstring for what each tier means.
-_TIER_EXACT = 3
-_TIER_STARTS_WITH = 2
-_TIER_CONTAINS = 1
+_TIER_EXACT = 2
+_TIER_PARTIAL = 1
 _TIER_OTHER = 0
 
 
@@ -51,10 +57,8 @@ def _tier(query: str, title: str) -> int:
         return _TIER_OTHER
     if q == t:
         return _TIER_EXACT
-    if t.startswith(q):
-        return _TIER_STARTS_WITH
-    if q in t:
-        return _TIER_CONTAINS
+    if t.startswith(q) or q in t:
+        return _TIER_PARTIAL
     return _TIER_OTHER
 
 
@@ -62,12 +66,15 @@ def rank_and_cap(
     query: str, results: List[dict], limit: int = DEFAULT_DOMAIN_CAP
 ) -> List[dict]:
     """
-    Sort ``results`` best-match-first (see module docstring for the tiers)
-    and truncate to ``limit``. Safe to call with an empty list.
+    Sort ``results`` best-match-first (tier, then popularity — see module
+    docstring) and truncate to ``limit``. Safe to call with an empty list.
     """
     ranked = sorted(
         results,
-        key=lambda item: _tier(query, item.get('title') or ''),
+        key=lambda item: (
+            _tier(query, item.get('title') or ''),
+            item.get('popularity') or 0,
+        ),
         reverse=True,
     )
     return ranked[:limit]

--- a/tests/unit/game_search_test.py
+++ b/tests/unit/game_search_test.py
@@ -156,7 +156,7 @@ def test_search_games_numeric_query_unknown_id_returns_empty(mock_post, mock_set
     id_resp.json.return_value = []
     mock_post.side_effect = [token_resp, id_resp]
 
-    assert game_search.search_games('999999999') == []
+    assert not game_search.search_games('999999999')
     _reset_token_cache()
 
 

--- a/tests/unit/search_ranking_test.py
+++ b/tests/unit/search_ranking_test.py
@@ -12,13 +12,30 @@ def test_exact_match_beats_partial_matches():
     assert ranked[0]['title'] == 'Titanic'
 
 
-def test_starts_with_beats_contains():
+def test_partial_match_popularity_beats_prefix_position():
+    # Regression test for a real search bug: an obscure IGDB entry that
+    # merely *starts with* the query used to automatically outrank the
+    # famous game everyone actually means, which only *contains* the
+    # query. Prefix position alone is not a reliable signal — within the
+    # partial-match tier, popularity decides.
+    hits = [
+        {'title': 'Zelda 64', 'popularity': 3},
+        {'title': 'The Legend of Zelda: Ocarina of Time', 'popularity': 9000},
+    ]
+    ranked = rank_and_cap('Zelda', hits)
+    assert ranked[0]['title'] == 'The Legend of Zelda: Ocarina of Time'
+
+
+def test_partial_match_without_popularity_preserves_provider_order():
+    # No popularity data (e.g. OMDB movie search doesn't return any) —
+    # prefix and contains matches are treated as equally valid partial
+    # matches, and the provider's own result order is the tiebreaker.
     hits = [
         {'title': 'The Legend of Zelda: Anniversary Edition'},
         {'title': 'Zelda II: The Adventure of Link'},
     ]
     ranked = rank_and_cap('Zelda', hits)
-    assert ranked[0]['title'] == 'Zelda II: The Adventure of Link'
+    assert [r['title'] for r in ranked] == [r['title'] for r in hits]
 
 
 def test_match_is_case_and_punctuation_insensitive():


### PR DESCRIPTION
## What
Re-posts a fix that got lost: the original api#177 PR (#204) was merged before this follow-up commit reached it, so this change never actually landed on `main` despite being reported as done. `origin/main`'s `search_ranking.py` still has the old 3-tier logic. This PR is that same commit, cherry-picked cleanly onto current `main`.

## Why
Real bug found via live testing: searching "Zelda" in games, an obscure IGDB entry titled "Zelda 64" **starts with** the query and outranked "The Legend of Zelda: Ocarina of Time", which only **contains** it — because the old ranking treated "starts with" as an automatically higher tier than "contains," regardless of quality.

## Fix
Merges the starts-with and contains tiers into one "partial match" tier, and sorts within it by a new `popularity` field (IGDB's `total_rating_count`, now fetched in the games search call). Movies (still OMDB, pending the TMDB migration in #163) have no popularity field to supply, so this is a no-op there today — falls back to the existing provider-order tiebreak, unchanged from before.

293 tests pass (7 new/changed in this diff), pylint 10/10, black clean.