### PR TITLE
Migrate movies from OMDb to TMDB (#163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ production.
 
 - **Sign in with Google** (OAuth) or a long-lived personal **API key** (`drk_…`) for tools/scripts
 - **Track four domains** — Movies, TV (with episodes), Books, and Games — each with watched/played/read status, notes, and completion dates
-- **Search & add** from external catalogs (OMDb, TMDB, Open Library, and more) behind one API
+- **Search & add** from external catalogs (TMDB, TVmaze, Open Library, IGDB) behind one API
 - **Role-based access** — you manage your own library; admins manage shared catalog data
 - **Secure by default** — OSS security pipeline (secrets, SAST, dependencies, container) on every PR
 

--- a/alembic/versions/a1c4f80b6e37_movie_tmdb_columns.py
+++ b/alembic/versions/a1c4f80b6e37_movie_tmdb_columns.py
@@ -1,0 +1,54 @@
+"""movie tmdb columns
+
+Adds ``movies.tmdb`` and ``movies.rating_tmdb`` for the OMDb->TMDB migration
+(#163). OMDb is CC BY-NC (non-commercial only) and its posters hotlinked
+m.media-amazon.com; TMDB licenses both data and images for application use.
+
+``tmdb`` becomes the catalog's external join key because TMDB's search
+endpoint returns no IMDb id — ``tracked_status`` can only badge search hits
+against something search actually returns. ``imdb`` is kept and still written
+(the detail endpoint supplies it), just no longer joined on.
+
+``rating_imdb`` is left in place holding its imported OMDb-era values. TMDB
+has no IMDb rating, so it can never be refreshed; ``rating_tmdb`` carries
+TMDB's ``vote_average`` instead and is what the UI displays.
+
+Both columns are nullable and unpopulated by this migration — the values are
+filled in afterwards by ``app.migration.backfill_tmdb``, which needs network
+access and throttling that don't belong in a schema migration.
+
+Revision ID: a1c4f80b6e37
+Revises: bdf47c1723a4
+Create Date: 2026-07-24 10:15:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1c4f80b6e37'
+down_revision: Union[str, Sequence[str], None] = 'bdf47c1723a4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('movies', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('tmdb', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('rating_tmdb', sa.Float(), nullable=True))
+    # A unique *index* rather than a constraint: it works identically on
+    # SQLite (local dev) and PostgreSQL, and NULLs stay allowed so rows the
+    # backfill can't resolve don't collide with each other.
+    op.create_index('ix_movies_tmdb', 'movies', ['tmdb'], unique=True)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('ix_movies_tmdb', table_name='movies')
+    with op.batch_alter_table('movies', schema=None) as batch_op:
+        batch_op.drop_column('rating_tmdb')
+        batch_op.drop_column('tmdb')

--- a/app/db/models_sandbox.py
+++ b/app/db/models_sandbox.py
@@ -84,14 +84,21 @@ class DbMovie(DBBaseModel):
     __tablename__ = 'movies'
 
     title = Column(String(255))
+    # TMDB id is the catalog's join key (#163): TMDB's search endpoint returns
+    # no IMDb id, so search results can only be matched to tracked rows on this.
+    tmdb = Column(Integer, unique=True, nullable=True)
     imdb = Column(String(40), unique=True)
     release_date = Column(DateTime, nullable=True)
+    # Legacy: real IMDb ratings from the OMDb era. Frozen — no longer written
+    # or displayed, since TMDB has no IMDb rating to keep it current (#163).
     rating_imdb = Column(Float, nullable=True)
+    # TMDB's own vote_average, which replaced it.
+    rating_tmdb = Column(Float, nullable=True)
     runtime = Column(Integer, nullable=True)
     language = Column(String(40), nullable=True)
     rated = Column(String(11), nullable=True)
     poster_url = Column(String(500), nullable=True)
-    # Rich detail (populated from OMDB) for the detail view + filtering.
+    # Rich detail (populated from TMDB) for the detail view + filtering.
     year = Column(Integer, nullable=True)
     genre = Column(String(255), nullable=True)
     director = Column(String(512), nullable=True)

--- a/app/migration/backfill_tmdb.py
+++ b/app/migration/backfill_tmdb.py
@@ -1,0 +1,137 @@
+"""
+Key the existing movie catalog onto TMDB and re-point posters off Amazon.
+
+This is the bridge step of the OMDb->TMDB migration (#163). It must run
+**after** the ``a1c4f80b6e37`` schema migration and **before** the TMDB search
+cutover is user-visible: until every row has a ``tmdb`` id, search results
+can't be matched against tracked movies (``tracked_status`` joins on ``tmdb``)
+and the watchlist badges silently read as "not tracked".
+
+For each movie it:
+
+1. resolves ``imdb`` -> ``tmdb`` id via TMDB's ``/find`` endpoint,
+2. re-points ``poster_url`` from ``m.media-amazon.com`` to image.tmdb.org,
+3. fills ``rating_tmdb`` from TMDB's ``vote_average``.
+
+Resumable: rows that already have a ``tmdb`` id are skipped, so a re-run
+continues where an interrupted pass stopped. Unlike the OMDb-era
+``enrich_movies``, there's no daily cap to nurse — TMDB publishes no daily
+limit, only ~40-50 req/s — so the throttle exists purely to stay well clear
+of that ceiling and of TMDB's "no bulk scraping" guidance.
+
+Usage::
+
+    TMDB_API_KEY=... DATABASE_URL=... ENV=prod \\
+        python -m app.migration.backfill_tmdb --dry-run
+    TMDB_API_KEY=... DATABASE_URL=... ENV=prod \\
+        python -m app.migration.backfill_tmdb
+"""
+
+import argparse
+import time
+
+from app.db.database import SessionLocal
+from app.db.models_sandbox import DbMovie
+from app.services.movie_search import get_movie_detail, resolve_tmdb_id
+
+# ~4 req/s against a ~40 req/s ceiling. A full pass over ~1,373 movies is
+# roughly 6 minutes at two calls each (find + detail).
+DEFAULT_THROTTLE_SECONDS = 0.25
+# Hosts we're migrating away from; anything else (already-TMDB URLs, or the 7
+# legacy image.tmdb.org posters) is left alone.
+_LEGACY_POSTER_HOSTS = ('m.media-amazon.com', 'ia.media-imdb.com')
+
+
+def _needs_new_poster(poster_url) -> bool:
+    """
+    True when TMDB's poster should replace what's stored: either a legacy
+    hotlinked host we're migrating off, or nothing at all (a row with no
+    poster renders a placeholder, so filling it is a pure gain). Posters
+    already on image.tmdb.org are left alone.
+    """
+    if not poster_url:
+        return True
+    return any(h in poster_url for h in _LEGACY_POSTER_HOSTS)
+
+
+def run(throttle: float = DEFAULT_THROTTLE_SECONDS, dry_run: bool = False) -> None:
+    """Resolve TMDB ids and refresh posters for movies not yet keyed."""
+    db = SessionLocal()
+    try:
+        pending = (
+            db.query(DbMovie)
+            .filter(DbMovie.tmdb.is_(None), DbMovie.imdb.isnot(None))
+            .all()
+        )
+        total = len(pending)
+        print(f'{total} movies to key onto TMDB' + (' (dry run)' if dry_run else ''))
+
+        resolved = unresolved = reposted = 0
+        unresolved_ids = []
+        for processed, movie in enumerate(pending, start=1):
+            tmdb_id = resolve_tmdb_id(movie.imdb)
+            if not tmdb_id:
+                unresolved += 1
+                unresolved_ids.append(movie.imdb)
+                time.sleep(throttle)
+                continue
+
+            resolved += 1
+            detail = get_movie_detail(tmdb_id) or {}
+            new_poster = detail.get('poster_url')
+
+            if not dry_run:
+                movie.tmdb = tmdb_id
+                if detail.get('rating_tmdb') is not None:
+                    movie.rating_tmdb = detail['rating_tmdb']
+                # Only replace a poster we're actually migrating away from, and
+                # only when TMDB gave us a real replacement — never blank out a
+                # working image for a null.
+                if new_poster and _needs_new_poster(movie.poster_url):
+                    movie.poster_url = new_poster
+                    reposted += 1
+                db.commit()
+            elif new_poster and _needs_new_poster(movie.poster_url):
+                reposted += 1
+
+            if processed % 25 == 0:
+                print(
+                    f'  {processed}/{total} '
+                    f'(resolved {resolved}, unresolved {unresolved})'
+                )
+            time.sleep(throttle)
+
+        print(
+            f'Done: resolved {resolved}, unresolved {unresolved}, '
+            f'posters re-pointed {reposted}'
+        )
+        if unresolved_ids:
+            # These keep a NULL tmdb id: they stay in the catalog and still
+            # render, but won't badge in search until fixed by hand.
+            print('Unresolved imdb ids (left with NULL tmdb):')
+            for imdb_id in unresolved_ids:
+                print(f'  {imdb_id}')
+    finally:
+        db.close()
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--throttle',
+        type=float,
+        default=DEFAULT_THROTTLE_SECONDS,
+        help=f'seconds between movies (default {DEFAULT_THROTTLE_SECONDS})',
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='report what would change without writing',
+    )
+    args = parser.parse_args()
+    run(throttle=args.throttle, dry_run=args.dry_run)
+
+
+if __name__ == '__main__':
+    main()

--- a/app/migration/enrich_movies.py
+++ b/app/migration/enrich_movies.py
@@ -1,12 +1,14 @@
 """
-Backfill OMDB detail (director/actors/genre/plot/year/rating) for movies that
+Backfill TMDB detail (director/actors/genre/plot/year/rating) for movies that
 were imported without it. Throttled and **resumable**: it only processes movies
-still missing detail, so re-running continues where it left off (e.g. after an
-OMDB daily-limit pause).
+still missing detail, so re-running continues where it left off.
+
+Requires ``movies.tmdb`` to be populated — run
+``app.migration.backfill_tmdb`` first (#163).
 
 Usage::
 
-    OMDB_API_KEY=... DATABASE_URL=... ENV=prod \\
+    TMDB_API_KEY=... DATABASE_URL=... ENV=prod \\
         python -m app.migration.enrich_movies
 """
 
@@ -16,10 +18,13 @@ from app.db.database import SessionLocal
 from app.db.models_sandbox import DbMovie
 from app.services.movie_search import apply_detail_to_movie, get_movie_detail
 
-# Be polite to OMDB; a full pass over ~1300 movies takes ~20 min.
-THROTTLE_SECONDS = 1.0
-# get_movie_detail returns None both for genuine misses and rate limiting; a run
-# of consecutive Nones almost certainly means the daily limit was hit.
+# ~4 req/s against TMDB's ~40 req/s ceiling. Far friendlier than the OMDb era,
+# which needed a full second per call to survive a 1,000/day cap.
+THROTTLE_SECONDS = 0.25
+# get_movie_detail returns None both for genuine misses and for upstream
+# trouble; a long run of consecutive Nones means something systemic (a revoked
+# key, a network partition) rather than a catalog gap, so stop and let a re-run
+# resume rather than burning through the rest of the list.
 STOP_AFTER_CONSECUTIVE_MISSES = 15
 
 
@@ -30,7 +35,7 @@ def run() -> None:
         pending = (
             db.query(DbMovie)
             .filter(
-                DbMovie.imdb.isnot(None),
+                DbMovie.tmdb.isnot(None),
                 DbMovie.plot.is_(None),
                 DbMovie.director.is_(None),
             )
@@ -41,7 +46,7 @@ def run() -> None:
         enriched = misses = consecutive = processed = 0
         for movie in pending:
             processed += 1
-            detail = get_movie_detail(movie.imdb)
+            detail = get_movie_detail(movie.tmdb)
             if detail:
                 apply_detail_to_movie(movie, detail)
                 db.commit()
@@ -55,7 +60,7 @@ def run() -> None:
             if consecutive >= STOP_AFTER_CONSECUTIVE_MISSES:
                 print(
                     f'Stopping after {consecutive} consecutive misses '
-                    '(likely OMDB rate limit). Re-run later to resume.'
+                    '(check TMDB_API_KEY and connectivity). Re-run to resume.'
                 )
                 break
             time.sleep(THROTTLE_SECONDS)

--- a/app/router/v1/router_movies.py
+++ b/app/router/v1/router_movies.py
@@ -6,7 +6,7 @@ This module contains the API routes for Movies.
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import func
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session, joinedload
 
 from app.db.database import get_db
@@ -32,7 +32,8 @@ from app.schemas.schemas_sandbox import (
 from app.services.movie_search import (
     apply_detail_to_movie,
     get_movie_detail,
-    search_movies as omdb_search_movies,
+    resolve_tmdb_id,
+    search_movies as tmdb_search_movies,
 )
 from app.services.search_correction import correct_query
 from app.services.tracked_status import attach_tracked_status
@@ -43,6 +44,22 @@ from app.services.tracker_query import (
 )
 
 router = APIRouter(prefix='/v1', tags=['Movies'])
+
+
+def _find_duplicate(db: Session, tmdb_id, imdb_id):
+    """
+    Existing catalog row matching either external id. Both are checked because
+    a movie added by imdb before the TMDB migration and the same movie found
+    via TMDB search must not become two rows.
+    """
+    clauses = []
+    if tmdb_id:
+        clauses.append(DbMovie.tmdb == tmdb_id)
+    if imdb_id:
+        clauses.append(DbMovie.imdb == imdb_id)
+    if not clauses:
+        return None
+    return db.query(DbMovie).filter(or_(*clauses)).first()
 
 
 # Global Entity Endpoints
@@ -61,11 +78,11 @@ def search_movies_endpoint(
     db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
 ):
-    results = omdb_search_movies(q)
+    results = tmdb_search_movies(q)
     if not results:
         corrected = correct_query(q)
         if corrected:
-            results = omdb_search_movies(corrected)
+            results = tmdb_search_movies(corrected)
     return attach_tracked_status(db, current_user[0].pk, results, 'movies')
 
 
@@ -83,15 +100,26 @@ def create_movie(
     # Any signed-in user may add to the shared catalog (the add-from-search
     # flow); editing and deleting catalog entries stay admin-only.
     del current_user
-    existing = db.query(DbMovie).filter(DbMovie.imdb == request.imdb).first()
-    if existing:
+    # Either id is accepted: the search flow posts a tmdb id (TMDB search
+    # returns no imdb), while the MCP tool and the IMDb CSV import (#140) are
+    # imdb-driven. Whichever is missing gets filled in by enrichment below.
+    if not request.tmdb and not request.imdb:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail='Movie imdb already exists'
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='Movie requires a tmdb or imdb id',
+        )
+
+    tmdb_id = request.tmdb or resolve_tmdb_id(request.imdb)
+    if _find_duplicate(db, tmdb_id, request.imdb):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail='Movie already exists'
         )
 
     new_movie = DbMovie(**request.model_dump())
-    # Enrich from OMDB on add so detail/filtering work immediately (best effort).
-    detail = get_movie_detail(request.imdb)
+    new_movie.tmdb = tmdb_id
+    # Enrich from TMDB on add so detail/filtering work immediately (best
+    # effort). This is also where imdb gets populated for search-driven adds.
+    detail = get_movie_detail(tmdb_id)
     if detail:
         apply_detail_to_movie(new_movie, detail)
     db.add(new_movie)
@@ -106,12 +134,14 @@ def get_movie(
     db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
 ):
-    """Return one movie's full detail, enriching from OMDB on first view."""
+    """Return one movie's full detail, enriching from TMDB on first view."""
     del current_user
     movie = _get_movie(db, movie_id)
-    # Lazily backfill detail the first time a sparse movie is opened.
+    # Lazily backfill detail the first time a sparse movie is opened. Rows the
+    # backfill couldn't resolve have no tmdb id; get_movie_detail returns None
+    # for those and the movie is served as-is.
     if movie.plot is None and movie.director is None:
-        detail = get_movie_detail(movie.imdb)
+        detail = get_movie_detail(movie.tmdb)
         if detail:
             apply_detail_to_movie(movie, detail)
             db.commit()

--- a/app/schemas/schemas_sandbox.py
+++ b/app/schemas/schemas_sandbox.py
@@ -78,9 +78,14 @@ class CountryRankingReorder(BaseModel):
 # --- Movies ---
 class MovieBase(BaseModel):
     title: str
-    imdb: str
+    # TMDB id is the catalog key; imdb is still stored but no longer required,
+    # since TMDB search results don't carry one until detail is fetched (#163).
+    tmdb: Optional[int] = None
+    imdb: Optional[str] = None
     release_date: Optional[datetime] = None
+    # Legacy OMDb-era values, frozen and not displayed; rating_tmdb replaces it.
     rating_imdb: Optional[float] = None
+    rating_tmdb: Optional[float] = None
     runtime: Optional[int] = None
     language: Optional[str] = None
     rated: Optional[str] = None
@@ -98,9 +103,11 @@ class MovieCreate(MovieBase):
 
 class MovieUpdate(BaseModel):
     title: Optional[str] = None
+    tmdb: Optional[int] = None
     imdb: Optional[str] = None
     release_date: Optional[datetime] = None
     rating_imdb: Optional[float] = None
+    rating_tmdb: Optional[float] = None
     runtime: Optional[int] = None
     language: Optional[str] = None
     rated: Optional[str] = None
@@ -124,9 +131,10 @@ class MovieSummary(BaseModel):
 
     id: str
     title: str
-    imdb: str
+    tmdb: Optional[int] = None
+    imdb: Optional[str] = None
     release_date: Optional[datetime] = None
-    rating_imdb: Optional[float] = None
+    rating_tmdb: Optional[float] = None
     runtime: Optional[int] = None
     rated: Optional[str] = None
     poster_url: Optional[str] = None
@@ -138,11 +146,15 @@ class MovieSummary(BaseModel):
 
 
 class MovieSearchResult(BaseModel):
-    imdb: str
+    # tmdb is what the add flow posts back; imdb only arrives on an id-shaped
+    # query, since TMDB's title search omits it (#163).
+    tmdb: int
+    imdb: Optional[str] = None
     title: str
     year: Optional[str] = None
     poster_url: Optional[str] = None
     type: Optional[str] = None
+    popularity: Optional[float] = None
     on_watchlist: bool = False
     on_rankings: bool = False
     rank: Optional[int] = None

--- a/app/services/movie_search.py
+++ b/app/services/movie_search.py
@@ -1,33 +1,107 @@
 """
 Movie search proxy.
 
-Wraps the OMDB search API (mirroring the legacy ``movies/findmovie.php``) so the
-web and MCP frontends can look up movies by title without holding the API key.
-Results are normalized into the shape the ``/v1/movies`` create endpoint expects.
+Wraps the TMDB API so the web and MCP frontends can look up movies without
+holding the API key. Results are normalized into the shape the ``/v1/movies``
+create endpoint expects.
+
+Migrated from OMDb (#163): OMDb's content is CC BY-NC, which blocked any
+commercial use, and its posters hotlinked ``m.media-amazon.com``. TMDB
+licenses images for application use and has no daily request cap.
+
+Two TMDB quirks shape this module:
+
+* **Search returns no IMDb id.** ``/search/movie`` yields TMDB ids only, so
+  ``tmdb`` — not ``imdb`` — is the catalog's join key (see
+  ``tracked_status._DOMAIN_CONFIG``). ``imdb`` is still stored, populated
+  from the detail call, but nothing joins on it.
+* **There is no IMDb rating.** ``vote_average`` is TMDB's own score and lands
+  in ``rating_tmdb``; the legacy ``rating_imdb`` column keeps its imported
+  values but is no longer written or displayed.
 """
 
 import re
+from datetime import datetime
 from typing import List, Optional
 
-import requests
 from fastapi import HTTPException, status
 
-from app.config import get_settings
 from app.log.logging_config import logger
-
-OMDB_URL = 'https://www.omdbapi.com/'
-REQUEST_TIMEOUT = 10
+from app.services import tmdb
 
 _IMDB_ID_RE = re.compile(r'^tt\d+$', re.IGNORECASE)
+
+# OMDb returned 4 principal cast members; match that so the detail page's
+# "Actors" line stays a short list rather than a full credit roll.
+_CAST_LIMIT = 4
+# US ratings only — the catalog is a single-region product (#163/web#26).
+_CERTIFICATION_REGION = 'US'
+
+
+def _year(release_date: Optional[str]) -> Optional[str]:
+    """TMDB dates are 'YYYY-MM-DD'; the search shape wants the year string."""
+    return (release_date or '')[:4] or None
+
+
+def _to_date(value: Optional[str]) -> Optional[datetime]:
+    """Parse TMDB's ISO release date; None when absent or malformed."""
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, '%Y-%m-%d')
+    except ValueError:
+        return None
+
+
+def _normalize_hit(item: dict) -> dict:
+    """Map a raw TMDB movie object to the search-hit shape callers expect."""
+    return {
+        'tmdb': item.get('id'),
+        # Present only on the detail endpoint; search hits carry None and the
+        # add flow fills it in from get_movie_detail.
+        'imdb': item.get('imdb_id'),
+        'title': item.get('title') or item.get('original_title'),
+        'year': _year(item.get('release_date')),
+        'poster_url': tmdb.image_url(item.get('poster_path')),
+        'type': 'movie',
+        # TMDB supplies a real popularity score; search_ranking uses it as the
+        # tiebreaker that OMDb could never provide.
+        'popularity': item.get('popularity'),
+    }
+
+
+def _search_by_imdb_id(imdb_id: str) -> List[dict]:
+    """
+    Resolve an IMDb-id-shaped query via TMDB's ``/find`` endpoint and map the
+    result into the same search-hit shape title matches produce. Returns ``[]``
+    when the id doesn't resolve, mirroring title search's "not found".
+    """
+    payload = tmdb.try_request(f'/find/{imdb_id}', {'external_source': 'imdb_id'})
+    if payload is None:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Upstream movie search failed',
+        )
+    results = payload.get('movie_results') or []
+    if not results:
+        return []
+    hit = _normalize_hit(results[0])
+    # /find echoes the id we looked up, so we can fill imdb without a second call.
+    hit['imdb'] = imdb_id.lower()
+    return [hit]
 
 
 def search_movies(query: str) -> List[dict]:
     """
-    Search OMDB for movies matching ``query``.
+    Search TMDB for movies matching ``query``.
 
-    Returns a list of normalized dicts (``imdb``, ``title``, ``year``,
-    ``poster_url``, ``type``). Raises 503 when the API key is not configured
-    and 502 when the upstream call fails.
+    A query shaped like an IMDb id (``tt`` + digits) resolves directly via
+    ``/find`` instead of a title search; an id that doesn't resolve returns
+    ``[]`` rather than raising.
+
+    Returns a list of normalized dicts (``tmdb``, ``imdb``, ``title``,
+    ``year``, ``poster_url``, ``type``, ``popularity``). Raises 503 when the
+    API key is not configured and 502 when the upstream call fails.
     """
     query = (query or '').strip()
     if not query:
@@ -36,122 +110,31 @@ def search_movies(query: str) -> List[dict]:
             detail='Search query must not be empty',
         )
 
-    settings = get_settings()
-    if not settings.omdb_api_key:
+    if not tmdb.is_configured():
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail='Movie search is not configured (OMDB_API_KEY missing)',
+            detail='Movie search is not configured (TMDB_API_KEY missing)',
         )
 
     if _IMDB_ID_RE.match(query):
-        return _search_by_imdb_id(query, settings.omdb_api_key)
+        return _search_by_imdb_id(query)
 
     try:
-        response = requests.get(
-            OMDB_URL,
-            params={
-                'apikey': settings.omdb_api_key,
-                's': query,
-                'type': 'movie',
-            },
-            timeout=REQUEST_TIMEOUT,
+        payload = tmdb.request(
+            '/search/movie', {'query': query, 'include_adult': 'false'}
         )
-        response.raise_for_status()
-    except requests.RequestException as exc:
-        logger.error('OMDB search failed for %r: %s', query, exc)
+    except tmdb.TmdbUnconfigured as exc:  # pragma: no cover - guarded above
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail='Movie search is not configured (TMDB_API_KEY missing)',
+        ) from exc
+    except tmdb.TmdbError as exc:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail='Upstream movie search failed',
         ) from exc
 
-    payload = response.json()
-    if payload.get('Response') == 'False':
-        # OMDB reports "Movie not found!" etc. as a non-error empty result.
-        return []
-
-    results = []
-    for item in payload.get('Search', []):
-        poster = item.get('Poster')
-        if poster in (None, 'N/A'):
-            poster = None
-        results.append(
-            {
-                'imdb': item.get('imdbID'),
-                'title': item.get('Title'),
-                'year': item.get('Year'),
-                'poster_url': poster,
-                'type': item.get('Type'),
-            }
-        )
-    return results
-
-
-def _search_by_imdb_id(imdb_id: str, api_key: str) -> List[dict]:
-    """
-    Resolve a query that looks like an IMDb id via OMDB's ``i=`` lookup and
-    map the result into the same search-hit shape ``search_movies`` returns
-    for title matches. Returns ``[]`` when the id doesn't resolve or the
-    upstream call fails, mirroring the "not found" behavior of title search.
-    """
-    try:
-        response = requests.get(
-            OMDB_URL,
-            params={'apikey': api_key, 'i': imdb_id},
-            timeout=REQUEST_TIMEOUT,
-        )
-        response.raise_for_status()
-    except requests.RequestException as exc:
-        logger.error('OMDB id lookup failed for %r: %s', imdb_id, exc)
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail='Upstream movie search failed',
-        ) from exc
-
-    payload = response.json()
-    if payload.get('Response') == 'False':
-        return []
-
-    poster = payload.get('Poster')
-    if poster in (None, 'N/A'):
-        poster = None
-    return [
-        {
-            'imdb': payload.get('imdbID'),
-            'title': payload.get('Title'),
-            'year': payload.get('Year'),
-            'poster_url': poster,
-            'type': payload.get('Type'),
-        }
-    ]
-
-
-def _na(value):
-    """Normalize OMDB's 'N/A' / empty strings to None."""
-    if value in (None, '', 'N/A'):
-        return None
-    return value
-
-
-def _to_int(value):
-    """Parse a leading integer (e.g. year '2002', runtime '113 min')."""
-    value = _na(value)
-    if value is None:
-        return None
-    digits = ''
-    for ch in str(value):
-        if ch.isdigit():
-            digits += ch
-        elif digits:
-            break
-    return int(digits) if digits else None
-
-
-def _to_float(value):
-    value = _na(value)
-    try:
-        return float(value) if value is not None else None
-    except (TypeError, ValueError):
-        return None
+    return [_normalize_hit(item) for item in payload.get('results') or []]
 
 
 # Max lengths for the bounded catalog columns (see models_sandbox.DbMovie).
@@ -162,12 +145,13 @@ _FIELD_LIMITS = {
     'language': 40,
     'rated': 11,
     'poster_url': 500,
+    'imdb': 40,
 }
 
 
 def apply_detail_to_movie(movie, detail: dict) -> None:
     """
-    Copy OMDB detail onto a DbMovie, truncating to column limits and only
+    Copy TMDB detail onto a DbMovie, truncating to column limits and only
     filling empty fields (never clobber a good value with None).
     """
     for key, value in detail.items():
@@ -178,43 +162,105 @@ def apply_detail_to_movie(movie, detail: dict) -> None:
         setattr(movie, key, value)
 
 
-def get_movie_detail(imdb_id: str) -> Optional[dict]:
+def _director(credits_block: dict) -> Optional[str]:
+    """Comma-joined names of everyone credited as Director."""
+    crew = (credits_block or {}).get('crew') or []
+    names = [c.get('name') for c in crew if c.get('job') == 'Director']
+    return ', '.join(n for n in names if n) or None
+
+
+def _actors(credits_block: dict) -> Optional[str]:
+    """Comma-joined top-billed cast, capped at ``_CAST_LIMIT``."""
+    cast = (credits_block or {}).get('cast') or []
+    names = [c.get('name') for c in cast[:_CAST_LIMIT]]
+    return ', '.join(n for n in names if n) or None
+
+
+def _certification(release_dates: dict) -> Optional[str]:
     """
-    Fetch full detail for a movie by imdb id (OMDB ``i=``) and map it to the
-    fields the catalog stores. Returns None when unavailable/unconfigured so
-    callers can skip enrichment gracefully.
+    Pull the US certification (G/PG/PG-13/R) out of TMDB's release_dates
+    block. TMDB lists one entry per release type; take the first non-empty
+    certification for the US.
+    """
+    for entry in (release_dates or {}).get('results') or []:
+        if entry.get('iso_3166_1') != _CERTIFICATION_REGION:
+            continue
+        for release in entry.get('release_dates') or []:
+            certification = (release.get('certification') or '').strip()
+            if certification:
+                return certification
+    return None
+
+
+def _language(payload: dict) -> Optional[str]:
+    """
+    Human-readable spoken languages ('English, French'), matching the format
+    OMDb used. Falls back to the two-letter original_language code.
+    """
+    spoken = payload.get('spoken_languages') or []
+    names = [lang.get('english_name') or lang.get('name') for lang in spoken]
+    joined = ', '.join(n for n in names if n)
+    return joined or payload.get('original_language') or None
+
+
+def _genre(payload: dict) -> Optional[str]:
+    genres = payload.get('genres') or []
+    return ', '.join(g.get('name') for g in genres if g.get('name')) or None
+
+
+def get_movie_detail(tmdb_id) -> Optional[dict]:
+    """
+    Fetch full detail for a movie by TMDB id and map it to the fields the
+    catalog stores. Returns None when unavailable/unconfigured so callers can
+    skip enrichment gracefully.
+
+    ``credits`` and ``release_dates`` come back in the same round trip via
+    append_to_response — director, cast and the US rating would each otherwise
+    need their own call.
+    """
+    if not tmdb_id:
+        return None
+    payload = tmdb.try_request(
+        f'/movie/{tmdb_id}',
+        {'append_to_response': 'credits,release_dates'},
+    )
+    if payload is None:
+        return None
+
+    release_date = _to_date(payload.get('release_date'))
+    year = release_date.year if release_date else None
+    return {
+        'title': payload.get('title') or payload.get('original_title'),
+        'tmdb': payload.get('id'),
+        'imdb': payload.get('imdb_id'),
+        'year': year,
+        'release_date': release_date,
+        'runtime': payload.get('runtime') or None,
+        'rated': _certification(payload.get('release_dates')),
+        'genre': _genre(payload),
+        'director': _director(payload.get('credits')),
+        'actors': _actors(payload.get('credits')),
+        'plot': payload.get('overview') or None,
+        'language': _language(payload),
+        'rating_tmdb': payload.get('vote_average') or None,
+        'poster_url': tmdb.image_url(payload.get('poster_path')),
+    }
+
+
+def resolve_tmdb_id(imdb_id: str) -> Optional[int]:
+    """
+    Map an IMDb id to a TMDB id via ``/find``. Used by the backfill to key
+    existing catalog rows (which only have imdb) onto TMDB. Returns None when
+    TMDB has no match.
     """
     imdb_id = (imdb_id or '').strip()
     if not imdb_id:
         return None
-    settings = get_settings()
-    if not settings.omdb_api_key:
+    payload = tmdb.try_request(f'/find/{imdb_id}', {'external_source': 'imdb_id'})
+    if payload is None:
         return None
-    try:
-        response = requests.get(
-            OMDB_URL,
-            params={'apikey': settings.omdb_api_key, 'i': imdb_id, 'plot': 'full'},
-            timeout=REQUEST_TIMEOUT,
-        )
-        response.raise_for_status()
-        payload = response.json()
-    except (requests.RequestException, ValueError) as exc:
-        logger.warning('OMDB detail failed for %s: %s', imdb_id, exc)
+    results = payload.get('movie_results') or []
+    if not results:
+        logger.info('TMDB has no movie for imdb id %s', imdb_id)
         return None
-    if payload.get('Response') == 'False':
-        return None
-
-    return {
-        'title': _na(payload.get('Title')),
-        'imdb': imdb_id,
-        'year': _to_int(payload.get('Year')),
-        'runtime': _to_int(payload.get('Runtime')),
-        'rated': _na(payload.get('Rated')),
-        'genre': _na(payload.get('Genre')),
-        'director': _na(payload.get('Director')),
-        'actors': _na(payload.get('Actors')),
-        'plot': _na(payload.get('Plot')),
-        'language': _na(payload.get('Language')),
-        'rating_imdb': _to_float(payload.get('imdbRating')),
-        'poster_url': _na(payload.get('Poster')),
-    }
+    return results[0].get('id')

--- a/app/services/tmdb.py
+++ b/app/services/tmdb.py
@@ -1,0 +1,146 @@
+"""
+Shared TMDB HTTP client.
+
+One place for auth, timeouts, 429 handling and image URL construction so the
+movie search/detail/watch-provider services don't each re-implement them.
+
+Two call styles, mirroring how the catalog services already behave:
+
+``request``
+    Raises :class:`TmdbUnconfigured` / :class:`TmdbError` so a *user-facing
+    search* can turn them into 503/502.
+``try_request``
+    Returns ``None`` on any failure so *enrichment* stays best-effort and
+    never breaks an add or a detail view.
+
+TMDB publishes no daily cap; the limit is roughly 40-50 requests/second with
+20 connections per IP, enforced by a 429 response. Their docs ask callers to
+"be respectful of the service" and to respond to 429 appropriately, which is
+what ``_RETRY_STATUS`` handling below does.
+"""
+
+import time
+from typing import Optional
+
+import requests
+
+from app.config import get_settings
+from app.log.logging_config import logger
+
+TMDB_URL = 'https://api.themoviedb.org/3'
+IMAGE_BASE = 'https://image.tmdb.org/t/p'
+REQUEST_TIMEOUT = 10
+
+# w500 is TMDB's standard poster width; the catalog's poster_url column caps at
+# 500 chars, and these URLs are ~55, so there's plenty of headroom.
+POSTER_SIZE = 'w500'
+# Provider logos render small (the detail page shows them inline at ~24px).
+LOGO_SIZE = 'w92'
+
+_RETRY_STATUS = (429, 502, 503, 504)
+_MAX_ATTEMPTS = 3
+# Fallback pause when TMDB returns 429 without a Retry-After header.
+_DEFAULT_BACKOFF_SECONDS = 2.0
+
+
+class TmdbUnconfigured(RuntimeError):
+    """TMDB_API_KEY is not set."""
+
+
+class TmdbError(RuntimeError):
+    """TMDB was unreachable or returned an unusable response."""
+
+
+def is_configured() -> bool:
+    """True when a TMDB API key is available."""
+    return bool(get_settings().tmdb_api_key)
+
+
+def image_url(path: Optional[str], size: str = POSTER_SIZE) -> Optional[str]:
+    """
+    Build a full image URL from TMDB's relative ``poster_path``/``logo_path``.
+
+    Returns None for a missing path so callers can store NULL rather than a
+    URL that would 404.
+    """
+    if not path:
+        return None
+    return f'{IMAGE_BASE}/{size}{path}'
+
+
+def _retry_after_seconds(response, attempt: int) -> float:
+    """Honor TMDB's Retry-After when present, else back off exponentially."""
+    header = response.headers.get('Retry-After') if response is not None else None
+    if header:
+        try:
+            return float(header)
+        except (TypeError, ValueError):
+            pass
+    return _DEFAULT_BACKOFF_SECONDS * attempt
+
+
+def request(path: str, params: Optional[dict] = None) -> dict:
+    """
+    GET ``path`` (e.g. ``/movie/603``) and return the decoded JSON body.
+
+    Retries 429/5xx up to ``_MAX_ATTEMPTS`` times, then raises. A 404 is *not*
+    retried and raises :class:`TmdbError` — callers that treat "no such movie"
+    as an empty result should use :func:`try_request` instead.
+    """
+    settings = get_settings()
+    if not settings.tmdb_api_key:
+        raise TmdbUnconfigured('TMDB_API_KEY missing')
+
+    query = dict(params or {})
+    query['api_key'] = settings.tmdb_api_key
+
+    last_exc: Optional[Exception] = None
+    for attempt in range(1, _MAX_ATTEMPTS + 1):
+        response = None
+        try:
+            response = requests.get(
+                f'{TMDB_URL}{path}',
+                params=query,
+                timeout=REQUEST_TIMEOUT,
+            )
+            if response.status_code in _RETRY_STATUS:
+                # Exhausted: report the throttling explicitly rather than
+                # letting raise_for_status decide what this means.
+                if attempt >= _MAX_ATTEMPTS:
+                    last_exc = TmdbError(
+                        f'{response.status_code} after {attempt} attempts'
+                    )
+                    break
+                pause = _retry_after_seconds(response, attempt)
+                logger.warning(
+                    'TMDB %s returned %s; retrying in %.1fs (attempt %d/%d)',
+                    path,
+                    response.status_code,
+                    pause,
+                    attempt,
+                    _MAX_ATTEMPTS,
+                )
+                time.sleep(pause)
+                continue
+            response.raise_for_status()
+            return response.json()
+        except (requests.RequestException, ValueError) as exc:
+            # A non-retryable status (404), a decode error, or a transport
+            # failure — all terminal, since retryable statuses are handled
+            # above before raise_for_status runs.
+            last_exc = exc
+            break
+
+    logger.error('TMDB request failed for %s: %s', path, last_exc)
+    raise TmdbError(f'TMDB request failed for {path}') from last_exc
+
+
+def try_request(path: str, params: Optional[dict] = None) -> Optional[dict]:
+    """
+    Best-effort variant of :func:`request` — returns None instead of raising,
+    for enrichment paths that must degrade quietly.
+    """
+    try:
+        return request(path, params)
+    except (TmdbUnconfigured, TmdbError):
+        return None

--- a/app/services/tracked_status.py
+++ b/app/services/tracked_status.py
@@ -22,7 +22,8 @@ from app.db.models_sandbox import (
 
 # domain -> (catalog model, catalog's external-id column, tracker model, tracker's FK column)
 _DOMAIN_CONFIG = {
-    'movies': (DbMovie, 'imdb', DbUserMovie, 'movie_id'),
+    # Movies join on tmdb, not imdb: TMDB search hits carry no IMDb id (#163).
+    'movies': (DbMovie, 'tmdb', DbUserMovie, 'movie_id'),
     'tv_shows': (DbTVShow, 'tvmaze', DbUserTVShow, 'tv_show_id'),
     'games': (DbVideoGame, 'igdb', DbUserVideoGame, 'game_id'),
     'books': (DbBook, 'isbn', DbUserBook, 'book_id'),

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -48,8 +48,13 @@ tasks:
     cmds:
       - alembic revision --autogenerate -m "{{.MSG}}"
 
+  backfill:tmdb:
+    desc: "Key existing movies onto TMDB ids + re-point posters (run before enrich:movies)"
+    cmds:
+      - python -m app.migration.backfill_tmdb {{.CLI_ARGS}}
+
   enrich:movies:
-    desc: "Backfill OMDB detail for existing movies (throttled, resumable)"
+    desc: "Backfill TMDB detail for existing movies (throttled, resumable)"
     cmds:
       - python -m app.migration.enrich_movies
 

--- a/tests/integration/rate_limit_test.py
+++ b/tests/integration/rate_limit_test.py
@@ -51,7 +51,7 @@ def test_auth_attempts_are_rate_limited_per_ip(mock_settings, test_client: TestC
     rate_limit.reset()
 
 
-@patch('app.router.v1.router_movies.omdb_search_movies')
+@patch('app.router.v1.router_movies.tmdb_search_movies')
 @patch('app.services.rate_limit.get_settings')
 def test_search_is_rate_limited_per_user(
     mock_settings, mock_search, test_client: TestClient
@@ -63,7 +63,7 @@ def test_search_is_rate_limited_per_user(
     mock_settings.return_value = Settings(**ENABLED, rate_limit_search=2)
     mock_search.return_value = [
         {
-            'imdb': 'tt1',
+            'tmdb': 1,
             'title': 'X',
             'year': '2020',
             'poster_url': None,

--- a/tests/integration/router_movies_test.py
+++ b/tests/integration/router_movies_test.py
@@ -259,38 +259,38 @@ def test_search_movies_requires_auth(test_client: TestClient):
     assert response.status_code == 401
 
 
-@patch('app.services.movie_search.get_settings')
+@patch('app.services.tmdb.get_settings')
 def test_search_movies_not_configured(mock_settings, test_client: TestClient):
-    mock_settings.return_value = Settings(omdb_api_key=None, env='github')
+    mock_settings.return_value = Settings(tmdb_api_key=None, env='github')
     user_headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
     response = test_client.get('/v1/movies/search?q=matrix', headers=user_headers)
     assert response.status_code == 503
 
 
-@patch('app.services.movie_search.get_settings')
-@patch('app.services.movie_search.requests.get')
+@patch('app.services.tmdb.get_settings')
+@patch('app.services.tmdb.requests.get')
 def test_search_movies_returns_results(
     mock_get, mock_settings, test_client: TestClient
 ):
-    mock_settings.return_value = Settings(omdb_api_key='test-key', env='github')
+    mock_settings.return_value = Settings(tmdb_api_key='test-key', env='github')
     mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {}
     mock_response.raise_for_status.return_value = None
     mock_response.json.return_value = {
-        'Response': 'True',
-        'Search': [
+        'results': [
             {
-                'Title': 'The Matrix',
-                'Year': '1999',
-                'imdbID': 'tt0133093',
-                'Type': 'movie',
-                'Poster': 'https://example.com/matrix.jpg',
+                'id': 603,
+                'title': 'The Matrix',
+                'release_date': '1999-03-30',
+                'poster_path': '/matrix.jpg',
+                'popularity': 84.1,
             },
             {
-                'Title': 'The Matrix Reloaded',
-                'Year': '2003',
-                'imdbID': 'tt0234215',
-                'Type': 'movie',
-                'Poster': 'N/A',
+                'id': 604,
+                'title': 'The Matrix Reloaded',
+                'release_date': '2003-05-15',
+                'poster_path': None,
             },
         ],
     }
@@ -301,17 +301,19 @@ def test_search_movies_returns_results(
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 2
-    assert data[0]['imdb'] == 'tt0133093'
+    assert data[0]['tmdb'] == 603
     assert data[0]['title'] == 'The Matrix'
-    assert data[0]['poster_url'] == 'https://example.com/matrix.jpg'
-    # 'N/A' posters are normalized to null.
+    assert data[0]['poster_url'] == 'https://image.tmdb.org/t/p/w500/matrix.jpg'
+    # TMDB title search carries no IMDb id.
+    assert data[0]['imdb'] is None
+    # A missing poster_path becomes null rather than a URL that would 404.
     assert data[1]['poster_url'] is None
 
 
-@patch('app.router.v1.router_movies.omdb_search_movies')
+@patch('app.router.v1.router_movies.tmdb_search_movies')
 def test_search_retries_with_spelling_fix(mock_search, test_client: TestClient):
     """An empty result retries once with a spell-corrected query."""
-    hit = [{'imdb': 'tt0107290', 'title': 'Jurassic Park', 'year': '1993'}]
+    hit = [{'tmdb': 329, 'title': 'Jurassic Park', 'year': '1993'}]
     mock_search.side_effect = [[], hit]
     headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
 
@@ -322,7 +324,7 @@ def test_search_retries_with_spelling_fix(mock_search, test_client: TestClient):
     assert mock_search.call_args_list[1].args[0] == 'jurassic'
 
 
-@patch('app.router.v1.router_movies.omdb_search_movies')
+@patch('app.router.v1.router_movies.tmdb_search_movies')
 def test_search_no_retry_when_spelling_correct(mock_search, test_client: TestClient):
     mock_search.return_value = []
     headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
@@ -333,15 +335,16 @@ def test_search_no_retry_when_spelling_correct(mock_search, test_client: TestCli
     assert mock_search.call_count == 1
 
 
-@patch('app.router.v1.router_movies.omdb_search_movies')
+@patch('app.router.v1.router_movies.tmdb_search_movies')
 def test_search_badges_already_ranked_result(mock_search, test_client: TestClient):
     """web#31: a search hit matching a movie the user has ranked carries
-    on_rankings + rank; an untracked hit in the same response stays false/None."""
+    on_rankings + rank; an untracked hit in the same response stays false/None.
+    Since #163 the join is on tmdb, not imdb."""
     admin_headers = {'Authorization': f"Bearer {test_client.admin_user.token}"}
     create_resp = test_client.post(
         '/v1/movies',
         headers=admin_headers,
-        json={'title': 'Inception', 'imdb': 'tt1375666'},
+        json={'title': 'Inception', 'tmdb': 27205, 'imdb': 'tt1375666'},
     )
     movie_id = create_resp.json()['id']
 
@@ -359,15 +362,16 @@ def test_search_badges_already_ranked_result(mock_search, test_client: TestClien
     )
     assert rank_resp.status_code == 200
 
+    # Title-search hits carry no imdb — the badge join has to work off tmdb alone.
     mock_search.return_value = [
-        {'imdb': 'tt1375666', 'title': 'Inception', 'year': '2010'},
-        {'imdb': 'tt0107290', 'title': 'Jurassic Park', 'year': '1993'},
+        {'tmdb': 27205, 'title': 'Inception', 'year': '2010'},
+        {'tmdb': 329, 'title': 'Jurassic Park', 'year': '1993'},
     ]
     response = test_client.get('/v1/movies/search?q=inception', headers=user_headers)
     assert response.status_code == 200
-    data = {r['imdb']: r for r in response.json()}
-    assert data['tt1375666']['on_rankings'] is True
-    assert data['tt1375666']['rank'] == 1
-    assert data['tt0107290']['on_rankings'] is False
-    assert data['tt0107290']['on_watchlist'] is False
-    assert data['tt0107290']['rank'] is None
+    data = {r['tmdb']: r for r in response.json()}
+    assert data[27205]['on_rankings'] is True
+    assert data[27205]['rank'] == 1
+    assert data[329]['on_rankings'] is False
+    assert data[329]['on_watchlist'] is False
+    assert data[329]['rank'] is None

--- a/tests/integration/router_search_test.py
+++ b/tests/integration/router_search_test.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
-MOVIE_HIT = [{'imdb': 'tt0107290', 'title': 'Jurassic Park', 'year': '1993'}]
+MOVIE_HIT = [{'tmdb': 329, 'title': 'Jurassic Park', 'year': '1993'}]
 SHOW_HIT = [{'tvmaze': 22, 'title': 'Jurassic Show', 'year': '2021'}]
 
 
@@ -63,12 +63,12 @@ def test_failing_provider_does_not_break_search(
 
 
 TITANIC_HITS = [
-    {'imdb': 'tt0000001', 'title': 'Raise the Titanic', 'year': '1980'},
-    {'imdb': 'tt0000002', 'title': 'Titanic II', 'year': '2010'},
-    {'imdb': 'tt0000003', 'title': 'The Legend of the Titanic', 'year': '1999'},
-    {'imdb': 'tt0000004', 'title': 'Titanic', 'year': '1997'},
-    {'imdb': 'tt0000005', 'title': 'Titanica', 'year': '1992'},
-    {'imdb': 'tt0000006', 'title': 'Titanic: Blood and Steel', 'year': '2012'},
+    {'tmdb': 1, 'title': 'Raise the Titanic', 'year': '1980'},
+    {'tmdb': 2, 'title': 'Titanic II', 'year': '2010'},
+    {'tmdb': 3, 'title': 'The Legend of the Titanic', 'year': '1999'},
+    {'tmdb': 4, 'title': 'Titanic', 'year': '1997'},
+    {'tmdb': 5, 'title': 'Titanica', 'year': '1992'},
+    {'tmdb': 6, 'title': 'Titanic: Blood and Steel', 'year': '2012'},
 ]
 
 

--- a/tests/unit/backfill_tmdb_test.py
+++ b/tests/unit/backfill_tmdb_test.py
@@ -1,0 +1,27 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+# pylint: disable=protected-access
+from app.migration import backfill_tmdb
+
+
+def test_legacy_hosts_are_replaced():
+    assert backfill_tmdb._needs_new_poster(
+        'https://m.media-amazon.com/images/M/matrix.jpg'
+    )
+    assert backfill_tmdb._needs_new_poster('https://ia.media-imdb.com/images/x.jpg')
+
+
+def test_missing_poster_is_filled():
+    # A row with no poster renders a placeholder, so TMDB's is a pure gain.
+    assert backfill_tmdb._needs_new_poster(None)
+    assert backfill_tmdb._needs_new_poster('')
+
+
+def test_existing_tmdb_poster_is_left_alone():
+    # The 7 legacy image.tmdb.org posters must not be churned.
+    assert not backfill_tmdb._needs_new_poster(
+        'https://image.tmdb.org/t/p/w500/legacy.jpg'
+    )
+
+
+def test_unrecognized_host_is_left_alone():
+    assert not backfill_tmdb._needs_new_poster('https://example.com/poster.jpg')

--- a/tests/unit/movie_search_test.py
+++ b/tests/unit/movie_search_test.py
@@ -2,19 +2,69 @@
 # pylint: disable=protected-access, missing-class-docstring
 from unittest.mock import MagicMock, patch
 
+import pytest
+from fastapi import HTTPException
+
 from app.config import Settings
-from app.services import movie_search
+from app.services import movie_search, tmdb
+
+DETAIL_PAYLOAD = {
+    'id': 603,
+    'imdb_id': 'tt0133093',
+    'title': 'The Matrix',
+    'release_date': '1999-03-30',
+    'runtime': 136,
+    'overview': 'A hacker learns the truth.',
+    'vote_average': 8.2,
+    'poster_path': '/matrix.jpg',
+    'original_language': 'en',
+    'spoken_languages': [{'english_name': 'English', 'name': 'English'}],
+    'genres': [{'name': 'Action'}, {'name': 'Science Fiction'}],
+    'credits': {
+        'crew': [
+            {'job': 'Director', 'name': 'Lana Wachowski'},
+            {'job': 'Director', 'name': 'Lilly Wachowski'},
+            {'job': 'Editor', 'name': 'Zach Staenberg'},
+        ],
+        'cast': [
+            {'name': 'Keanu Reeves'},
+            {'name': 'Laurence Fishburne'},
+            {'name': 'Carrie-Anne Moss'},
+            {'name': 'Hugo Weaving'},
+            {'name': 'Gloria Foster'},
+        ],
+    },
+    'release_dates': {
+        'results': [
+            {'iso_3166_1': 'GB', 'release_dates': [{'certification': '15'}]},
+            {
+                'iso_3166_1': 'US',
+                'release_dates': [
+                    {'certification': ''},
+                    {'certification': 'R'},
+                ],
+            },
+        ]
+    },
+}
 
 
-def test_na_and_parsers():
-    assert movie_search._na('N/A') is None
-    assert movie_search._na('') is None
-    assert movie_search._na('Drama') == 'Drama'
-    assert movie_search._to_int('2002') == 2002
-    assert movie_search._to_int('113 min') == 113
-    assert movie_search._to_int('N/A') is None
-    assert movie_search._to_float('8.6') == 8.6
-    assert movie_search._to_float('N/A') is None
+def _response(payload, status_code=200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = {}
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = payload
+    return resp
+
+
+def test_image_url_builds_and_handles_missing():
+    assert tmdb.image_url('/x.jpg') == 'https://image.tmdb.org/t/p/w500/x.jpg'
+    assert (
+        tmdb.image_url('/x.jpg', size='w92') == 'https://image.tmdb.org/t/p/w92/x.jpg'
+    )
+    assert tmdb.image_url(None) is None
+    assert tmdb.image_url('') is None
 
 
 def test_apply_detail_truncates_and_skips_none():
@@ -32,130 +82,215 @@ def test_apply_detail_truncates_and_skips_none():
     assert m.plot is None  # None values are skipped
 
 
-@patch('app.services.movie_search.get_settings')
-@patch('app.services.movie_search.requests.get')
+@patch('app.services.tmdb.get_settings')
+@patch('app.services.tmdb.requests.get')
 def test_get_movie_detail_maps_fields(mock_get, mock_settings):
-    mock_settings.return_value = Settings(omdb_api_key='k', env='github')
-    resp = MagicMock()
-    resp.raise_for_status.return_value = None
-    resp.json.return_value = {
-        'Response': 'True',
-        'Title': 'The Matrix',
-        'Year': '1999',
-        'Runtime': '136 min',
-        'Genre': 'Action, Sci-Fi',
-        'Director': 'Lana Wachowski, Lilly Wachowski',
-        'Actors': 'Keanu Reeves, Laurence Fishburne',
-        'Plot': 'A hacker learns the truth.',
-        'imdbRating': '8.7',
-        'Poster': 'https://x/p.jpg',
-    }
-    mock_get.return_value = resp
+    mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+    mock_get.return_value = _response(DETAIL_PAYLOAD)
 
-    detail = movie_search.get_movie_detail('tt0133093')
+    detail = movie_search.get_movie_detail(603)
+
+    assert detail['tmdb'] == 603
+    assert detail['imdb'] == 'tt0133093'
     assert detail['year'] == 1999
     assert detail['runtime'] == 136
-    assert detail['genre'] == 'Action, Sci-Fi'
-    assert detail['director'].startswith('Lana')
-    assert detail['rating_imdb'] == 8.7
+    assert detail['genre'] == 'Action, Science Fiction'
+    assert detail['director'] == 'Lana Wachowski, Lilly Wachowski'
+    assert detail['language'] == 'English'
+    assert detail['plot'] == 'A hacker learns the truth.'
+    # TMDB's own score lands in rating_tmdb; rating_imdb is never written.
+    assert detail['rating_tmdb'] == 8.2
+    assert 'rating_imdb' not in detail
+    assert detail['poster_url'] == 'https://image.tmdb.org/t/p/w500/matrix.jpg'
+    # Cast is capped, and only Directors count as director.
+    assert detail['actors'] == (
+        'Keanu Reeves, Laurence Fishburne, Carrie-Anne Moss, Hugo Weaving'
+    )
+    # US certification wins over GB, skipping the empty entry.
+    assert detail['rated'] == 'R'
 
 
-@patch('app.services.movie_search.get_settings')
+@patch('app.services.tmdb.get_settings')
 def test_get_movie_detail_unconfigured_returns_none(mock_settings):
-    mock_settings.return_value = Settings(omdb_api_key=None, env='github')
-    assert movie_search.get_movie_detail('tt1') is None
+    mock_settings.return_value = Settings(tmdb_api_key=None, env='github')
+    assert movie_search.get_movie_detail(603) is None
 
 
-@patch('app.services.movie_search.get_settings')
-@patch('app.services.movie_search.requests.get')
+@patch('app.services.tmdb.get_settings')
+def test_get_movie_detail_without_id_returns_none(mock_settings):
+    mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+    # Rows the backfill couldn't resolve have a NULL tmdb id.
+    assert movie_search.get_movie_detail(None) is None
+
+
+@patch('app.services.tmdb.get_settings')
+@patch('app.services.tmdb.requests.get')
 def test_search_movies_by_imdb_id_returns_search_hit_shape(mock_get, mock_settings):
-    mock_settings.return_value = Settings(omdb_api_key='k', env='github')
-    resp = MagicMock()
-    resp.raise_for_status.return_value = None
-    resp.json.return_value = {
-        'Response': 'True',
-        'imdbID': 'tt0120338',
-        'Title': 'Titanic',
-        'Year': '1997',
-        'Poster': 'https://x/p.jpg',
-        'Type': 'movie',
-    }
-    mock_get.return_value = resp
+    mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+    mock_get.return_value = _response(
+        {
+            'movie_results': [
+                {
+                    'id': 597,
+                    'title': 'Titanic',
+                    'release_date': '1997-11-18',
+                    'poster_path': '/t.jpg',
+                    'popularity': 91.2,
+                }
+            ]
+        }
+    )
 
     results = movie_search.search_movies('tt0120338')
 
     assert results == [
         {
+            'tmdb': 597,
             'imdb': 'tt0120338',
             'title': 'Titanic',
             'year': '1997',
-            'poster_url': 'https://x/p.jpg',
+            'poster_url': 'https://image.tmdb.org/t/p/w500/t.jpg',
             'type': 'movie',
+            'popularity': 91.2,
         }
     ]
-    # Called OMDB's i= lookup, not the s= title search.
-    _, kwargs = mock_get.call_args
-    assert kwargs['params']['i'] == 'tt0120338'
-    assert 's' not in kwargs['params']
+    # Called TMDB's /find endpoint, not the title search.
+    args, kwargs = mock_get.call_args
+    assert args[0].endswith('/find/tt0120338')
+    assert kwargs['params']['external_source'] == 'imdb_id'
 
 
-@patch('app.services.movie_search.get_settings')
-@patch('app.services.movie_search.requests.get')
+@patch('app.services.tmdb.get_settings')
+@patch('app.services.tmdb.requests.get')
 def test_search_movies_by_imdb_id_case_insensitive(mock_get, mock_settings):
-    mock_settings.return_value = Settings(omdb_api_key='k', env='github')
-    resp = MagicMock()
-    resp.raise_for_status.return_value = None
-    resp.json.return_value = {
-        'Response': 'True',
-        'imdbID': 'tt0120338',
-        'Title': 'Titanic',
-        'Year': '1997',
-        'Poster': 'N/A',
-        'Type': 'movie',
-    }
-    mock_get.return_value = resp
+    mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+    mock_get.return_value = _response(
+        {'movie_results': [{'id': 597, 'title': 'Titanic', 'poster_path': None}]}
+    )
 
     results = movie_search.search_movies('TT0120338')
 
     assert len(results) == 1
+    # Missing poster_path stores NULL rather than a URL that would 404.
     assert results[0]['poster_url'] is None
+    assert results[0]['imdb'] == 'tt0120338'
 
 
-@patch('app.services.movie_search.get_settings')
-@patch('app.services.movie_search.requests.get')
+@patch('app.services.tmdb.get_settings')
+@patch('app.services.tmdb.requests.get')
 def test_search_movies_by_unknown_imdb_id_returns_empty(mock_get, mock_settings):
-    mock_settings.return_value = Settings(omdb_api_key='k', env='github')
-    resp = MagicMock()
-    resp.raise_for_status.return_value = None
-    resp.json.return_value = {'Response': 'False', 'Error': 'Incorrect IMDb ID.'}
-    mock_get.return_value = resp
+    mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+    mock_get.return_value = _response({'movie_results': []})
 
     assert not movie_search.search_movies('tt9999999')
 
 
-@patch('app.services.movie_search.get_settings')
-@patch('app.services.movie_search.requests.get')
-def test_search_movies_title_query_still_uses_title_search(mock_get, mock_settings):
-    mock_settings.return_value = Settings(omdb_api_key='k', env='github')
-    resp = MagicMock()
-    resp.raise_for_status.return_value = None
-    resp.json.return_value = {
-        'Response': 'True',
-        'Search': [
-            {
-                'imdbID': 'tt0120338',
-                'Title': 'Titanic',
-                'Year': '1997',
-                'Poster': 'https://x/p.jpg',
-                'Type': 'movie',
-            }
-        ],
-    }
-    mock_get.return_value = resp
+@patch('app.services.tmdb.get_settings')
+@patch('app.services.tmdb.requests.get')
+def test_search_movies_title_query_uses_search_endpoint(mock_get, mock_settings):
+    mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+    mock_get.return_value = _response(
+        {
+            'results': [
+                {
+                    'id': 597,
+                    'title': 'Titanic',
+                    'release_date': '1997-11-18',
+                    'poster_path': '/t.jpg',
+                    'popularity': 91.2,
+                }
+            ]
+        }
+    )
 
     results = movie_search.search_movies('Titanic')
 
     assert results[0]['title'] == 'Titanic'
-    _, kwargs = mock_get.call_args
-    assert kwargs['params']['s'] == 'Titanic'
-    assert 'i' not in kwargs['params']
+    assert results[0]['tmdb'] == 597
+    # Title search carries no IMDb id — that's why tmdb is the join key.
+    assert results[0]['imdb'] is None
+    assert results[0]['popularity'] == 91.2
+    args, kwargs = mock_get.call_args
+    assert args[0].endswith('/search/movie')
+    assert kwargs['params']['query'] == 'Titanic'
+
+
+@patch('app.services.tmdb.get_settings')
+def test_search_movies_unconfigured_returns_503(mock_settings):
+    mock_settings.return_value = Settings(tmdb_api_key=None, env='github')
+    with pytest.raises(HTTPException) as exc:
+        movie_search.search_movies('Titanic')
+    assert exc.value.status_code == 503
+
+
+@patch('app.services.tmdb.get_settings')
+def test_search_movies_empty_query_returns_400(mock_settings):
+    mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+    with pytest.raises(HTTPException) as exc:
+        movie_search.search_movies('   ')
+    assert exc.value.status_code == 400
+
+
+@patch('app.services.tmdb.time.sleep')
+@patch('app.services.tmdb.get_settings')
+@patch('app.services.tmdb.requests.get')
+def test_search_movies_upstream_failure_returns_502(
+    mock_get, mock_settings, mock_sleep
+):
+    mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+    mock_get.side_effect = tmdb.requests.RequestException('boom')
+
+    with pytest.raises(HTTPException) as exc:
+        movie_search.search_movies('Titanic')
+    assert exc.value.status_code == 502
+    del mock_sleep
+
+
+@patch('app.services.tmdb.time.sleep')
+@patch('app.services.tmdb.get_settings')
+@patch('app.services.tmdb.requests.get')
+def test_rate_limited_request_retries_then_succeeds(
+    mock_get, mock_settings, mock_sleep
+):
+    mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+    throttled = _response({}, status_code=429)
+    throttled.headers = {'Retry-After': '0.01'}
+    mock_get.side_effect = [throttled, _response({'results': []})]
+
+    assert movie_search.search_movies('Titanic') == []
+    assert mock_get.call_count == 2
+    # Backed off using TMDB's Retry-After rather than the default.
+    mock_sleep.assert_called_once_with(0.01)
+
+
+@patch('app.services.tmdb.time.sleep')
+@patch('app.services.tmdb.get_settings')
+@patch('app.services.tmdb.requests.get')
+def test_rate_limited_request_gives_up_after_max_attempts(
+    mock_get, mock_settings, mock_sleep
+):
+    mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+    mock_get.return_value = _response({}, status_code=429)
+
+    with pytest.raises(HTTPException) as exc:
+        movie_search.search_movies('Titanic')
+    assert exc.value.status_code == 502
+    assert mock_get.call_count == tmdb._MAX_ATTEMPTS
+    del mock_sleep
+
+
+@patch('app.services.tmdb.get_settings')
+@patch('app.services.tmdb.requests.get')
+def test_resolve_tmdb_id(mock_get, mock_settings):
+    mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+    mock_get.return_value = _response({'movie_results': [{'id': 597}]})
+    assert movie_search.resolve_tmdb_id('tt0120338') == 597
+
+
+@patch('app.services.tmdb.get_settings')
+@patch('app.services.tmdb.requests.get')
+def test_resolve_tmdb_id_no_match_returns_none(mock_get, mock_settings):
+    mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+    mock_get.return_value = _response({'movie_results': []})
+    assert movie_search.resolve_tmdb_id('tt9999999') is None
+    assert movie_search.resolve_tmdb_id('') is None


### PR DESCRIPTION
Closes #163 (movies portion; book/game cover backfills follow in a separate PR).

## Why

OMDb is **CC BY-NC 4.0 — non-commercial only**, the single hard blocker to ever recouping costs. 1,366 of 1,373 movie posters hotlinked `m.media-amazon.com`. TMDB licenses data and images for application use and publishes **no daily cap** (~40–50 req/s, 20 connections/IP, enforced by 429).

## Two TMDB quirks that shaped the design

**Search returns no IMDb id.** `/search/movie` yields TMDB ids only, so `tmdb` replaces `imdb` as the catalog's join key — `tracked_status` can only badge search hits on something search actually returns. `imdb` is still stored (the detail endpoint supplies it), just not joined on.

**There is no IMDb rating.** `vote_average` is TMDB's own score and lands in the new `rating_tmdb`. `rating_imdb` keeps its imported OMDb-era values as a frozen legacy column — never written or displayed again, because TMDB can never refresh it.

`create_movie` accepts **either** id and resolves the missing one, so imdb-driven callers (MCP, and the IMDb CSV import in #140) keep working while search posts tmdb ids.

## What's here

- `app/services/tmdb.py` — shared client: auth, timeouts, `Retry-After`-aware 429 backoff. Two call styles: `request` raises (→ 503/502), `try_request` returns `None` so enrichment degrades quietly.
- `app/services/movie_search.py` — rewritten on `/search/movie`, `/find`, and `/movie/{id}?append_to_response=credits,release_dates` (director, cast and US certification in one round trip).
- `a1c4f80b6e37` — adds `movies.tmdb` (unique index, NULLs allowed) and `movies.rating_tmdb`.
- `app/migration/backfill_tmdb.py` — resumable, `--dry-run`, ~4 req/s, reports unresolvable ids rather than leaving silent NULLs.

Movie search also gains a real `popularity` signal for the first time — `search_ranking.py:25` notes OMDb never supplied one.

## ⚠️ Deploy order is load-bearing

```
migrate → backfill_tmdb → verify → deploy API + web together
```

Between migrate and backfill every `tmdb` is NULL, so search badges read "not tracked" catalog-wide. Run `task backfill:tmdb -- --dry-run` first. Pairs with druthers-web#71 and druthers-mcp#28 — **must ship together**, the old API rejects a tmdb-keyed create.

`OMDB_API_KEY` can be dropped from prod secrets once the cutover is verified.

## Verification

322 tests pass, pylint 10.00/10, black clean, migration verified up **and** down.

Exercised against **live TMDB**, not just mocks:
- Field mapping: `rated: R` from the US certification block, director filtered from crew, cast capped at 4, `rating_tmdb: 8.252`
- Poster URLs return real JPEGs (HTTP 200)
- Backfill's four cases on a scratch DB with real IMDb ids: legacy host re-pointed, existing TMDB poster left alone, unresolvable id reported, missing poster filled
- Dry run left the DB byte-identical; second run found only the unresolved row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2FUXZMc8JYbEqB23aEGnq