### PR TITLE
Repair legacy book and game cover URLs (#163)

### DIFF
--- a/app/migration/backfill_covers.py
+++ b/app/migration/backfill_covers.py
@@ -1,0 +1,195 @@
+"""
+Cover URL hygiene for books and games (#163).
+
+Both search services already emit correct URLs for anything added today —
+``book_search._cover`` builds covers.openlibrary.org and ``game_search``
+serves IGDB's ``t_cover_big_2x``. This only repairs rows imported before
+that, so it is a pure data backfill with no service changes:
+
+* **Books** — 221 covers still point at books.google.com, left over from the
+  Google Books era. Re-pointed to Open Library, keyed on the row's ISBN.
+* **Games** — legacy covers use IGDB's ``t_thumb`` (~90px, blurry at the
+  size the UI renders). Upgraded by swapping the size token in the URL.
+
+The two domains need different care:
+
+Open Library serves a **blank placeholder with HTTP 200** for an ISBN it has
+no cover for — only ``?default=false`` turns that into a 404. So every book
+candidate is verified before it is written; without that check this would
+silently trade working Google covers for grey boxes.
+
+IGDB renders every size from the same ``image_id``, so a cover that exists
+at ``t_thumb`` exists at the target size too. That substitution is
+deterministic and needs no network call.
+
+Usage::
+
+    DATABASE_URL=... ENV=prod python -m app.migration.backfill_covers --dry-run
+    DATABASE_URL=... ENV=prod python -m app.migration.backfill_covers
+"""
+
+import argparse
+import re
+import time
+from typing import Optional
+
+import requests
+
+from app.db.database import SessionLocal
+from app.db.models_sandbox import DbBook, DbVideoGame
+from app.log.logging_config import logger
+from app.services.game_search import COVER_URL
+
+REQUEST_TIMEOUT = 10
+# Only books hit the network (one HEAD each); 221 rows at ~4/s is under a
+# minute. Games need no requests at all.
+DEFAULT_THROTTLE_SECONDS = 0.25
+
+# Hosts that mean "this cover predates the Open Library switch".
+_LEGACY_BOOK_HOSTS = ('books.google.com', 'books.googleusercontent.com')
+# ``default=false`` is load-bearing — see the module docstring.
+_OPENLIBRARY_COVER = 'https://covers.openlibrary.org/b/isbn/{isbn}-L.jpg'
+_VERIFY_SUFFIX = '?default=false'
+
+# The size token the service currently serves, taken from game_search's own
+# constant so the two can never drift apart.
+_TARGET_SIZE = COVER_URL.rstrip('/').rsplit('/', 1)[-1]
+_IGDB_SIZE_RE = re.compile(r'/t_[a-z0-9_]+/')
+
+
+def _is_legacy_book_cover(poster_url: Optional[str]) -> bool:
+    """True for a cover still served by Google Books."""
+    if not poster_url:
+        return False
+    return any(host in poster_url for host in _LEGACY_BOOK_HOSTS)
+
+
+def openlibrary_cover_url(isbn: Optional[str]) -> Optional[str]:
+    """
+    Open Library cover URL for ``isbn``, or None when the row has no usable
+    ISBN. Hyphens and spacing vary across the imported data, so they're
+    stripped — Open Library wants the bare digits (X is a valid check digit).
+    """
+    if not isbn:
+        return None
+    cleaned = re.sub(r'[^0-9Xx]', '', isbn).upper()
+    if len(cleaned) not in (10, 13):
+        return None
+    return _OPENLIBRARY_COVER.format(isbn=cleaned)
+
+
+def upgrade_igdb_size(poster_url: Optional[str]) -> Optional[str]:
+    """
+    Rewrite an IGDB cover URL to the size the service serves today. Returns
+    None when there's nothing to do — not an IGDB URL, or already correct.
+    """
+    if not poster_url or 'images.igdb.com' not in poster_url:
+        return None
+    if f'/{_TARGET_SIZE}/' in poster_url:
+        return None
+    upgraded = _IGDB_SIZE_RE.sub(f'/{_TARGET_SIZE}/', poster_url, count=1)
+    return upgraded if upgraded != poster_url else None
+
+
+def _cover_exists(url: str) -> bool:
+    """
+    HEAD the candidate with ``default=false`` so a missing cover 404s instead
+    of returning Open Library's blank placeholder. Redirects are followed —
+    a real cover answers with a 302 to the CDN.
+    """
+    try:
+        response = requests.head(
+            f'{url}{_VERIFY_SUFFIX}',
+            timeout=REQUEST_TIMEOUT,
+            allow_redirects=True,
+        )
+        return response.status_code == 200
+    except requests.RequestException as exc:
+        logger.warning('Open Library cover check failed for %s: %s', url, exc)
+        return False
+
+
+def backfill_books(db, throttle: float, dry_run: bool) -> tuple:
+    """Re-point Google Books covers at Open Library. Returns (fixed, skipped)."""
+    rows = db.query(DbBook).all()
+    pending = [b for b in rows if _is_legacy_book_cover(b.poster_url)]
+    print(f'{len(pending)} book covers still on Google Books')
+
+    fixed = 0
+    skipped = []
+    for book in pending:
+        candidate = openlibrary_cover_url(book.isbn)
+        if not candidate:
+            skipped.append((book.title, 'no usable ISBN'))
+            continue
+        if not _cover_exists(candidate):
+            # Leaving the Google cover in place beats a blank placeholder.
+            skipped.append((book.title, 'no Open Library cover'))
+            time.sleep(throttle)
+            continue
+        if not dry_run:
+            book.poster_url = candidate
+            db.commit()
+        fixed += 1
+        time.sleep(throttle)
+
+    return fixed, skipped
+
+
+def backfill_games(db, dry_run: bool) -> int:
+    """Upgrade legacy IGDB cover sizes. Returns the number changed."""
+    rows = db.query(DbVideoGame).all()
+    fixed = 0
+    for game in rows:
+        upgraded = upgrade_igdb_size(game.poster_url)
+        if not upgraded:
+            continue
+        if not dry_run:
+            game.poster_url = upgraded
+        fixed += 1
+    if not dry_run:
+        db.commit()
+    print(f'{fixed} game covers upgraded to {_TARGET_SIZE}')
+    return fixed
+
+
+def run(throttle: float = DEFAULT_THROTTLE_SECONDS, dry_run: bool = False) -> None:
+    """Repair legacy book and game cover URLs."""
+    db = SessionLocal()
+    try:
+        if dry_run:
+            print('(dry run — no writes)')
+        books_fixed, books_skipped = backfill_books(db, throttle, dry_run)
+        games_fixed = backfill_games(db, dry_run)
+        print(
+            f'\nDone: {books_fixed} book covers re-pointed, '
+            f'{games_fixed} game covers upgraded'
+        )
+        if books_skipped:
+            print(f'\n{len(books_skipped)} books left on Google Books:')
+            for title, reason in books_skipped:
+                print(f'  {title[:60]:<60} {reason}')
+    finally:
+        db.close()
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description='Repair legacy cover URLs.')
+    parser.add_argument(
+        '--throttle',
+        type=float,
+        default=DEFAULT_THROTTLE_SECONDS,
+        help=f'seconds between book checks (default {DEFAULT_THROTTLE_SECONDS})',
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='report what would change without writing',
+    )
+    args = parser.parse_args()
+    run(throttle=args.throttle, dry_run=args.dry_run)
+
+
+if __name__ == '__main__':
+    main()

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -48,6 +48,11 @@ tasks:
     cmds:
       - alembic revision --autogenerate -m "{{.MSG}}"
 
+  backfill:covers:
+    desc: "Re-point legacy book covers to Open Library, upgrade IGDB cover sizes"
+    cmds:
+      - python -m app.migration.backfill_covers {{.CLI_ARGS}}
+
   enrich:movies:
     desc: "Backfill OMDB detail for existing movies (throttled, resumable)"
     cmds:

--- a/tests/unit/backfill_covers_test.py
+++ b/tests/unit/backfill_covers_test.py
@@ -1,0 +1,98 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+# pylint: disable=protected-access
+from unittest.mock import MagicMock, patch
+
+from app.migration import backfill_covers
+
+
+def test_detects_legacy_book_hosts():
+    assert backfill_covers._is_legacy_book_cover(
+        'http://books.google.com/books/content?id=x'
+    )
+    assert backfill_covers._is_legacy_book_cover(
+        'https://books.googleusercontent.com/x.jpg'
+    )
+
+
+def test_openlibrary_covers_are_left_alone():
+    assert not backfill_covers._is_legacy_book_cover(
+        'https://covers.openlibrary.org/b/id/123-L.jpg'
+    )
+    assert not backfill_covers._is_legacy_book_cover(None)
+
+
+def test_openlibrary_url_normalizes_isbn():
+    # Hyphenation varies across the imported data.
+    assert (
+        backfill_covers.openlibrary_cover_url('978-0-441-01359-3')
+        == 'https://covers.openlibrary.org/b/isbn/9780441013593-L.jpg'
+    )
+    # X is a valid ISBN-10 check digit and must survive.
+    assert backfill_covers.openlibrary_cover_url('080442957x').endswith(
+        '080442957X-L.jpg'
+    )
+
+
+def test_openlibrary_url_rejects_unusable_isbn():
+    assert backfill_covers.openlibrary_cover_url(None) is None
+    assert backfill_covers.openlibrary_cover_url('') is None
+    assert backfill_covers.openlibrary_cover_url('12345') is None
+
+
+def test_igdb_size_upgrade():
+    assert (
+        backfill_covers.upgrade_igdb_size(
+            'https://images.igdb.com/igdb/image/upload/t_thumb/co1r7f.jpg'
+        )
+        == 'https://images.igdb.com/igdb/image/upload/t_cover_big_2x/co1r7f.jpg'
+    )
+
+
+def test_igdb_upgrade_skips_current_size_and_foreign_urls():
+    # Already at the size the service serves — nothing to do.
+    assert (
+        backfill_covers.upgrade_igdb_size(
+            'https://images.igdb.com/igdb/image/upload/t_cover_big_2x/co1r7f.jpg'
+        )
+        is None
+    )
+    assert (
+        backfill_covers.upgrade_igdb_size('https://example.com/t_thumb/x.jpg') is None
+    )
+    assert backfill_covers.upgrade_igdb_size(None) is None
+
+
+def test_target_size_tracks_the_service_constant():
+    """The target is derived from game_search.COVER_URL so they can't drift."""
+    assert backfill_covers.COVER_URL.endswith(backfill_covers._TARGET_SIZE)
+
+
+@patch('app.migration.backfill_covers.requests.head')
+def test_cover_exists_requires_default_false(mock_head):
+    """
+    Open Library returns a blank placeholder with HTTP 200 unless
+    default=false is passed, so the check must send it.
+    """
+    mock_head.return_value = MagicMock(status_code=200)
+    assert backfill_covers._cover_exists(
+        'https://covers.openlibrary.org/b/isbn/9780441013593-L.jpg'
+    )
+    called_url = mock_head.call_args[0][0]
+    assert called_url.endswith('?default=false')
+    assert mock_head.call_args.kwargs['allow_redirects'] is True
+
+
+@patch('app.migration.backfill_covers.requests.head')
+def test_missing_cover_is_not_written(mock_head):
+    mock_head.return_value = MagicMock(status_code=404)
+    assert not backfill_covers._cover_exists(
+        'https://covers.openlibrary.org/b/isbn/9999999999999-L.jpg'
+    )
+
+
+@patch('app.migration.backfill_covers.requests.head')
+def test_network_failure_leaves_cover_alone(mock_head):
+    mock_head.side_effect = backfill_covers.requests.RequestException('boom')
+    assert not backfill_covers._cover_exists(
+        'https://covers.openlibrary.org/b/isbn/9780441013593-L.jpg'
+    )


### PR DESCRIPTION
Completes #163 alongside #220 (the movies half). Independent of that PR — this touches books and games only, so it branches from `main` and can merge in either order.

## Pure data backfill, no service changes

Both search services already emit correct URLs for anything added today: `book_search._cover` builds `covers.openlibrary.org`, and `game_search` serves IGDB's `t_cover_big_2x`. Only rows imported before that are wrong.

- **Books** — 221 covers still point at `books.google.com` from the Google Books era → re-pointed to Open Library, keyed on the row's ISBN
- **Games** — legacy covers use IGDB's `t_thumb` (~90px, blurry at the size the UI renders) → upgraded by swapping the size token

## The two domains need different care

**Open Library serves a blank placeholder with HTTP 200** for an ISBN it has no cover for. Only `?default=false` turns that into a 404:

```
9999999999999-L.jpg                    -> 200  (blank placeholder!)
9999999999999-L.jpg?default=false      -> 404
```

So every book candidate is verified before it's written. Without that check this would silently trade working Google covers for grey boxes — worse than leaving them alone. Rows that fail keep their Google cover and are reported by title, so the remainder can be handled by hand.

**IGDB renders every size from the same `image_id`**, so a cover that exists at `t_thumb` exists at the target size too. Deterministic, no network call. The target is derived from `game_search.COVER_URL` rather than hardcoded, so the backfill and the service can't drift — there's a test asserting exactly that.

ISBNs are normalized before use (hyphenation varies across the imported data; the `X` check digit is preserved).

## Verification

320 tests pass, pylint 10.00/10, black clean.

Exercised end to end on a scratch DB covering every branch:

| Row | Outcome |
|---|---|
| Real ISBN with an OL cover | re-pointed; written URL returns `image/jpeg` |
| ISBN with no OL cover | left on Google, reported |
| No ISBN | left on Google, reported |
| Already on Open Library | untouched |
| IGDB `t_thumb` | upgraded; URL returns `image/jpeg` |
| Already `t_cover_big_2x` / NULL | untouched |

Dry run left the DB byte-identical; a second run is a no-op.

Run with `task backfill:covers -- --dry-run` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2FUXZMc8JYbEqB23aEGnq