### PR TITLE
Run catalog backfills as part of the release (#163)

### DIFF
--- a/.github/workflows/deploy_cloud_run.yaml
+++ b/.github/workflows/deploy_cloud_run.yaml
@@ -2,8 +2,15 @@ name: Deploy to Cloud Run
 
 # Prod deploys are release-driven (see druthers-infra/docs/PROMOTION.md):
 # publishing a vX.Y.Z release builds the image into Artifact Registry,
-# runs alembic migrations against Neon, and rolls the druthers-api service.
+# runs alembic migrations against Neon, backfills any data the new schema
+# needs, and rolls the druthers-api service.
 # No-ops until the GCP_* repo variables exist (set by the launch runbook).
+#
+# Order matters: backfills run *between* the migration and the Cloud Run
+# roll, so the data a release depends on is in place before the code that
+# reads it goes live. Running them after the roll would leave a window where
+# the new code queries columns the backfill hasn't filled yet — for #163 that
+# window showed every movie as "not tracked" in search.
 
 on:
   release:
@@ -38,16 +45,45 @@ jobs:
           docker push "$IMAGE"
 
       - name: Run database migrations
+        id: migrate
         env:
           DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
           ENV: prod
         run: |
           if [ -z "$DATABASE_URL" ]; then
             echo "NEON_DATABASE_URL secret not set — skipping migrations."
+            echo "ran=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           pip install -r requirements/base.txt
           alembic upgrade head
+          echo "ran=true" >> "$GITHUB_OUTPUT"
+
+      # Both backfills are idempotent and resumable: they only touch rows that
+      # still need work, so re-running on every release is a near-no-op once
+      # the catalog is keyed. That is deliberate — it makes a release
+      # self-contained instead of depending on someone remembering to run
+      # these by hand afterwards.
+      - name: Backfill catalog data
+        if: steps.migrate.outputs.ran == 'true'
+        env:
+          DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+          ENV: prod
+        run: |
+          set -euo pipefail
+          # A missing key is not a soft failure here: resolve_tmdb_id would
+          # return None for every row, the script would report "0 resolved"
+          # and exit 0, and the deploy would ship a catalog whose search
+          # badges are all blank. Fail loudly instead.
+          if [ -z "$TMDB_API_KEY" ]; then
+            echo "::error::TMDB_API_KEY secret is not set. backfill_tmdb cannot"
+            echo "::error::resolve any movie and the release would deploy with"
+            echo "::error::an unkeyed catalog. Add the secret and re-run."
+            exit 1
+          fi
+          python -m app.migration.backfill_tmdb
+          python -m app.migration.backfill_covers
 
       - name: Deploy to Cloud Run
         run: |


### PR DESCRIPTION
## The gap this closes

The TMDB migration added a step the pipeline doesn't know about. `alembic upgrade head` creates `movies.tmdb`, but only `app.migration.backfill_tmdb` **populates** it.

So publishing a release today does:

1. migration adds `tmdb` — all 1,373 movies NULL
2. Cloud Run rolls, new code keys search on `tmdb`
3. every movie reads "not tracked" in search until someone manually runs the backfill

That's a real user-visible regression that depends entirely on a human remembering a step.

## The fix

Backfills run **between** the migration and the Cloud Run roll:

```
migrate -> backfill -> deploy
```

so the data a release depends on is in place *before* the code that reads it goes live. Running them after the roll would leave the same window open, just shorter.

Both scripts are idempotent and resumable — they only touch rows that still need work — so running them on every release is a near-no-op once the catalog is keyed, and a re-run after a transient failure continues where it stopped.

## ⚠️ Needs a new Actions secret before the next release

**`TMDB_API_KEY` must be added to repo Actions secrets.** The value already exists in Secret Manager as `druthers-tmdb-key`; this just needs it available to the workflow, matching how `NEON_DATABASE_URL` is already handled.

**A missing key fails the step rather than warning.** That's deliberate: without a key `resolve_tmdb_id` returns `None` for every row, so the script would print "0 resolved" and exit 0 — a successful-looking no-op that ships a broken catalog. A loud failure is much better than a green checkmark over a broken deploy.

If you'd rather not duplicate the secret, the alternative is granting the deploy SA `secretAccessor` on `druthers-tmdb-key` and reading it via gcloud in the step. I matched the existing `NEON_DATABASE_URL` pattern instead, since that's what the workflow already does.

## Verification

YAML parses; step ordering asserted (migrate → backfill → deploy). The backfill step is gated on the migration actually having run, so the existing "no `NEON_DATABASE_URL` → skip" behavior still short-circuits cleanly rather than failing on missing dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2FUXZMc8JYbEqB23aEGnq