### PR TITLE
Remove OMDb remnants (#163)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -72,8 +72,7 @@ class Settings(BaseSettings):
     # --- CORS (comma-separated origins) ---
     cors_origins: str = 'http://localhost:3000'
 
-    # --- External APIs (movies search proxy) ---
-    omdb_api_key: Optional[str] = None
+    # --- External APIs (movies search proxy — TMDB) ---
     tmdb_api_key: Optional[str] = None
 
     # --- External APIs (games search proxy — IGDB via Twitch OAuth) ---

--- a/app/services/game_search.py
+++ b/app/services/game_search.py
@@ -9,7 +9,7 @@ also the enrichment source, keyed on the catalog's ``igdb`` id: release
 year, genres, platforms, summary, rating (0–100), and cover art.
 
 Raises 503 when ``TWITCH_CLIENT_ID``/``TWITCH_CLIENT_SECRET`` are not
-configured (same graceful degradation as the OMDB movie search).
+configured (same graceful degradation as the TMDB movie search).
 """
 
 import time

--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -33,7 +33,7 @@ def sweep_movie_releases(db: Session, user_pk: int) -> int:
     Notify about watchlist movies whose release date lands within the next
     ``RELEASE_WINDOW_DAYS`` days. Returns the number of notifications created.
     """
-    # release_date is stored tz-naive (parsed from OMDB), so compare naive.
+    # release_date is stored tz-naive (parsed from TMDB), so compare naive.
     today = datetime.now(timezone.utc).replace(
         hour=0, minute=0, second=0, microsecond=0, tzinfo=None
     )

--- a/app/services/search_correction.py
+++ b/app/services/search_correction.py
@@ -1,7 +1,7 @@
 """
 Spelling fallback for the search proxies.
 
-The external providers (OMDB especially) do exact-ish matching, so a typo
+The external providers do exact-ish matching, so a typo
 like "jurrasic" returns nothing. When a search comes back empty, the routers
 retry once with a spell-corrected query. Correction is per-word against an
 offline English dictionary; words it can't improve pass through unchanged,

--- a/app/services/search_ranking.py
+++ b/app/services/search_ranking.py
@@ -19,15 +19,18 @@ fuzzy-matching library:
        *contains* it. Prefix position alone shouldn't decide that matchup.
 
 Within the partial-match tier (and as a tiebreaker anywhere else), we sort
-by each hit's ``popularity`` field when a provider supplies one (IGDB's
-``total_rating_count``, for example) — real popularity is a much stronger
-signal than where in the title the query happens to appear. When
-``popularity`` is absent (OMDB's movie search returns none) it defaults to
-0 for every hit, which makes the sort a no-op and falls back to the
-provider's own result order — Python's ``sorted`` is stable, so that order
-is preserved automatically. The ranked list is then capped to ``limit`` per
-domain so the UI shows a short, best-first list instead of a long unranked
-one.
+by each hit's ``popularity`` field when a provider supplies one — real
+popularity is a much stronger signal than where in the title the query
+happens to appear. Games carry IGDB's ``total_rating_count`` and movies
+carry TMDB's ``popularity`` (gained in #163; OMDb supplied none, so movie
+search had no tiebreaker at all before that). TV and books still have no
+such field: TVMaze and Open Library don't publish one.
+
+Where ``popularity`` is absent it defaults to 0 for every hit, which makes
+the sort a no-op and falls back to the provider's own result order —
+Python's ``sorted`` is stable, so that order is preserved automatically.
+The ranked list is then capped to ``limit`` per domain so the UI shows a
+short, best-first list instead of a long unranked one.
 """
 
 import re

--- a/tests/unit/search_ranking_test.py
+++ b/tests/unit/search_ranking_test.py
@@ -27,7 +27,7 @@ def test_partial_match_popularity_beats_prefix_position():
 
 
 def test_partial_match_without_popularity_preserves_provider_order():
-    # No popularity data (e.g. OMDB movie search doesn't return any) —
+    # No popularity data (e.g. TVMaze and Open Library don't supply any) —
     # prefix and contains matches are treated as equally valid partial
     # matches, and the provider's own result order is the tiebreaker.
     hits = [


### PR DESCRIPTION
Nothing has called OMDb since the TMDB migration, and the Secret Manager secrets and Cloud Run mappings are now deleted in **both prod and QA** (verified). This clears what was left in the code.

Pairs with **ALeonard9/druthers-infra#23**, which removes the last references to the now-deleted secret from the provisioning scripts.

## What changed

**One functional reference** — `Settings.omdb_api_key` in `app/config.py`.

**Five stale comments**, one of which had become actively wrong. `search_ranking.py`'s docstring said:

> *"When `popularity` is absent (OMDB's movie search returns none) it defaults to 0..."*

TMDB **does** supply `popularity`, so movies now rank the same way games always have. The domains genuinely without it are TV and books — TVMaze and Open Library don't publish one. Rewrote the docstring to say that, since the old text would have misled anyone reasoning about why movie search ordering changed.

## Verification

332 tests pass, pylint 10.00/10, black clean. `grep -rn "omdb\|OMDB" app/ tests/` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2FUXZMc8JYbEqB23aEGnq