### PR TITLE
Serve streaming availability from TMDB (druthers-web#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ All endpoints are prefixed with `/v1`; protected routes require `Authorization: 
 | **Catalog** (movies · tv-shows · books · games) | `GET /v1/{domain}` · admin `POST/PUT/DELETE` |
 | **My library** | `GET /v1/users/me/{domain}` · `POST/PUT/DELETE /v1/users/me/{domain}/{id}` (mark watched/played/read, notes, dates) |
 | **TV episodes** | `…/tv-shows/{id}/episodes` · `…/users/me/episodes` |
+| **Streaming availability** | `GET /v1/movies/{id}/watch-providers` · `GET /v1/tv-shows/{id}/watch-providers` (`?region=US`, JustWatch via TMDB) |
 | **Docs** | `/docs` (Swagger) · `/redoc` · `/openapi.json` |
 
 ## Customer-facing docs
@@ -101,6 +102,7 @@ Auto-generated docs: **Swagger UI** at `/docs`, **ReDoc** at `/redoc`, raw schem
 | **Catalog** (movies · tv-shows · books · games) | `GET /v1/{domain}` · admin `POST/PUT/DELETE` |
 | **My library** | `GET /v1/users/me/{domain}` · `POST/PUT/DELETE /v1/users/me/{domain}/{id}` (mark watched/played/read, notes, dates) |
 | **TV episodes** | `…/tv-shows/{id}/episodes` · `…/users/me/episodes` |
+| **Streaming availability** | `GET /v1/movies/{id}/watch-providers` · `GET /v1/tv-shows/{id}/watch-providers` (`?region=US`, JustWatch via TMDB) |
 
 ## Security
 

--- a/app/router/v1/router_movies.py
+++ b/app/router/v1/router_movies.py
@@ -28,6 +28,7 @@ from app.schemas.schemas_sandbox import (
     UserMovieCreate,
     UserMovieResponse,
     UserMovieUpdate,
+    WatchProviders,
 )
 from app.services.movie_search import (
     apply_detail_to_movie,
@@ -35,6 +36,7 @@ from app.services.movie_search import (
     resolve_tmdb_id,
     search_movies as tmdb_search_movies,
 )
+from app.services.watch_providers import DEFAULT_REGION, get_movie_providers
 from app.services.search_correction import correct_query
 from app.services.tracked_status import attach_tracked_status
 from app.services.tracker_query import (
@@ -147,6 +149,25 @@ def get_movie(
             db.commit()
             db.refresh(movie)
     return movie
+
+
+@router.get('/movies/{movie_id}/watch-providers', response_model=WatchProviders)
+def get_movie_watch_providers(
+    movie_id: str,
+    region: str = DEFAULT_REGION,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """
+    Where this movie can be streamed, rented or bought in ``region`` (web#26).
+
+    Live TMDB/JustWatch data, not catalog data, so nothing here is stored. A
+    movie with no availability — or one the backfill never keyed onto TMDB —
+    returns empty buckets rather than an error; only an unknown movie 404s.
+    """
+    del current_user
+    movie = _get_movie(db, movie_id)
+    return get_movie_providers(movie.tmdb, region)
 
 
 @router.put('/movies/{movie_id}', response_model=MovieResponse)

--- a/app/router/v1/router_tv.py
+++ b/app/router/v1/router_tv.py
@@ -47,7 +47,9 @@ from app.schemas.schemas_sandbox import (
     UserTVShowResponse,
     UserTVShowUpdate,
     UserTVShowWithStatus,
+    WatchProviders,
 )
+from app.services.watch_providers import DEFAULT_REGION, get_tv_providers
 from app.services.tv_search import (
     apply_detail_to_show,
     get_tv_show_detail,
@@ -145,6 +147,24 @@ def get_tv_show(
             db.commit()
             db.refresh(show)
     return show
+
+
+@router.get('/tv-shows/{show_id}/watch-providers', response_model=WatchProviders)
+def get_tv_watch_providers(
+    show_id: str,
+    region: str = DEFAULT_REGION,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """
+    Where this show can be streamed, rented or bought in ``region`` (web#26).
+
+    Keyed on the show's IMDb id, since the catalog's TV data comes from TVMaze
+    and carries no TMDB id; a show without one returns empty buckets.
+    """
+    del current_user
+    show = _get_show(db, show_id)
+    return get_tv_providers(show.imdb, region)
 
 
 @router.put('/tv-shows/{show_id}', response_model=TVShowResponse)

--- a/app/schemas/schemas_sandbox.py
+++ b/app/schemas/schemas_sandbox.py
@@ -75,6 +75,37 @@ class CountryRankingReorder(BaseModel):
     country_ids: List[str]
 
 
+# --- Watch providers (shared by Movies and TV) ---
+class WatchProvider(BaseModel):
+    """One streaming service a title is available on."""
+
+    provider_id: Optional[int] = None
+    name: str
+    logo_url: Optional[str] = None
+
+
+class WatchProviders(BaseModel):
+    """
+    Where a title can be watched in one region (web#26).
+
+    Never 404s and never errors: a title with no availability — or one TMDB
+    can't resolve — comes back with empty buckets, so the detail page renders
+    the same either way. ``attribution`` carries the credit TMDB requires
+    wherever this data is displayed.
+    """
+
+    region: str
+    # TMDB's own "watch" page for the title, JustWatch-powered; None when the
+    # title has no availability in this region.
+    link: Optional[str] = None
+    attribution: str
+    # Subscription (Netflix, Max), free/ad-supported (Tubi), and transactional.
+    stream: List[WatchProvider] = []
+    free: List[WatchProvider] = []
+    rent: List[WatchProvider] = []
+    buy: List[WatchProvider] = []
+
+
 # --- Movies ---
 class MovieBase(BaseModel):
     title: str

--- a/app/services/watch_providers.py
+++ b/app/services/watch_providers.py
@@ -1,0 +1,205 @@
+"""
+Streaming availability ("where can I watch this") from TMDB (web#26).
+
+TMDB's ``/watch/providers`` endpoints resell JustWatch's availability data, so
+one provider covers both movie metadata and streaming availability — which is
+why this landed on top of the OMDb->TMDB migration (#163) rather than as a
+separate JustWatch integration.
+
+Two things shape this module:
+
+* **TV is not on TMDB.** The catalog's shows come from TVMaze and carry no
+  TMDB id, only an IMDb id from TVMaze's ``externals`` block. So a show has to
+  be resolved through TMDB's ``/find`` endpoint first; movies already store
+  the ``tmdb`` id the lookup needs.
+* **Availability is live data, not catalog data.** Nothing is persisted —
+  where a title streams changes without warning, and a stale row is worse
+  than no row. The TTL cache below keeps detail views off TMDB's rate limit
+  without pretending we own the data.
+
+TMDB requires that any surface using this data attribute JustWatch as the
+source; :data:`ATTRIBUTION` is served alongside every response so the frontends
+can't render the logos without it.
+"""
+
+import re
+import threading
+import time
+from typing import List, Optional
+
+from app.log.logging_config import logger
+from app.services import tmdb
+
+# TMDB asks for JustWatch to be credited wherever this data is shown.
+ATTRIBUTION = 'JustWatch'
+
+DEFAULT_REGION = 'US'
+_REGION_RE = re.compile(r'^[A-Za-z]{2}$')
+
+# JustWatch refreshes availability roughly daily; six hours keeps a detail page
+# off the wire without letting a removed title linger for a day.
+_CACHE_TTL_SECONDS = 6 * 60 * 60
+
+# TMDB's per-region keys, mapped to the buckets the UI groups by. ``ads`` is
+# folded into ``free`` because from a viewer's side both mean "no extra
+# payment" — Tubi and Pluto are ad-supported and belong next to the free tier,
+# not in their own row.
+_BUCKETS = {
+    'stream': ('flatrate',),
+    'free': ('free', 'ads'),
+    'rent': ('rent',),
+    'buy': ('buy',),
+}
+
+_lock = threading.Lock()
+_cache: dict = {}
+
+
+def reset_cache() -> None:
+    """Drop every cached lookup (tests, and anything that needs a cold read)."""
+    with _lock:
+        _cache.clear()
+
+
+def _cached(key, loader):
+    """
+    Memoize ``loader()`` under ``key`` for :data:`_CACHE_TTL_SECONDS`.
+
+    Failures are cached as ``None`` too: a title TMDB has never heard of would
+    otherwise re-ask on every page view.
+    """
+    now = time.monotonic()
+    with _lock:
+        entry = _cache.get(key)
+        if entry is not None and entry[0] > now:
+            return entry[1]
+
+    value = loader()
+
+    with _lock:
+        _cache[key] = (now + _CACHE_TTL_SECONDS, value)
+    return value
+
+
+def normalize_region(region: Optional[str]) -> str:
+    """
+    Coerce a caller-supplied region to the ISO-3166-1 alpha-2 code TMDB keys
+    its results by. Anything unrecognizable falls back to
+    :data:`DEFAULT_REGION` rather than 400ing — a bad region should degrade to
+    "US availability", not break the detail page.
+    """
+    region = (region or '').strip()
+    if not _REGION_RE.match(region):
+        return DEFAULT_REGION
+    return region.upper()
+
+
+def _provider(entry: dict) -> Optional[dict]:
+    """Map one TMDB provider object to the shape the API returns."""
+    name = (entry.get('provider_name') or '').strip()
+    if not name:
+        return None
+    return {
+        'provider_id': entry.get('provider_id'),
+        'name': name,
+        'logo_url': tmdb.image_url(entry.get('logo_path'), tmdb.LOGO_SIZE),
+    }
+
+
+def _bucket(region_block: dict, keys) -> List[dict]:
+    """
+    Collect the providers under ``keys``, ordered by TMDB's display_priority
+    and de-duplicated by provider — a service listed under both ``free`` and
+    ``ads`` must not render twice.
+    """
+    entries = []
+    for key in keys:
+        entries.extend(region_block.get(key) or [])
+    entries.sort(key=lambda e: e.get('display_priority') or 0)
+
+    providers = []
+    seen = set()
+    for entry in entries:
+        provider = _provider(entry)
+        if provider is None:
+            continue
+        marker = provider['provider_id'] or provider['name']
+        if marker in seen:
+            continue
+        seen.add(marker)
+        providers.append(provider)
+    return providers
+
+
+def _shape(payload: Optional[dict], region: str) -> dict:
+    """
+    Reduce a raw ``/watch/providers`` payload to one region's buckets.
+
+    A title TMDB doesn't carry, or one with no availability in ``region``,
+    yields the same empty-but-valid response — "we looked and found nothing"
+    and "we couldn't look" are the same story for the viewer, and the frontend
+    renders neither.
+    """
+    results = (payload or {}).get('results') or {}
+    region_block = results.get(region) or {}
+    return {
+        'region': region,
+        'link': region_block.get('link'),
+        'attribution': ATTRIBUTION,
+        **{name: _bucket(region_block, keys) for name, keys in _BUCKETS.items()},
+    }
+
+
+def get_movie_providers(tmdb_id, region: str = DEFAULT_REGION) -> dict:
+    """
+    Streaming availability for a movie by TMDB id.
+
+    Always returns a valid (possibly empty) response: a movie the backfill
+    couldn't key onto TMDB has no id to look up, and an unreachable TMDB
+    should leave the detail page intact.
+    """
+    region = normalize_region(region)
+    if not tmdb_id:
+        return _shape(None, region)
+
+    payload = _cached(
+        ('movie', tmdb_id, region),
+        lambda: tmdb.try_request(f'/movie/{tmdb_id}/watch/providers'),
+    )
+    return _shape(payload, region)
+
+
+def _resolve_tv_tmdb_id(imdb_id: str) -> Optional[int]:
+    """
+    Map a show's IMDb id (stored by the TVMaze enrichment) to TMDB's tv id.
+    Returns None when TMDB has no matching show.
+    """
+    payload = tmdb.try_request(f'/find/{imdb_id}', {'external_source': 'imdb_id'})
+    if payload is None:
+        return None
+    results = payload.get('tv_results') or []
+    if not results:
+        logger.info('TMDB has no tv show for imdb id %s', imdb_id)
+        return None
+    return results[0].get('id')
+
+
+def get_tv_providers(imdb_id: Optional[str], region: str = DEFAULT_REGION) -> dict:
+    """
+    Streaming availability for a TV show, keyed by the IMDb id the catalog
+    stores (see module docstring — shows have no TMDB id of their own).
+    """
+    region = normalize_region(region)
+    imdb_id = (imdb_id or '').strip()
+    if not imdb_id:
+        return _shape(None, region)
+
+    tmdb_id = _cached(('tv-id', imdb_id), lambda: _resolve_tv_tmdb_id(imdb_id))
+    if not tmdb_id:
+        return _shape(None, region)
+
+    payload = _cached(
+        ('tv', tmdb_id, region),
+        lambda: tmdb.try_request(f'/tv/{tmdb_id}/watch/providers'),
+    )
+    return _shape(payload, region)

--- a/docs/druthers-api.postman_collection.json
+++ b/docs/druthers-api.postman_collection.json
@@ -1146,7 +1146,7 @@
             },
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"title\": \"string\",\n  \"imdb\": \"string\",\n  \"release_date\": \"2026-01-01T00:00:00Z\",\n  \"rating_imdb\": 0\n}",
+              "raw": "{\n  \"title\": \"string\",\n  \"tmdb\": 0,\n  \"imdb\": \"string\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -1223,7 +1223,42 @@
                 }
               ]
             },
-            "description": "Return one movie's full detail, enriching from OMDB on first view."
+            "description": "Return one movie's full detail, enriching from TMDB on first view."
+          }
+        },
+        {
+          "name": "Get Movie Watch Providers",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/movies/:movie_id/watch-providers?region=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "movies",
+                ":movie_id",
+                "watch-providers"
+              ],
+              "query": [
+                {
+                  "key": "region",
+                  "value": "",
+                  "description": "",
+                  "disabled": true
+                }
+              ],
+              "variable": [
+                {
+                  "key": "movie_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Where this movie can be streamed, rented or bought in ``region`` (web#26).\n\nLive TMDB/JustWatch data, not catalog data, so nothing here is stored. A\nmovie with no availability \u2014 or one the backfill never keyed onto TMDB \u2014\nreturns empty buckets rather than an error; only an unknown movie 404s."
           }
         },
         {
@@ -1506,7 +1541,7 @@
             },
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"title\": \"string\",\n  \"imdb\": \"string\",\n  \"release_date\": \"2026-01-01T00:00:00Z\",\n  \"rating_imdb\": 0,\n  \"runtime\": 0,\n  \"language\": \"string\",\n  \"rated\": \"string\",\n  \"poster_url\": \"string\",\n  \"year\": 0,\n  \"genre\": \"string\",\n  \"director\": \"string\",\n  \"actors\": \"string\",\n  \"plot\": \"string\"\n}",
+              "raw": "{\n  \"title\": \"string\",\n  \"tmdb\": 0,\n  \"imdb\": \"string\",\n  \"release_date\": \"2026-01-01T00:00:00Z\",\n  \"rating_imdb\": 0,\n  \"rating_tmdb\": 0,\n  \"runtime\": 0,\n  \"language\": \"string\",\n  \"rated\": \"string\",\n  \"poster_url\": \"string\",\n  \"year\": 0,\n  \"genre\": \"string\",\n  \"director\": \"string\",\n  \"actors\": \"string\",\n  \"plot\": \"string\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -1963,6 +1998,41 @@
               ]
             },
             "description": "Return one show's full detail, enriching from TVMaze on first view."
+          }
+        },
+        {
+          "name": "Get Tv Watch Providers",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/tv-shows/:show_id/watch-providers?region=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "tv-shows",
+                ":show_id",
+                "watch-providers"
+              ],
+              "query": [
+                {
+                  "key": "region",
+                  "value": "",
+                  "description": "",
+                  "disabled": true
+                }
+              ],
+              "variable": [
+                {
+                  "key": "show_id",
+                  "value": "",
+                  "description": ""
+                }
+              ]
+            },
+            "description": "Where this show can be streamed, rented or bought in ``region`` (web#26).\n\nKeyed on the show's IMDb id, since the catalog's TV data comes from TVMaze\nand carries no TMDB id; a show without one returns empty buckets."
           }
         },
         {

--- a/openapi.json
+++ b/openapi.json
@@ -4,9 +4,8 @@
     "title": "druthers.io API local",
     "description": "API for druthers.io \u2014 track and rank the movies, TV, books, and games you actually care about.",
     "contact": {
-      "name": "Adam",
-      "url": "https://www.druthers.io/",
-      "email": "aleonard9@hotmail.com"
+      "name": "Druthers",
+      "url": "https://www.druthers.io/"
     },
     "license": {
       "name": "GPL-3.0",
@@ -15,6 +14,10 @@
     "version": "0.0.1"
   },
   "servers": [
+    {
+      "url": "https://api.druthers.io",
+      "description": "Production server"
+    },
     {
       "url": "http://localhost:8000",
       "description": "Local server"
@@ -1022,7 +1025,7 @@
           "Movies"
         ],
         "summary": "Get Movie",
-        "description": "Return one movie's full detail, enriching from OMDB on first view.",
+        "description": "Return one movie's full detail, enriching from TMDB on first view.",
         "operationId": "get_movie_v1_movies__movie_id__get",
         "security": [
           {
@@ -1143,6 +1146,64 @@
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/movies/{movie_id}/watch-providers": {
+      "get": {
+        "tags": [
+          "Movies"
+        ],
+        "summary": "Get Movie Watch Providers",
+        "description": "Where this movie can be streamed, rented or bought in ``region`` (web#26).\n\nLive TMDB/JustWatch data, not catalog data, so nothing here is stored. A\nmovie with no availability \u2014 or one the backfill never keyed onto TMDB \u2014\nreturns empty buckets rather than an error; only an unknown movie 404s.",
+        "operationId": "get_movie_watch_providers_v1_movies__movie_id__watch_providers_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "movie_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Movie Id"
+            }
+          },
+          {
+            "name": "region",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "US",
+              "title": "Region"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WatchProviders"
+                }
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
@@ -3162,6 +3223,64 @@
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/tv-shows/{show_id}/watch-providers": {
+      "get": {
+        "tags": [
+          "TV"
+        ],
+        "summary": "Get Tv Watch Providers",
+        "description": "Where this show can be streamed, rented or bought in ``region`` (web#26).\n\nKeyed on the show's IMDb id, since the catalog's TV data comes from TVMaze\nand carries no TMDB id; a show without one returns empty buckets.",
+        "operationId": "get_tv_watch_providers_v1_tv_shows__show_id__watch_providers_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "show_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Show Id"
+            }
+          },
+          {
+            "name": "region",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "US",
+              "title": "Region"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WatchProviders"
+                }
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
@@ -6235,8 +6354,26 @@
             "type": "string",
             "title": "Title"
           },
+          "tmdb": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tmdb"
+          },
           "imdb": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Imdb"
           },
           "release_date": {
@@ -6261,6 +6398,17 @@
               }
             ],
             "title": "Rating Imdb"
+          },
+          "rating_tmdb": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rating Tmdb"
           },
           "runtime": {
             "anyOf": [
@@ -6364,8 +6512,7 @@
         },
         "type": "object",
         "required": [
-          "title",
-          "imdb"
+          "title"
         ],
         "title": "MovieCreate"
       },
@@ -6375,8 +6522,26 @@
             "type": "string",
             "title": "Title"
           },
+          "tmdb": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tmdb"
+          },
           "imdb": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Imdb"
           },
           "release_date": {
@@ -6401,6 +6566,17 @@
               }
             ],
             "title": "Rating Imdb"
+          },
+          "rating_tmdb": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rating Tmdb"
           },
           "runtime": {
             "anyOf": [
@@ -6519,7 +6695,6 @@
         "type": "object",
         "required": [
           "title",
-          "imdb",
           "id",
           "created_at",
           "updated_at"
@@ -6528,8 +6703,19 @@
       },
       "MovieSearchResult": {
         "properties": {
+          "tmdb": {
+            "type": "integer",
+            "title": "Tmdb"
+          },
           "imdb": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Imdb"
           },
           "title": {
@@ -6569,6 +6755,17 @@
             ],
             "title": "Type"
           },
+          "popularity": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Popularity"
+          },
           "on_watchlist": {
             "type": "boolean",
             "title": "On Watchlist",
@@ -6593,7 +6790,7 @@
         },
         "type": "object",
         "required": [
-          "imdb",
+          "tmdb",
           "title"
         ],
         "title": "MovieSearchResult"
@@ -6608,8 +6805,26 @@
             "type": "string",
             "title": "Title"
           },
+          "tmdb": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tmdb"
+          },
           "imdb": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Imdb"
           },
           "release_date": {
@@ -6624,7 +6839,7 @@
             ],
             "title": "Release Date"
           },
-          "rating_imdb": {
+          "rating_tmdb": {
             "anyOf": [
               {
                 "type": "number"
@@ -6633,7 +6848,7 @@
                 "type": "null"
               }
             ],
-            "title": "Rating Imdb"
+            "title": "Rating Tmdb"
           },
           "runtime": {
             "anyOf": [
@@ -6716,8 +6931,7 @@
         "type": "object",
         "required": [
           "id",
-          "title",
-          "imdb"
+          "title"
         ],
         "title": "MovieSummary",
         "description": "Lightweight movie for list responses \u2014 omits the large ``plot`` field."
@@ -6734,6 +6948,17 @@
               }
             ],
             "title": "Title"
+          },
+          "tmdb": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tmdb"
           },
           "imdb": {
             "anyOf": [
@@ -6768,6 +6993,17 @@
               }
             ],
             "title": "Rating Imdb"
+          },
+          "rating_tmdb": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rating Tmdb"
           },
           "runtime": {
             "anyOf": [
@@ -10423,6 +10659,104 @@
         },
         "type": "object",
         "title": "VideoGameUpdate"
+      },
+      "WatchProvider": {
+        "properties": {
+          "provider_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "logo_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Logo Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "WatchProvider",
+        "description": "One streaming service a title is available on."
+      },
+      "WatchProviders": {
+        "properties": {
+          "region": {
+            "type": "string",
+            "title": "Region"
+          },
+          "link": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Link"
+          },
+          "attribution": {
+            "type": "string",
+            "title": "Attribution"
+          },
+          "stream": {
+            "items": {
+              "$ref": "#/components/schemas/WatchProvider"
+            },
+            "type": "array",
+            "title": "Stream",
+            "default": []
+          },
+          "free": {
+            "items": {
+              "$ref": "#/components/schemas/WatchProvider"
+            },
+            "type": "array",
+            "title": "Free",
+            "default": []
+          },
+          "rent": {
+            "items": {
+              "$ref": "#/components/schemas/WatchProvider"
+            },
+            "type": "array",
+            "title": "Rent",
+            "default": []
+          },
+          "buy": {
+            "items": {
+              "$ref": "#/components/schemas/WatchProvider"
+            },
+            "type": "array",
+            "title": "Buy",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "region",
+          "attribution"
+        ],
+        "title": "WatchProviders",
+        "description": "Where a title can be watched in one region (web#26).\n\nNever 404s and never errors: a title with no availability \u2014 or one TMDB\ncan't resolve \u2014 comes back with empty buckets, so the detail page renders\nthe same either way. ``attribution`` carries the credit TMDB requires\nwherever this data is displayed."
       }
     },
     "securitySchemes": {

--- a/tests/integration/router_movies_test.py
+++ b/tests/integration/router_movies_test.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 from fastapi.testclient import TestClient
 
 from app.config import Settings
+from app.services import watch_providers
 
 
 def test_create_movie(test_client: TestClient):
@@ -375,3 +376,99 @@ def test_search_badges_already_ranked_result(mock_search, test_client: TestClien
     assert data[329]['on_rankings'] is False
     assert data[329]['on_watchlist'] is False
     assert data[329]['rank'] is None
+
+
+# --- Watch providers (web#26) ---
+PROVIDER_PAYLOAD = {
+    'results': {
+        'US': {
+            'link': 'https://www.themoviedb.org/movie/603/watch?locale=US',
+            'flatrate': [
+                {
+                    'provider_id': 8,
+                    'provider_name': 'Netflix',
+                    'logo_path': '/netflix.jpg',
+                    'display_priority': 0,
+                }
+            ],
+            'rent': [
+                {
+                    'provider_id': 2,
+                    'provider_name': 'Apple TV',
+                    'logo_path': '/apple.jpg',
+                    'display_priority': 0,
+                }
+            ],
+        }
+    }
+}
+
+
+@patch('app.services.tmdb.try_request')
+def test_movie_watch_providers(mock_request, test_client: TestClient):
+    watch_providers.reset_cache()
+    mock_request.return_value = PROVIDER_PAYLOAD
+    headers = {'Authorization': f"Bearer {test_client.admin_user.token}"}
+    movie_id = test_client.post(
+        '/v1/movies', headers=headers, json={'title': 'The Matrix', 'tmdb': 603}
+    ).json()['id']
+
+    response = test_client.get(
+        f"/v1/movies/{movie_id}/watch-providers", headers=headers
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data['region'] == 'US'
+    assert data['attribution'] == 'JustWatch'
+    assert data['stream'] == [
+        {
+            'provider_id': 8,
+            'name': 'Netflix',
+            'logo_url': 'https://image.tmdb.org/t/p/w92/netflix.jpg',
+        }
+    ]
+    assert [p['name'] for p in data['rent']] == ['Apple TV']
+    assert data['free'] == []
+
+
+@patch('app.services.tmdb.try_request')
+def test_movie_watch_providers_accepts_a_region(mock_request, test_client: TestClient):
+    watch_providers.reset_cache()
+    mock_request.return_value = PROVIDER_PAYLOAD
+    headers = {'Authorization': f"Bearer {test_client.admin_user.token}"}
+    movie_id = test_client.post(
+        '/v1/movies', headers=headers, json={'title': 'The Matrix', 'tmdb': 603}
+    ).json()['id']
+
+    response = test_client.get(
+        f"/v1/movies/{movie_id}/watch-providers?region=GB", headers=headers
+    )
+
+    assert response.status_code == 200
+    # TMDB has no GB block in this payload — empty, not an error.
+    assert response.json() == {
+        'region': 'GB',
+        'link': None,
+        'attribution': 'JustWatch',
+        'stream': [],
+        'free': [],
+        'rent': [],
+        'buy': [],
+    }
+
+
+def test_movie_watch_providers_unknown_movie_404s(test_client: TestClient):
+    headers = {'Authorization': f"Bearer {test_client.admin_user.token}"}
+    response = test_client.get('/v1/movies/nope/watch-providers', headers=headers)
+    assert response.status_code == 404
+
+
+def test_movie_watch_providers_requires_auth(test_client: TestClient):
+    headers = {'Authorization': f"Bearer {test_client.admin_user.token}"}
+    movie_id = test_client.post(
+        '/v1/movies', headers=headers, json={'title': 'The Matrix', 'tmdb': 603}
+    ).json()['id']
+
+    response = test_client.get(f"/v1/movies/{movie_id}/watch-providers")
+    assert response.status_code == 401

--- a/tests/integration/router_tv_test.py
+++ b/tests/integration/router_tv_test.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
 
+from app.services import watch_providers
+
 
 def _make_show(test_client: TestClient, title='Breaking Bad', **extra) -> str:
     headers = {'Authorization': f"Bearer {test_client.admin_user.token}"}
@@ -659,3 +661,66 @@ def test_deleting_ranked_tracker_closes_the_gap(test_client: TestClient):
         if item['on_rankings']
     }
     assert remaining == {'First': 1, 'Third': 2}
+
+
+# --- Watch providers (web#26) ---
+@patch('app.services.tmdb.try_request')
+def test_tv_watch_providers_resolves_via_imdb(mock_request, test_client: TestClient):
+    watch_providers.reset_cache()
+    # Shows carry no TMDB id, so /find maps the IMDb id first.
+    mock_request.side_effect = [
+        {'tv_results': [{'id': 1396}]},
+        {
+            'results': {
+                'US': {
+                    'link': 'https://www.themoviedb.org/tv/1396/watch?locale=US',
+                    'flatrate': [
+                        {
+                            'provider_id': 8,
+                            'provider_name': 'Netflix',
+                            'logo_path': '/netflix.jpg',
+                            'display_priority': 0,
+                        }
+                    ],
+                }
+            }
+        },
+    ]
+    headers = {'Authorization': f"Bearer {test_client.admin_user.token}"}
+    show_id = _make_show(test_client, imdb='tt0903747')
+
+    response = test_client.get(
+        f"/v1/tv-shows/{show_id}/watch-providers", headers=headers
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data['attribution'] == 'JustWatch'
+    assert data['stream'] == [
+        {
+            'provider_id': 8,
+            'name': 'Netflix',
+            'logo_url': 'https://image.tmdb.org/t/p/w92/netflix.jpg',
+        }
+    ]
+
+
+@patch('app.services.tmdb.try_request')
+def test_tv_watch_providers_without_imdb_id(mock_request, test_client: TestClient):
+    watch_providers.reset_cache()
+    headers = {'Authorization': f"Bearer {test_client.admin_user.token}"}
+    show_id = _make_show(test_client, title='Unmatched Show')
+
+    response = test_client.get(
+        f"/v1/tv-shows/{show_id}/watch-providers", headers=headers
+    )
+
+    assert response.status_code == 200
+    assert response.json()['stream'] == []
+    mock_request.assert_not_called()
+
+
+def test_tv_watch_providers_unknown_show_404s(test_client: TestClient):
+    headers = {'Authorization': f"Bearer {test_client.admin_user.token}"}
+    response = test_client.get('/v1/tv-shows/nope/watch-providers', headers=headers)
+    assert response.status_code == 404

--- a/tests/unit/watch_providers_test.py
+++ b/tests/unit/watch_providers_test.py
@@ -1,0 +1,268 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+# pylint: disable=protected-access
+from unittest.mock import patch
+
+import pytest
+
+from app.services import watch_providers
+
+MOVIE_PAYLOAD = {
+    'id': 603,
+    'results': {
+        'US': {
+            'link': 'https://www.themoviedb.org/movie/603/watch?locale=US',
+            'flatrate': [
+                {
+                    'provider_id': 8,
+                    'provider_name': 'Netflix',
+                    'logo_path': '/netflix.jpg',
+                    'display_priority': 3,
+                },
+                {
+                    'provider_id': 1899,
+                    'provider_name': 'Max',
+                    'logo_path': '/max.jpg',
+                    'display_priority': 1,
+                },
+            ],
+            'free': [
+                {
+                    'provider_id': 73,
+                    'provider_name': 'Tubi TV',
+                    'logo_path': '/tubi.jpg',
+                    'display_priority': 5,
+                }
+            ],
+            'ads': [
+                {
+                    'provider_id': 73,
+                    'provider_name': 'Tubi TV',
+                    'logo_path': '/tubi.jpg',
+                    'display_priority': 5,
+                },
+                {
+                    'provider_id': 300,
+                    'provider_name': 'Pluto TV',
+                    'logo_path': '/pluto.jpg',
+                    'display_priority': 2,
+                },
+            ],
+            'rent': [
+                {
+                    'provider_id': 2,
+                    'provider_name': 'Apple TV',
+                    'logo_path': '/apple.jpg',
+                    'display_priority': 0,
+                }
+            ],
+            'buy': [
+                {
+                    'provider_id': 10,
+                    'provider_name': 'Amazon Video',
+                    'logo_path': '/amazon.jpg',
+                    'display_priority': 0,
+                }
+            ],
+        },
+        'GB': {
+            'link': 'https://www.themoviedb.org/movie/603/watch?locale=GB',
+            'flatrate': [
+                {
+                    'provider_id': 39,
+                    'provider_name': 'Now TV',
+                    'logo_path': '/now.jpg',
+                    'display_priority': 0,
+                }
+            ],
+        },
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _cold_cache():
+    """Each test starts with no memoized lookups."""
+    watch_providers.reset_cache()
+    yield
+    watch_providers.reset_cache()
+
+
+@patch('app.services.tmdb.try_request')
+def test_movie_providers_group_and_order(mock_request):
+    mock_request.return_value = MOVIE_PAYLOAD
+
+    result = watch_providers.get_movie_providers(603)
+
+    mock_request.assert_called_once_with('/movie/603/watch/providers')
+    assert result['region'] == 'US'
+    assert result['link'] == 'https://www.themoviedb.org/movie/603/watch?locale=US'
+    assert result['attribution'] == 'JustWatch'
+    # Ordered by TMDB's display_priority, not payload order.
+    assert [p['name'] for p in result['stream']] == ['Max', 'Netflix']
+    assert result['stream'][0]['logo_url'] == 'https://image.tmdb.org/t/p/w92/max.jpg'
+    assert result['stream'][0]['provider_id'] == 1899
+    assert [p['name'] for p in result['rent']] == ['Apple TV']
+    assert [p['name'] for p in result['buy']] == ['Amazon Video']
+
+
+@patch('app.services.tmdb.try_request')
+def test_ads_fold_into_free_without_duplicates(mock_request):
+    mock_request.return_value = MOVIE_PAYLOAD
+
+    result = watch_providers.get_movie_providers(603)
+
+    # Tubi is listed under both free and ads; it appears once, and Pluto's
+    # lower display_priority puts it first.
+    assert [p['name'] for p in result['free']] == ['Pluto TV', 'Tubi TV']
+
+
+@patch('app.services.tmdb.try_request')
+def test_region_selects_a_different_block(mock_request):
+    mock_request.return_value = MOVIE_PAYLOAD
+
+    result = watch_providers.get_movie_providers(603, region='gb')
+
+    assert result['region'] == 'GB'
+    assert [p['name'] for p in result['stream']] == ['Now TV']
+
+
+@patch('app.services.tmdb.try_request')
+def test_unknown_region_falls_back_to_us(mock_request):
+    mock_request.return_value = MOVIE_PAYLOAD
+
+    # A junk region degrades to US availability rather than 400ing.
+    assert watch_providers.get_movie_providers(603, region='nonsense')['region'] == 'US'
+    assert watch_providers.get_movie_providers(603, region='')['region'] == 'US'
+    # A well-formed region TMDB has no data for is empty, not an error.
+    empty = watch_providers.get_movie_providers(603, region='JP')
+    assert empty['region'] == 'JP'
+    assert empty['stream'] == []
+    assert empty['link'] is None
+
+
+@patch('app.services.tmdb.try_request')
+def test_movie_without_tmdb_id_skips_the_call(mock_request):
+    # Rows the backfill couldn't resolve have a NULL tmdb id.
+    result = watch_providers.get_movie_providers(None)
+
+    mock_request.assert_not_called()
+    assert result == {
+        'region': 'US',
+        'link': None,
+        'attribution': 'JustWatch',
+        'stream': [],
+        'free': [],
+        'rent': [],
+        'buy': [],
+    }
+
+
+@patch('app.services.tmdb.try_request')
+def test_upstream_failure_returns_empty_buckets(mock_request):
+    # try_request returns None when TMDB is unreachable or unconfigured.
+    mock_request.return_value = None
+
+    result = watch_providers.get_movie_providers(603)
+
+    assert result['stream'] == []
+    assert result['link'] is None
+
+
+@patch('app.services.tmdb.try_request')
+def test_providers_are_cached_per_title_and_region(mock_request):
+    mock_request.return_value = MOVIE_PAYLOAD
+
+    watch_providers.get_movie_providers(603)
+    watch_providers.get_movie_providers(603)
+    assert mock_request.call_count == 1
+
+    # A different region is a different cache key.
+    watch_providers.get_movie_providers(603, region='GB')
+    assert mock_request.call_count == 2
+
+    watch_providers.reset_cache()
+    watch_providers.get_movie_providers(603)
+    assert mock_request.call_count == 3
+
+
+@patch('app.services.tmdb.try_request')
+def test_expired_cache_entry_refetches(mock_request):
+    mock_request.return_value = MOVIE_PAYLOAD
+    watch_providers.get_movie_providers(603)
+
+    # Age every entry past its TTL.
+    with watch_providers._lock:
+        for key, (_, value) in list(watch_providers._cache.items()):
+            watch_providers._cache[key] = (0, value)
+
+    watch_providers.get_movie_providers(603)
+    assert mock_request.call_count == 2
+
+
+@patch('app.services.tmdb.try_request')
+def test_tv_resolves_imdb_id_then_fetches_providers(mock_request):
+    find_payload = {'tv_results': [{'id': 1396}]}
+    tv_payload = {
+        'results': {
+            'US': {
+                'link': 'https://www.themoviedb.org/tv/1396/watch?locale=US',
+                'flatrate': [
+                    {
+                        'provider_id': 8,
+                        'provider_name': 'Netflix',
+                        'logo_path': '/netflix.jpg',
+                        'display_priority': 0,
+                    }
+                ],
+            }
+        }
+    }
+    mock_request.side_effect = [find_payload, tv_payload]
+
+    result = watch_providers.get_tv_providers('tt0903747')
+
+    assert mock_request.call_args_list[0][0] == (
+        '/find/tt0903747',
+        {'external_source': 'imdb_id'},
+    )
+    assert mock_request.call_args_list[1][0][0] == '/tv/1396/watch/providers'
+    assert [p['name'] for p in result['stream']] == ['Netflix']
+
+
+@patch('app.services.tmdb.try_request')
+def test_tv_without_imdb_id_skips_the_call(mock_request):
+    result = watch_providers.get_tv_providers(None)
+
+    mock_request.assert_not_called()
+    assert result['stream'] == []
+
+
+@patch('app.services.tmdb.try_request')
+def test_tv_unresolvable_on_tmdb_returns_empty(mock_request):
+    mock_request.return_value = {'tv_results': []}
+
+    result = watch_providers.get_tv_providers('tt9999999')
+
+    # Only the /find call happens — there's no id to fetch providers for.
+    assert mock_request.call_count == 1
+    assert result['stream'] == []
+
+
+@patch('app.services.tmdb.try_request')
+def test_provider_without_a_name_is_dropped(mock_request):
+    mock_request.return_value = {
+        'results': {
+            'US': {
+                'flatrate': [
+                    {'provider_id': 1, 'provider_name': '  ', 'logo_path': '/a.jpg'},
+                    {'provider_id': 2, 'provider_name': 'Hulu', 'logo_path': None},
+                ]
+            }
+        }
+    }
+
+    result = watch_providers.get_movie_providers(603)
+
+    assert [p['name'] for p in result['stream']] == ['Hulu']
+    # A provider TMDB has no logo for still renders by name.
+    assert result['stream'][0]['logo_url'] is None


### PR DESCRIPTION
## What

Adds two endpoints backing [druthers-web#26](https://github.com/ALeonard9/druthers-web/issues/26):

- `GET /v1/movies/{id}/watch-providers`
- `GET /v1/tv-shows/{id}/watch-providers`

Both take an optional `?region=` (default `US`) and return providers grouped
into `stream` / `free` / `rent` / `buy`, each with a name and logo URL, plus
TMDB's own watch link and the required `attribution`.

## Why this source

TMDB's `/watch/providers` endpoints resell JustWatch's availability data, so
this rides on the OMDb→TMDB migration (#163) rather than standing up a second
JustWatch integration — same provider, same attribution.

## Shape decisions

- **Nothing is persisted.** Where a title streams changes without warning, and
  a stale row is worse than no row. A six-hour in-process TTL cache keeps
  detail views off TMDB's rate limit without pretending we own the data.
- **TV goes through `/find` first.** The catalog's shows come from TVMaze and
  carry no TMDB id, only an IMDb id, so a show is resolved to a TMDB tv id
  before the providers call. Movies already store the `tmdb` id.
- **`ads` folds into `free`.** Both mean "no extra payment" to a viewer; Tubi
  and Pluto belong next to the free tier, not in a row of their own.
- **Empty buckets, never an error.** A title with no availability, one TMDB
  can't resolve, a movie the #163 backfill never keyed onto TMDB, and an
  unreachable TMDB all return the same valid empty response. Only an unknown
  catalog id 404s.
- **A junk `region` degrades to US** rather than 400ing — a bad query param
  shouldn't break a detail page.

## Verified

- `pytest`: 351 passed, including 12 new unit tests (grouping, ordering,
  dedupe, region fallback, caching + TTL expiry, TV resolution) and 7 new
  integration tests.
- Black, Pylint 10.00/10.
- Live against TMDB in the dev stack: The Matrix returns rent/buy only,
  Breaking Bad returns Netflix + buy, and `?region=GB` returns a different
  buy list.

## Note on the generated files

`openapi.json` and the Postman collection also pick up OMDb→TMDB drift from
$(echo '#163') — both are generated and hadn't been regenerated since that migration,
so they still described `enriching from OMDB` and a required `rating_imdb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2FUXZMc8JYbEqB23aEGnq