### PR TITLE
Fix stale rank-0/missing-year regressions on the Top 5 board

### DIFF
--- a/.github/workflows/deploy_cloud_run.yaml
+++ b/.github/workflows/deploy_cloud_run.yaml
@@ -59,16 +59,20 @@ jobs:
           alembic upgrade head
           echo "ran=true" >> "$GITHUB_OUTPUT"
 
-      # Both backfills are idempotent and resumable: they only touch rows that
+      # Every step here is idempotent and resumable: they only touch rows that
       # still need work, so re-running on every release is a near-no-op once
-      # the catalog is keyed. That is deliberate — it makes a release
-      # self-contained instead of depending on someone remembering to run
-      # these by hand afterwards.
+      # the catalog is keyed and enriched. That is deliberate — it makes a
+      # release self-contained instead of depending on someone remembering to
+      # run these by hand afterwards. The one-off scripts that were *not*
+      # wired in are exactly the ones that regressed in prod: movie ranks went
+      # back to 0-based and Top 5 rows lost their years.
       - name: Backfill catalog data
         if: steps.migrate.outputs.ran == 'true'
         env:
           DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+          TWITCH_CLIENT_ID: ${{ secrets.TWITCH_CLIENT_ID }}
+          TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}
           ENV: prod
         run: |
           set -euo pipefail
@@ -84,6 +88,24 @@ jobs:
           fi
           python -m app.migration.backfill_tmdb
           python -m app.migration.backfill_covers
+          # Pure SQL, no upstream calls: shift any shelf still sitting on the
+          # legacy 0-based ranks onto the API's 1-based contract.
+          python -m app.migration.backfill_rank_base --all-users
+          # These fill `year` (among other detail). Throttled, so the first
+          # release after a large import is slow; every release after that
+          # has almost nothing left to do.
+          python -m app.migration.enrich_movies
+          python -m app.migration.enrich_books
+          # Unlike TMDB, Twitch creds are optional here: without them games
+          # simply keep their current detail. Warn rather than block a release
+          # on a shelf-sized gap.
+          if [ -n "$TWITCH_CLIENT_ID" ] && [ -n "$TWITCH_CLIENT_SECRET" ]; then
+            python -m app.migration.enrich_games
+          else
+            echo "::warning::TWITCH_CLIENT_ID/SECRET not set — skipping"
+            echo "::warning::enrich_games. Game years and genres will stay"
+            echo "::warning::blank until the secrets are added."
+          fi
 
       - name: Deploy to Cloud Run
         run: |

--- a/.github/workflows/deploy_qa.yaml
+++ b/.github/workflows/deploy_qa.yaml
@@ -68,6 +68,8 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.NEON_DATABASE_URL_QA }}
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+          TWITCH_CLIENT_ID: ${{ secrets.TWITCH_CLIENT_ID }}
+          TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}
           ENV: qa
         run: |
           set -euo pipefail
@@ -79,6 +81,15 @@ jobs:
           fi
           python -m app.migration.backfill_tmdb
           python -m app.migration.backfill_covers
+          python -m app.migration.backfill_rank_base --all-users
+          python -m app.migration.enrich_movies
+          python -m app.migration.enrich_books
+          if [ -n "$TWITCH_CLIENT_ID" ] && [ -n "$TWITCH_CLIENT_SECRET" ]; then
+            python -m app.migration.enrich_games
+          else
+            echo "::warning::TWITCH_CLIENT_ID/SECRET not set — skipping"
+            echo "::warning::enrich_games (see the prod workflow)."
+          fi
 
       - name: Deploy to Cloud Run
         run: |

--- a/app/migration/enrich_books.py
+++ b/app/migration/enrich_books.py
@@ -11,6 +11,8 @@ Usage::
 
 import time
 
+from sqlalchemy import and_, or_
+
 from app.db.database import SessionLocal
 from app.db.models_sandbox import DbBook
 from app.services.book_search import apply_detail_to_book, get_book_detail
@@ -22,19 +24,32 @@ THROTTLE_SECONDS = 1.0
 STOP_AFTER_CONSECUTIVE_MISSES = 15
 
 
+def pending_books(db):
+    """
+    Books still worth an Open Library call.
+
+    See ``enrich_movies.pending_movies``: ``description``/``authors`` is only
+    a proxy for "never enriched", so a row that has them but no ``year``
+    would never be retried. Select on the missing field too.
+    """
+    return (
+        db.query(DbBook)
+        .filter(
+            DbBook.isbn.isnot(None),
+            or_(
+                and_(DbBook.description.is_(None), DbBook.authors.is_(None)),
+                DbBook.year.is_(None),
+            ),
+        )
+        .all()
+    )
+
+
 def run() -> None:
     """Enrich all books still missing detail."""
     db = SessionLocal()
     try:
-        pending = (
-            db.query(DbBook)
-            .filter(
-                DbBook.isbn.isnot(None),
-                DbBook.description.is_(None),
-                DbBook.authors.is_(None),
-            )
-            .all()
-        )
+        pending = pending_books(db)
         total = len(pending)
         print(f'{total} books to enrich')
         enriched = misses = consecutive = processed = 0

--- a/app/migration/enrich_games.py
+++ b/app/migration/enrich_games.py
@@ -13,6 +13,8 @@ Usage::
 
 import time
 
+from sqlalchemy import and_, or_
+
 from app.db.database import SessionLocal
 from app.db.models_sandbox import DbVideoGame
 from app.services.game_search import apply_detail_to_game, get_game_detail
@@ -24,19 +26,32 @@ THROTTLE_SECONDS = 0.5
 STOP_AFTER_CONSECUTIVE_MISSES = 15
 
 
+def pending_games(db):
+    """
+    Games still worth an IGDB call.
+
+    See ``enrich_movies.pending_movies``: ``summary``/``genre`` is only a
+    proxy for "never enriched", so a row that has them but no ``year`` would
+    never be retried. Select on the missing field too.
+    """
+    return (
+        db.query(DbVideoGame)
+        .filter(
+            DbVideoGame.igdb.isnot(None),
+            or_(
+                and_(DbVideoGame.summary.is_(None), DbVideoGame.genre.is_(None)),
+                DbVideoGame.year.is_(None),
+            ),
+        )
+        .all()
+    )
+
+
 def run() -> None:
     """Enrich all games still missing detail."""
     db = SessionLocal()
     try:
-        pending = (
-            db.query(DbVideoGame)
-            .filter(
-                DbVideoGame.igdb.isnot(None),
-                DbVideoGame.summary.is_(None),
-                DbVideoGame.genre.is_(None),
-            )
-            .all()
-        )
+        pending = pending_games(db)
         total = len(pending)
         print(f'{total} games to enrich')
         enriched = misses = consecutive = processed = 0

--- a/app/migration/enrich_movies.py
+++ b/app/migration/enrich_movies.py
@@ -14,6 +14,8 @@ Usage::
 
 import time
 
+from sqlalchemy import and_, or_
+
 from app.db.database import SessionLocal
 from app.db.models_sandbox import DbMovie
 from app.services.movie_search import apply_detail_to_movie, get_movie_detail
@@ -28,19 +30,34 @@ THROTTLE_SECONDS = 0.25
 STOP_AFTER_CONSECUTIVE_MISSES = 15
 
 
+def pending_movies(db):
+    """
+    Movies still worth a TMDB call.
+
+    ``plot``/``director`` are the usual proxy for "never enriched", but a row
+    the OMDb era filled in can carry both and still have no ``year`` — the
+    Top 5 and the shelf lists print a blank year for those forever, because
+    the proxy says they are done. Selecting on the missing field itself as
+    well means a partially-filled row is retried instead of stranded.
+    """
+    return (
+        db.query(DbMovie)
+        .filter(
+            DbMovie.tmdb.isnot(None),
+            or_(
+                and_(DbMovie.plot.is_(None), DbMovie.director.is_(None)),
+                DbMovie.year.is_(None),
+            ),
+        )
+        .all()
+    )
+
+
 def run() -> None:
     """Enrich all movies still missing detail."""
     db = SessionLocal()
     try:
-        pending = (
-            db.query(DbMovie)
-            .filter(
-                DbMovie.tmdb.isnot(None),
-                DbMovie.plot.is_(None),
-                DbMovie.director.is_(None),
-            )
-            .all()
-        )
+        pending = pending_movies(db)
         total = len(pending)
         print(f'{total} movies to enrich')
         enriched = misses = consecutive = processed = 0

--- a/tests/unit/enrich_pending_test.py
+++ b/tests/unit/enrich_pending_test.py
@@ -1,0 +1,106 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+"""
+The enrichers pick their work by proxy fields (plot/director, description/
+authors, summary/genre). A row that carries those but has no ``year`` used to
+fall outside the filter and stay year-less forever — which is what blanked
+half the years on the home Top 5. These pin the missing field itself as a
+selection criterion.
+"""
+
+from app.db.models_sandbox import DbBook, DbMovie, DbVideoGame
+from app.migration.enrich_books import pending_books
+from app.migration.enrich_games import pending_games
+from app.migration.enrich_movies import pending_movies
+
+
+def _titles(rows):
+    return sorted(r.title for r in rows)
+
+
+def test_movie_with_detail_but_no_year_is_still_pending(test_client):
+    session = test_client.test_db_session
+    session.add_all(
+        [
+            # The OMDb-era shape: enriched enough to look done, no year.
+            DbMovie(
+                title='The Matrix',
+                imdb='tt0133093',
+                tmdb=603,
+                plot='A hacker learns the truth.',
+                director='The Wachowskis',
+                year=None,
+            ),
+            DbMovie(title='Never touched', imdb='tt0000001', tmdb=1, year=None),
+            DbMovie(
+                title='Fully enriched',
+                imdb='tt0816692',
+                tmdb=157336,
+                plot='Astronauts.',
+                director='Christopher Nolan',
+                year=2014,
+            ),
+        ]
+    )
+    session.commit()
+
+    assert _titles(pending_movies(session)) == ['Never touched', 'The Matrix']
+
+
+def test_movie_without_a_tmdb_key_is_not_pending(test_client):
+    # enrich_movies calls get_movie_detail(movie.tmdb); an unkeyed row would
+    # burn a request on None. backfill_tmdb keys it first.
+    session = test_client.test_db_session
+    session.add(DbMovie(title='Unkeyed', imdb='tt0000002', tmdb=None, year=None))
+    session.commit()
+
+    assert pending_movies(session) == []
+
+
+def test_book_with_detail_but_no_year_is_still_pending(test_client):
+    session = test_client.test_db_session
+    session.add_all(
+        [
+            DbBook(
+                title='The Name of the Wind',
+                isbn='9780756404741',
+                authors='Patrick Rothfuss',
+                description='Kvothe tells his story.',
+                year=None,
+            ),
+            DbBook(
+                title='Fully enriched',
+                isbn='9780765326355',
+                authors='Brandon Sanderson',
+                description='Bridge Four.',
+                year=2010,
+            ),
+        ]
+    )
+    session.commit()
+
+    assert _titles(pending_books(session)) == ['The Name of the Wind']
+
+
+def test_game_with_detail_but_no_year_is_still_pending(test_client):
+    session = test_client.test_db_session
+    session.add_all(
+        [
+            DbVideoGame(
+                title='Portal',
+                igdb=7346,
+                summary='Now you are thinking with portals.',
+                genre='Puzzle',
+                year=None,
+            ),
+            DbVideoGame(
+                title='Fully enriched',
+                igdb=1234,
+                summary='Robots.',
+                genre='Action',
+                year=2017,
+            ),
+        ]
+    )
+    session.commit()
+
+    assert _titles(pending_games(session)) == ['Portal']


### PR DESCRIPTION
## Summary
- `backfill_rank_base` and the `enrich_*` scripts existed but were never wired into the release pipeline, so a legacy movie could still show at rank 0 on the home Top 5 (druthers-web#26 follow-up) and a row enriched under the old OMDb-era proxy fields (plot/director present, year absent) was never picked up for re-enrichment.
- Widens the `pending_movies`/`pending_books`/`pending_games` selection filters to also match on the missing field itself (`year IS NULL`), not just the old proxy pair.
- Runs `backfill_rank_base`, `enrich_movies`, `enrich_books`, and (when Twitch creds are present) `enrich_games` as part of every release, alongside the existing `backfill_tmdb`/`backfill_covers` step.

## Test plan
- [x] `pytest` — 355 passed (full suite, pre-existing + 4 new tests in `enrich_pending_test.py`)
- [x] `black --check` / `pylint` — clean
- [x] Reproduced the bug against a local Postgres seeded with real TMDB-keyed rows in the legacy shape (0-based rank, year-less), confirmed `backfill_rank_base` + `enrich_movies` fix it live against the real TMDB API
- [ ] First prod release after this merges will take longer than usual (~5-6 min) while `enrich_movies` backfills the existing ~1,300-movie catalog; every release after that is a near-no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)