### PR TITLE
Cascade catalog deletes to their dependent rows (#227)

### DIFF
--- a/app/db/models_sandbox.py
+++ b/app/db/models_sandbox.py
@@ -54,7 +54,10 @@ class DbCountry(DBBaseModel):
     flag_emoji = Column(String(8), nullable=True)
     flag_url = Column(String(500), nullable=True)
 
-    user_countries = relationship('DbUserCountry', back_populates='country')
+    # See DbTVShow.user_tv_shows for why this cascades (#227).
+    user_countries = relationship(
+        'DbUserCountry', back_populates='country', cascade='all, delete-orphan'
+    )
 
 
 class DbUserCountry(DBBaseModel):
@@ -105,7 +108,10 @@ class DbMovie(DBBaseModel):
     actors = Column(Text, nullable=True)
     plot = Column(Text, nullable=True)
 
-    user_movies = relationship('DbUserMovie', back_populates='movie')
+    # See DbTVShow.user_tv_shows for why this cascades (#227).
+    user_movies = relationship(
+        'DbUserMovie', back_populates='movie', cascade='all, delete-orphan'
+    )
 
 
 class DbUserMovie(DBBaseModel):
@@ -155,8 +161,15 @@ class DbTVShow(DBBaseModel):
     rating = Column(Float, nullable=True)
     summary = Column(Text, nullable=True)
 
-    user_tv_shows = relationship('DbUserTVShow', back_populates='tv_show')
-    episodes = relationship('DbTVEpisode', back_populates='tv_show')
+    # Cascade, not the SQLAlchemy default: every child FK below is
+    # nullable=False, so the default "disassociate" behaviour issues
+    # UPDATE ... SET tv_show_id = NULL and the delete fails (#227).
+    user_tv_shows = relationship(
+        'DbUserTVShow', back_populates='tv_show', cascade='all, delete-orphan'
+    )
+    episodes = relationship(
+        'DbTVEpisode', back_populates='tv_show', cascade='all, delete-orphan'
+    )
 
 
 class DbUserTVShow(DBBaseModel):
@@ -198,7 +211,11 @@ class DbTVEpisode(DBBaseModel):
     season_number = Column(Integer, nullable=True)
 
     tv_show = relationship('DbTVShow', back_populates='episodes')
-    user_episodes = relationship('DbUserTVEpisode', back_populates='episode')
+    # Second level: deleting a show cascades to its episodes, and each episode
+    # must in turn take its per-user watch marks with it (#227).
+    user_episodes = relationship(
+        'DbUserTVEpisode', back_populates='episode', cascade='all, delete-orphan'
+    )
 
 
 class DbUserTVEpisode(DBBaseModel):
@@ -233,7 +250,10 @@ class DbVideoGame(DBBaseModel):
     platforms = Column(String(254), nullable=True)
     summary = Column(Text, nullable=True)
 
-    user_games = relationship('DbUserVideoGame', back_populates='game')
+    # See DbTVShow.user_tv_shows for why this cascades (#227).
+    user_games = relationship(
+        'DbUserVideoGame', back_populates='game', cascade='all, delete-orphan'
+    )
 
 
 class DbUserVideoGame(DBBaseModel):
@@ -280,7 +300,10 @@ class DbBook(DBBaseModel):
     rating = Column(Float, nullable=True)
     language = Column(String(40), nullable=True)
 
-    user_books = relationship('DbUserBook', back_populates='book')
+    # See DbTVShow.user_tv_shows for why this cascades (#227).
+    user_books = relationship(
+        'DbUserBook', back_populates='book', cascade='all, delete-orphan'
+    )
 
 
 class DbUserBook(DBBaseModel):

--- a/tests/integration/router_catalog_delete_test.py
+++ b/tests/integration/router_catalog_delete_test.py
@@ -1,0 +1,235 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+"""
+Deleting a catalog row must take its dependent rows with it (#227).
+
+Before the cascades on the parent-side relationships in models_sandbox.py,
+SQLAlchemy's default was to *disassociate* children — issuing
+``UPDATE ... SET <parent>_id = NULL`` against FK columns declared
+``nullable=False``, which the database rejected and the whole DELETE 500'd.
+Every catalog domain was affected, so every one gets a regression test here.
+"""
+
+from fastapi.testclient import TestClient
+
+from app.db.models_sandbox import (
+    DbBook,
+    DbCountry,
+    DbMovie,
+    DbTVEpisode,
+    DbTVShow,
+    DbUserBook,
+    DbUserCountry,
+    DbUserMovie,
+    DbUserTVEpisode,
+    DbUserTVShow,
+    DbUserVideoGame,
+    DbVideoGame,
+)
+
+
+def _admin(test_client: TestClient) -> dict:
+    return {'Authorization': f"Bearer {test_client.admin_user.token}"}
+
+
+def _user(test_client: TestClient) -> dict:
+    return {'Authorization': f"Bearer {test_client.first_user.token}"}
+
+
+def test_delete_movie_with_tracker_row(test_client: TestClient):
+    resp = test_client.post(
+        '/v1/movies',
+        headers=_admin(test_client),
+        json={'title': 'Inception', 'imdb': 'tt1375666'},
+    )
+    movie_id = resp.json()['id']
+    assert (
+        test_client.post(
+            f"/v1/users/me/movies/{movie_id}",
+            headers=_user(test_client),
+            json={'on_watchlist': True},
+        ).status_code
+        == 201
+    )
+
+    assert (
+        test_client.delete(
+            f"/v1/movies/{movie_id}", headers=_admin(test_client)
+        ).status_code
+        == 204
+    )
+
+    db = test_client.test_db_session
+    assert db.query(DbMovie).count() == 0
+    assert db.query(DbUserMovie).count() == 0
+
+
+def test_delete_book_with_tracker_row(test_client: TestClient):
+    book_id = test_client.post(
+        '/v1/books', headers=_admin(test_client), json={'title': 'Dune'}
+    ).json()['id']
+    assert (
+        test_client.post(
+            f"/v1/users/me/books/{book_id}",
+            headers=_user(test_client),
+            json={'on_watchlist': True},
+        ).status_code
+        == 201
+    )
+
+    assert (
+        test_client.delete(
+            f"/v1/books/{book_id}", headers=_admin(test_client)
+        ).status_code
+        == 204
+    )
+
+    db = test_client.test_db_session
+    assert db.query(DbBook).count() == 0
+    assert db.query(DbUserBook).count() == 0
+
+
+def test_delete_game_with_tracker_row(test_client: TestClient):
+    game_id = test_client.post(
+        '/v1/games', headers=_admin(test_client), json={'title': 'Zelda'}
+    ).json()['id']
+    assert (
+        test_client.post(
+            f"/v1/users/me/games/{game_id}",
+            headers=_user(test_client),
+            json={'on_watchlist': True},
+        ).status_code
+        == 201
+    )
+
+    assert (
+        test_client.delete(
+            f"/v1/games/{game_id}", headers=_admin(test_client)
+        ).status_code
+        == 204
+    )
+
+    db = test_client.test_db_session
+    assert db.query(DbVideoGame).count() == 0
+    assert db.query(DbUserVideoGame).count() == 0
+
+
+def test_delete_country_with_tracker_row(test_client: TestClient):
+    country_id = test_client.post(
+        '/v1/countries',
+        headers=_admin(test_client),
+        json={'title': 'Japan', 'country_code': 'jp'},
+    ).json()['id']
+    assert (
+        test_client.post(
+            f"/v1/users/me/countries/{country_id}",
+            headers=_user(test_client),
+            json={'on_watchlist': True},
+        ).status_code
+        == 201
+    )
+
+    assert (
+        test_client.delete(
+            f"/v1/countries/{country_id}", headers=_admin(test_client)
+        ).status_code
+        == 204
+    )
+
+    db = test_client.test_db_session
+    assert db.query(DbCountry).count() == 0
+    assert db.query(DbUserCountry).count() == 0
+
+
+def test_delete_tv_show_cascades_two_levels(test_client: TestClient):
+    """A show carries episodes, and each episode carries per-user watch marks."""
+    show_id = test_client.post(
+        '/v1/tv-shows', headers=_admin(test_client), json={'title': 'Breaking Bad'}
+    ).json()['id']
+    episode_id = test_client.post(
+        f"/v1/tv-shows/{show_id}/episodes",
+        headers=_admin(test_client),
+        json={'title': 'Pilot', 'season': 1, 'season_number': 1},
+    ).json()['id']
+    # Both a show-level tracker row and an episode-level watch mark.
+    assert (
+        test_client.post(
+            f"/v1/users/me/tv-shows/{show_id}",
+            headers=_user(test_client),
+            json={'on_watchlist': True},
+        ).status_code
+        == 201
+    )
+    test_client.post(f"/v1/users/me/episodes/{episode_id}", headers=_user(test_client))
+
+    db = test_client.test_db_session
+    assert db.query(DbUserTVEpisode).count() == 1, 'watch mark should exist first'
+
+    assert (
+        test_client.delete(
+            f"/v1/tv-shows/{show_id}", headers=_admin(test_client)
+        ).status_code
+        == 204
+    )
+
+    assert db.query(DbTVShow).count() == 0
+    assert db.query(DbUserTVShow).count() == 0
+    assert db.query(DbTVEpisode).count() == 0
+    # The two-levels-down rows are the ones a single cascade would have missed.
+    assert db.query(DbUserTVEpisode).count() == 0
+
+
+def test_delete_episode_with_watch_mark(test_client: TestClient):
+    """Deleting a single episode clears its watch marks but leaves the show."""
+    show_id = test_client.post(
+        '/v1/tv-shows', headers=_admin(test_client), json={'title': 'Severance'}
+    ).json()['id']
+    episode_id = test_client.post(
+        f"/v1/tv-shows/{show_id}/episodes",
+        headers=_admin(test_client),
+        json={'title': 'Good News About Hell', 'season': 1, 'season_number': 1},
+    ).json()['id']
+    test_client.post(f"/v1/users/me/episodes/{episode_id}", headers=_user(test_client))
+
+    assert (
+        test_client.delete(
+            f"/v1/episodes/{episode_id}", headers=_admin(test_client)
+        ).status_code
+        == 204
+    )
+
+    db = test_client.test_db_session
+    assert db.query(DbTVEpisode).count() == 0
+    assert db.query(DbUserTVEpisode).count() == 0
+    assert db.query(DbTVShow).count() == 1, 'the show itself must survive'
+
+
+def test_delete_movie_leaves_other_movies_untouched(test_client: TestClient):
+    """The cascade must be scoped to the deleted row, not the whole table."""
+    keep_id = test_client.post(
+        '/v1/movies',
+        headers=_admin(test_client),
+        json={'title': 'Keep Me', 'imdb': 'tt0000001'},
+    ).json()['id']
+    drop_id = test_client.post(
+        '/v1/movies',
+        headers=_admin(test_client),
+        json={'title': 'Drop Me', 'imdb': 'tt0000002'},
+    ).json()['id']
+    for movie_id in (keep_id, drop_id):
+        test_client.post(
+            f"/v1/users/me/movies/{movie_id}",
+            headers=_user(test_client),
+            json={'on_watchlist': True},
+        )
+
+    assert (
+        test_client.delete(
+            f"/v1/movies/{drop_id}", headers=_admin(test_client)
+        ).status_code
+        == 204
+    )
+
+    db = test_client.test_db_session
+    assert db.query(DbMovie).count() == 1
+    assert db.query(DbUserMovie).count() == 1
+    assert db.query(DbMovie).one().title == 'Keep Me'


### PR DESCRIPTION
Closes #227.

## The bug

`DELETE` on any catalog entry returned 500 once anything referenced it — a movie on someone's watchlist, or a show with episodes, which after enrichment is every real show. The only way to remove a referenced row was manual SQL against the database.

Every parent-side relationship was declared without a cascade, so on `db.delete(parent)` SQLAlchemy's default was to *disassociate* the children:

```
UPDATE tv_episodes SET tv_show_id = NULL WHERE tv_show_id = ...
```

Every one of those FK columns is `nullable=False`, so the database rejected the UPDATE and the whole transaction failed. All five catalog domains were affected — movies, TV, books, games, countries.

## The fix

`cascade='all, delete-orphan'` on the parent side of each relationship.

`DbTVEpisode.user_episodes` is included deliberately: deleting a show has to reach the per-user watch marks hanging off its episodes. That's two levels down and would **not** come for free from a cascade on `DbTVShow.episodes` alone.

**ORM cascade over `ondelete='CASCADE'` + `passive_deletes=True`:** no migration needed, and it behaves identically against the SQLite test database and Postgres. The cost is loading children into the session on delete, negligible for an admin-only operation. Worth revisiting if catalog deletes ever become bulk or hot.

## Why CI missed it

There was no delete test for any of the five catalog endpoints. The tests that *do* exercise deletion go through the tracker endpoints, which delete the child directly and never reach this path.

This PR adds one regression test per domain, plus the two-level TV case and a check that the cascade stays scoped to the row being deleted rather than the whole table. **All seven fail without the model change** — verified by stashing it and re-running.

## Testing

- 7 new integration tests; full suite 372 passing. Black and pylint clean (10.00/10).
- Verified against real Postgres on the dev stack, not just the SQLite test DB: reproduced the exact `psycopg2.errors.NotNullViolation` from the issue as a negative control, then confirmed the fix deletes cleanly with zero orphaned rows database-wide (checked with `LEFT JOIN` sweeps across all four child tables).

## Unrelated issue found while verifying

The local `api-dev` container has no volume mount and serves code baked in at build time, and `docker compose up --build` cache-hit for me repeatedly — leaving an 11-hour-old image running that predates `is_seed_data` from #228. That makes the local API 500 on tracker POSTs and silently invalidates local API testing. Filed separately; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1n7HLn6kGyB6BetSCCXaf