### PR TITLE
Stay signed in with revocable, rotating refresh tokens (#246)

### DIFF
--- a/alembic/versions/b4c8d21e9f57_refresh_tokens.py
+++ b/alembic/versions/b4c8d21e9f57_refresh_tokens.py
@@ -1,0 +1,64 @@
+"""refresh tokens
+
+Revocable, rotating browser sessions (#246). Only the SHA-256 hash of each
+token is stored; ``family_id`` groups a sign-in's rotation chain so a replayed
+token can take the whole chain down.
+
+Revision ID: b4c8d21e9f57
+Revises: d3b81f4a9c67
+Create Date: 2026-07-31 09:20:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'b4c8d21e9f57'
+down_revision: Union[str, Sequence[str], None] = 'd3b81f4a9c67'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'refresh_tokens',
+        sa.Column('pk', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('id', sa.String(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('token_hash', sa.String(length=64), nullable=False),
+        sa.Column('family_id', sa.String(), nullable=False),
+        sa.Column('expires_at', sa.DateTime(), nullable=False),
+        sa.Column('revoked_at', sa.DateTime(), nullable=True),
+        sa.Column('used_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['users.pk'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('pk'),
+    )
+    with op.batch_alter_table('refresh_tokens', schema=None) as batch_op:
+        batch_op.create_index(batch_op.f('ix_refresh_tokens_id'), ['id'], unique=True)
+        batch_op.create_index(batch_op.f('ix_refresh_tokens_pk'), ['pk'], unique=False)
+        batch_op.create_index(
+            batch_op.f('ix_refresh_tokens_token_hash'), ['token_hash'], unique=True
+        )
+        batch_op.create_index(
+            batch_op.f('ix_refresh_tokens_user_id'), ['user_id'], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f('ix_refresh_tokens_family_id'), ['family_id'], unique=False
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('refresh_tokens', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_refresh_tokens_family_id'))
+        batch_op.drop_index(batch_op.f('ix_refresh_tokens_user_id'))
+        batch_op.drop_index(batch_op.f('ix_refresh_tokens_token_hash'))
+        batch_op.drop_index(batch_op.f('ix_refresh_tokens_pk'))
+        batch_op.drop_index(batch_op.f('ix_refresh_tokens_id'))
+    op.drop_table('refresh_tokens')

--- a/app/auth/authentication.py
+++ b/app/auth/authentication.py
@@ -12,12 +12,13 @@ from google.oauth2 import id_token as google_id_token
 from pydantic import BaseModel
 from sqlalchemy.orm.session import Session
 
-from app.auth import oauth2
-from app.services.rate_limit import auth_rate_limit
+from app.auth import oauth2, refresh_tokens
+from app.services.rate_limit import auth_rate_limit, refresh_rate_limit
 from app.config import get_settings
 from app.db import models
 from app.db.database import get_db
 from app.db.hash import Hash
+from app.schemas.model_schemas import InRefreshToken, OutToken
 
 router = APIRouter(tags=['authentication'])
 
@@ -28,19 +29,27 @@ class GoogleAuthRequest(BaseModel):
     credential: str
 
 
-def _token_response(user: models.DbUser) -> dict:
+def _token_response(user: models.DbUser, refresh_token: str) -> dict:
     """Build the standard token response for a user."""
     access_token = oauth2.create_access_token(data={'sub': user.id})
     return {
         'access_token': access_token,
+        'refresh_token': refresh_token,
         'token_type': 'bearer',
+        'expires_in': oauth2.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+        'refresh_expires_in': get_settings().refresh_token_expire_days * 86400,
         'user_id': user.id,
         'user_group': user.user_group,
         'email': user.email,
     }
 
 
-@router.post('/token', dependencies=[Depends(auth_rate_limit)])
+def _sign_in_response(user: models.DbUser, db: Session) -> dict:
+    """Token response for a fresh sign-in — starts a new rotation family."""
+    return _token_response(user, refresh_tokens.issue_refresh_token(db, user))
+
+
+@router.post('/token', response_model=OutToken, dependencies=[Depends(auth_rate_limit)])
 def get_token(
     request: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)
 ):
@@ -52,7 +61,7 @@ def get_token(
         password: The password of the user
 
     Returns:
-        Access token
+        Access token, plus the refresh token that renews it
     """
     if get_settings().disable_password_login:
         raise HTTPException(
@@ -74,10 +83,12 @@ def get_token(
             status_code=status.HTTP_404_NOT_FOUND, detail='Invalid credentials'
         )
 
-    return _token_response(user)
+    return _sign_in_response(user, db)
 
 
-@router.post('/google', dependencies=[Depends(auth_rate_limit)])
+@router.post(
+    '/google', response_model=OutToken, dependencies=[Depends(auth_rate_limit)]
+)
 def google_login(request: GoogleAuthRequest, db: Session = Depends(get_db)):
     """
     Sign in with a Google Identity Services ID token.
@@ -142,4 +153,46 @@ def google_login(request: GoogleAuthRequest, db: Session = Depends(get_db)):
         db.commit()
         db.refresh(user)
 
-    return _token_response(user)
+    return _sign_in_response(user, db)
+
+
+@router.post('/refresh', response_model=OutToken)
+def refresh(request: InRefreshToken, db: Session = Depends(get_db)):
+    """
+    Trade a refresh token for a new access token, and a new refresh token.
+
+    The presented token is spent: rotation means a stolen copy is only good
+    until the legitimate client next refreshes, at which point the replay is
+    detected and the whole session dies. Every failure is a flat 401 so the
+    caller's only move is to send the user back to sign-in.
+    """
+    # Rate limit before rotating: throttling a rotation that already spent the
+    # token would kill the very session the cap exists to protect.
+    owner = refresh_tokens.peek_user(db, request.refresh_token)
+    if owner is not None:
+        refresh_rate_limit(owner)
+
+    try:
+        user, new_refresh_token = refresh_tokens.rotate_refresh_token(
+            db, request.refresh_token
+        )
+    except refresh_tokens.RefreshTokenError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail='Invalid or expired refresh token',
+            headers={'WWW-Authenticate': 'Bearer'},
+        ) from exc
+
+    return _token_response(user, new_refresh_token)
+
+
+@router.post('/logout', status_code=status.HTTP_204_NO_CONTENT)
+def logout(request: InRefreshToken, db: Session = Depends(get_db)):
+    """
+    Sign out server-side: the refresh token and its family stop working.
+
+    Deliberately 204 whether or not the token was recognised — sign-out must
+    not depend on the client still holding a valid credential, and the status
+    shouldn't reveal whether a guessed token existed.
+    """
+    refresh_tokens.revoke_refresh_token(db, request.refresh_token)

--- a/app/auth/refresh_tokens.py
+++ b/app/auth/refresh_tokens.py
@@ -1,0 +1,233 @@
+"""
+Issue, rotate, and revoke refresh tokens (#246).
+
+The access token stays short-lived and stateless; this module owns the piece
+that makes staying signed in safe — a long-lived opaque token that can be
+killed individually, rotates every time it is spent, and takes its whole
+family down with it if a spent one comes back.
+
+Nothing here touches API keys (``drk_``), which authenticate directly and are
+deliberately out of this flow.
+"""
+
+import hashlib
+import secrets
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from app.config import get_settings
+from app.db.models import DbRefreshToken, DbUser
+from app.log.logging_config import logger
+
+# Distinct from the API key prefix so a refresh token pasted into an
+# Authorization header fails as a malformed JWT instead of being probed
+# against the API key table.
+REFRESH_TOKEN_PREFIX = 'drr_'
+
+
+class RefreshTokenError(Exception):
+    """A presented refresh token is unknown, expired, revoked, or replayed."""
+
+
+def generate_refresh_token() -> str:
+    """Mint the plaintext secret — returned to the caller exactly once."""
+    return f'{REFRESH_TOKEN_PREFIX}{secrets.token_urlsafe(32)}'
+
+
+def hash_refresh_token(token: str) -> str:
+    """SHA-256 of the full token — the only form ever stored."""
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _as_utc(value: datetime) -> datetime:
+    """
+    Read a stored timestamp back as UTC-aware.
+
+    The columns are naive ``DateTime`` and SQLite hands back naive values, so
+    comparing a stored expiry against an aware ``now()`` would raise. Postgres
+    behaves the same way for a bare ``timestamp``.
+    """
+    return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+
+
+def issue_refresh_token(
+    db: Session, user: DbUser, family_id: Optional[str] = None
+) -> str:
+    """
+    Store a new refresh token for ``user`` and return the plaintext.
+
+    Pass ``family_id`` to continue an existing session's rotation chain; omit
+    it for a fresh sign-in, which starts a new family.
+    """
+    settings = get_settings()
+    token = generate_refresh_token()
+    row = DbRefreshToken(
+        user_id=user.pk,
+        token_hash=hash_refresh_token(token),
+        family_id=family_id or str(uuid.uuid4()),
+        expires_at=_now() + timedelta(days=settings.refresh_token_expire_days),
+    )
+    db.add(row)
+    _purge_expired(db, user)
+    db.commit()
+    return token
+
+
+def _purge_expired(db: Session, user: DbUser) -> None:
+    """
+    Drop this user's already-expired rows so the table stays bounded.
+
+    Safe for replay detection: an expired token is rejected whether or not the
+    row survives, so forgetting it costs nothing.
+    """
+    db.query(DbRefreshToken).filter(
+        DbRefreshToken.user_id == user.pk,
+        DbRefreshToken.expires_at < _now(),
+    ).delete(synchronize_session=False)
+
+
+def revoke_family(db: Session, family_id: str) -> None:
+    """Revoke every unrevoked token in a rotation chain."""
+    db.query(DbRefreshToken).filter(
+        DbRefreshToken.family_id == family_id,
+        DbRefreshToken.revoked_at.is_(None),
+    ).update({'revoked_at': _now()}, synchronize_session=False)
+
+
+def revoke_refresh_token(db: Session, token: str) -> bool:
+    """
+    Revoke a token and the rest of its family — this is what sign-out calls.
+
+    The family goes too, so signing out on a device can't be undone by a
+    token that happened to be minted earlier in the same chain. Returns
+    whether the token was recognised; an unknown token is not an error, since
+    sign-out has to succeed regardless.
+    """
+    row = (
+        db.query(DbRefreshToken)
+        .filter(DbRefreshToken.token_hash == hash_refresh_token(token))
+        .first()
+    )
+    if row is None:
+        return False
+    revoke_family(db, row.family_id)
+    db.commit()
+    return True
+
+
+def _family_is_terminated(db: Session, family_id: str) -> bool:
+    """
+    True once a family has been killed outright rather than rotated onward.
+
+    Sign-out and replay-detection both revoke tokens that were never spent,
+    so a revoked row with no ``used_at`` is the signature of a session that
+    was ended deliberately. Rotation never leaves one behind.
+    """
+    return (
+        db.query(DbRefreshToken)
+        .filter(
+            DbRefreshToken.family_id == family_id,
+            DbRefreshToken.revoked_at.isnot(None),
+            DbRefreshToken.used_at.is_(None),
+        )
+        .first()
+        is not None
+    )
+
+
+def _within_reuse_leeway(db: Session, row: DbRefreshToken) -> bool:
+    """
+    True when a revoked token was spent by rotation moments ago.
+
+    Two guards, not one. ``used_at`` rules out a token revoked at sign-out;
+    the family check rules out re-presenting an *earlier* token from a family
+    that has since been signed out, which would otherwise resurrect the
+    session inside the grace window.
+    """
+    if row.used_at is None:
+        return False
+    leeway = timedelta(seconds=get_settings().refresh_token_reuse_leeway_seconds)
+    if _now() - _as_utc(row.used_at) > leeway:
+        return False
+    return not _family_is_terminated(db, row.family_id)
+
+
+def peek_user(db: Session, token: str) -> Optional[DbUser]:
+    """
+    Owner of a refresh token without spending it, or ``None`` if unknown.
+
+    Only for checks that must happen *before* rotation — rate limiting a
+    rotation that already consumed the token would destroy the session it was
+    meant to protect. Says nothing about whether the token is still valid.
+    """
+    row = (
+        db.query(DbRefreshToken)
+        .filter(DbRefreshToken.token_hash == hash_refresh_token(token))
+        .first()
+    )
+    return row.user if row else None
+
+
+def rotate_refresh_token(db: Session, token: str) -> Tuple[DbUser, str]:
+    """
+    Spend a refresh token and return ``(user, new_plaintext_token)``.
+
+    Raises ``RefreshTokenError`` for anything the caller should answer with a
+    401: unknown, expired, or already-spent. A replayed token additionally
+    revokes its family, on the assumption that a token used twice is a token
+    someone else also has.
+    """
+    row = (
+        db.query(DbRefreshToken)
+        .filter(DbRefreshToken.token_hash == hash_refresh_token(token))
+        .first()
+    )
+    if row is None:
+        raise RefreshTokenError('Unknown refresh token')
+
+    if row.revoked_at is not None:
+        if _within_reuse_leeway(db, row):
+            # Two of the client's requests raced past the same expiry. Hand
+            # out another token in the family rather than reading a race as
+            # theft — the alternative signs people out at random.
+            logger.info(
+                'Concurrent refresh for user_id=%s family=%s within the reuse '
+                'window; issuing an additional token',
+                row.user_id,
+                row.family_id,
+            )
+            return row.user, issue_refresh_token(db, row.user, family_id=row.family_id)
+
+        # Outside the window this is a genuine replay of a spent token, or a
+        # token revoked at sign-out. Either way the chain is no longer
+        # trustworthy and everything in it dies.
+        logger.warning(
+            'Refresh token replay detected for user_id=%s family=%s; '
+            'revoking the family',
+            row.user_id,
+            row.family_id,
+        )
+        revoke_family(db, row.family_id)
+        db.commit()
+        raise RefreshTokenError('Refresh token already used')
+
+    if _as_utc(row.expires_at) <= _now():
+        raise RefreshTokenError('Refresh token expired')
+
+    user = row.user
+    if user is None:
+        raise RefreshTokenError('Refresh token has no owner')
+
+    now = _now()
+    row.revoked_at = now
+    row.used_at = now
+    # Same family, fresh expiry: an active session slides forward instead of
+    # hitting a hard wall mid-use.
+    return user, issue_refresh_token(db, user, family_id=row.family_id)

--- a/app/config.py
+++ b/app/config.py
@@ -47,6 +47,17 @@ class Settings(BaseSettings):
     # --- Auth ---
     jwt_secret_key: Optional[str] = None
     access_token_expire_minutes: int = 30
+    # Refresh tokens (#246) keep the access token short-lived without making
+    # people re-authenticate with Google. Expiry slides on every rotation, so
+    # a user who opens the app at least once a month never signs in again;
+    # one who disappears for longer does.
+    refresh_token_expire_days: int = 30
+    # Grace window in which re-presenting a just-rotated token is treated as
+    # two requests racing, not as a replay. A page render fans out several
+    # calls at once; without this, the second one to arrive after expiry
+    # would look like theft and sign the user out. Beyond the window, reuse
+    # still burns the whole session down.
+    refresh_token_reuse_leeway_seconds: int = 30
     google_client_id: Optional[str] = None
     # Additional OAuth client ids accepted at sign-in, comma-separated. Native
     # clients need their own client id (an iOS client is keyed to the bundle
@@ -61,6 +72,11 @@ class Settings(BaseSettings):
     # None = enforce in dev/prod, skip in local/CI; set explicitly to override.
     rate_limits_enabled: Optional[bool] = None
     rate_limit_auth: int = 10  # sign-in attempts per IP per 5 minutes
+    # Refresh is keyed per user, not per IP: the web BFF calls the API
+    # server-to-server, so every browser shares one source IP and an IP bucket
+    # would throttle the whole site. A signed-in user needs ~2 refreshes an
+    # hour, so this only catches a client stuck in a loop.
+    rate_limit_refresh: int = 60  # refreshes per user per 5 minutes
     rate_limit_search: int = 60  # search-proxy calls per user per minute
     catalog_add_daily_cap: int = 200  # catalog creations per user per day
 

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime, timezone
 
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import backref, relationship
 
 from app.db.database import Base
 
@@ -67,6 +67,43 @@ class DbApiKey(DBBaseModel):
     last_used_at = Column(DateTime, nullable=True)
 
     user = relationship('DbUser', backref='api_keys')
+
+
+class DbRefreshToken(DBBaseModel):
+    """
+    Long-lived, revocable browser-session credential (#246).
+
+    Opaque and random rather than a JWT: the point of choosing a refresh flow
+    over a longer-lived access token was individual revocation, which needs
+    server-side state. Only the SHA-256 hash is stored, so a database leak
+    doesn't hand over usable sessions.
+
+    ``family_id`` ties every token minted by rotating an earlier one back to
+    the original sign-in. Presenting an already-rotated token means it leaked
+    (or was replayed), and the whole family dies with it.
+    """
+
+    __tablename__ = 'refresh_tokens'
+    user_id = Column(
+        Integer,
+        ForeignKey('users.pk', ondelete='CASCADE'),
+        nullable=False,
+        index=True,
+    )
+    token_hash = Column(String(length=64), unique=True, index=True, nullable=False)
+    family_id = Column(String, nullable=False, index=True)
+    expires_at = Column(DateTime, nullable=False)
+    # Set together on rotation; kept apart so a revoked-but-unused token
+    # (sign-out) is distinguishable from one that was spent.
+    revoked_at = Column(DateTime, nullable=True)
+    used_at = Column(DateTime, nullable=True)
+
+    # Sessions are meaningless without their owner, so deleting a user takes
+    # their tokens with them rather than orphaning rows on a NOT NULL column.
+    user = relationship(
+        'DbUser',
+        backref=backref('refresh_tokens', cascade='all, delete-orphan'),
+    )
 
 
 # Import sandbox models to ensure they are registered with the Base metadata

--- a/app/schemas/model_schemas.py
+++ b/app/schemas/model_schemas.py
@@ -99,6 +99,34 @@ class OutApiKeyCreated(OutApiKey):
     key: str
 
 
+class InRefreshToken(BaseModel):
+    """
+    Request body for the refresh and sign-out endpoints (#246).
+    """
+
+    refresh_token: str = Field(min_length=1)
+
+
+class OutToken(BaseModel):
+    """
+    What every sign-in and refresh returns.
+
+    Both lifetimes are reported in seconds so a client can size its cookies
+    off the response instead of hardcoding guesses that drift from
+    ``ACCESS_TOKEN_EXPIRE_MINUTES`` and ``REFRESH_TOKEN_EXPIRE_DAYS`` — which
+    is exactly how the web session cookie ended up outliving its token.
+    """
+
+    access_token: str
+    refresh_token: str
+    token_type: str = 'bearer'
+    expires_in: int
+    refresh_expires_in: int
+    user_id: str
+    user_group: str
+    email: str
+
+
 class InVisibilityUpdate(BaseModel):
     """
     Request body for visibility settings. Only sent fields change; a null

--- a/app/services/rate_limit.py
+++ b/app/services/rate_limit.py
@@ -79,6 +79,22 @@ def auth_rate_limit(request: Request) -> None:
         _reject('sign-in attempts', AUTH_WINDOW_SECONDS)
 
 
+def refresh_rate_limit(user) -> None:
+    """
+    Per-user cap on token refreshes (#246).
+
+    Called from inside the endpoint rather than as a dependency: the user is
+    only known once the refresh token resolves. Keying on the user instead of
+    the IP matters here — the web BFF refreshes server-to-server, so an IP
+    bucket would be shared by every browser on the site.
+    """
+    if not _enforced():
+        return
+    limit = get_settings().rate_limit_refresh
+    if not _allow(f'refresh:{user.pk}', limit, AUTH_WINDOW_SECONDS):
+        _reject('token refreshes', AUTH_WINDOW_SECONDS)
+
+
 def search_rate_limit(current_user: list = Depends(get_current_user)) -> None:
     """Per-user cap on external search-proxy calls (they burn API quotas)."""
     if not _enforced():

--- a/docs/druthers-api.postman_collection.json
+++ b/docs/druthers-api.postman_collection.json
@@ -3131,7 +3131,7 @@
                 }
               ]
             },
-            "description": "Retrieves a JWT token if username (email) and password match\n\nArgs:\n    username: The email of the user\n    password: The password of the user\n\nReturns:\n    Access token",
+            "description": "Retrieves a JWT token if username (email) and password match\n\nArgs:\n    username: The email of the user\n    password: The password of the user\n\nReturns:\n    Access token, plus the refresh token that renews it",
             "auth": {
               "type": "noauth"
             }
@@ -3171,6 +3171,72 @@
             "auth": {
               "type": "noauth"
             }
+          }
+        },
+        {
+          "name": "Logout",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/auth/logout",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "auth",
+                "logout"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"refresh_token\": \"string\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Sign out server-side: the refresh token and its family stop working.\n\nDeliberately 204 whether or not the token was recognised \u2014 sign-out must\nnot depend on the client still holding a valid credential, and the status\nshouldn't reveal whether a guessed token existed."
+          }
+        },
+        {
+          "name": "Refresh",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/auth/refresh",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "auth",
+                "refresh"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"refresh_token\": \"string\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Trade a refresh token for a new access token, and a new refresh token.\n\nThe presented token is spent: rotation means a stolen copy is only good\nuntil the legitimate client next refreshes, at which point the replay is\ndetected and the whole session dies. Every failure is a flat 401 so the\ncaller's only move is to send the user back to sign-in."
           }
         }
       ]

--- a/openapi.json
+++ b/openapi.json
@@ -30,7 +30,7 @@
           "authentication"
         ],
         "summary": "Get Token",
-        "description": "Retrieves a JWT token if username (email) and password match\n\nArgs:\n    username: The email of the user\n    password: The password of the user\n\nReturns:\n    Access token",
+        "description": "Retrieves a JWT token if username (email) and password match\n\nArgs:\n    username: The email of the user\n    password: The password of the user\n\nReturns:\n    Access token, plus the refresh token that renews it",
         "operationId": "get_token_v1_auth_token_post",
         "requestBody": {
           "content": {
@@ -47,7 +47,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/OutToken"
+                }
               }
             }
           },
@@ -87,9 +89,88 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/OutToken"
+                }
               }
             }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/auth/refresh": {
+      "post": {
+        "tags": [
+          "authentication"
+        ],
+        "summary": "Refresh",
+        "description": "Trade a refresh token for a new access token, and a new refresh token.\n\nThe presented token is spent: rotation means a stolen copy is only good\nuntil the legitimate client next refreshes, at which point the replay is\ndetected and the whole session dies. Every failure is a flat 401 so the\ncaller's only move is to send the user back to sign-in.",
+        "operationId": "refresh_v1_auth_refresh_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InRefreshToken"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutToken"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/auth/logout": {
+      "post": {
+        "tags": [
+          "authentication"
+        ],
+        "summary": "Logout",
+        "description": "Sign out server-side: the refresh token and its family stop working.\n\nDeliberately 204 whether or not the token was recognised \u2014 sign-out must\nnot depend on the client still holding a valid credential, and the status\nshouldn't reveal whether a guessed token existed.",
+        "operationId": "logout_v1_auth_logout_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InRefreshToken"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
           },
           "422": {
             "description": "Validation Error",
@@ -5007,7 +5088,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -5448,7 +5530,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -6147,7 +6230,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -6261,6 +6345,21 @@
         ],
         "title": "InApiKeyCreate",
         "description": "Request body for minting an API key."
+      },
+      "InRefreshToken": {
+        "properties": {
+          "refresh_token": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Refresh Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "refresh_token"
+        ],
+        "title": "InRefreshToken",
+        "description": "Request body for the refresh and sign-out endpoints (#246)."
       },
       "InUserBase": {
         "properties": {
@@ -6779,7 +6878,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -7472,6 +7572,55 @@
         "title": "OutSummaryShelf",
         "description": "One domain's headline numbers plus its best-ranked entries."
       },
+      "OutToken": {
+        "properties": {
+          "access_token": {
+            "type": "string",
+            "title": "Access Token"
+          },
+          "refresh_token": {
+            "type": "string",
+            "title": "Refresh Token"
+          },
+          "token_type": {
+            "type": "string",
+            "title": "Token Type",
+            "default": "bearer"
+          },
+          "expires_in": {
+            "type": "integer",
+            "title": "Expires In"
+          },
+          "refresh_expires_in": {
+            "type": "integer",
+            "title": "Refresh Expires In"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "user_group": {
+            "type": "string",
+            "title": "User Group"
+          },
+          "email": {
+            "type": "string",
+            "title": "Email"
+          }
+        },
+        "type": "object",
+        "required": [
+          "access_token",
+          "refresh_token",
+          "expires_in",
+          "refresh_expires_in",
+          "user_id",
+          "user_group",
+          "email"
+        ],
+        "title": "OutToken",
+        "description": "What every sign-in and refresh returns.\n\nBoth lifetimes are reported in seconds so a client can size its cookies\noff the response instead of hardcoding guesses that drift from\n``ACCESS_TOKEN_EXPIRE_MINUTES`` and ``REFRESH_TOKEN_EXPIRE_DAYS`` \u2014 which\nis exactly how the web session cookie ended up outliving its token."
+      },
       "OutUserDisplay": {
         "properties": {
           "id": {
@@ -7584,6 +7733,7 @@
         "properties": {
           "position": {
             "type": "integer",
+            "minimum": 1.0,
             "title": "Position"
           }
         },
@@ -8336,7 +8486,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -8659,7 +8810,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -8732,7 +8884,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -8828,7 +8981,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -8901,7 +9055,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -8974,7 +9129,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -9070,7 +9226,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -9143,7 +9300,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -9216,7 +9374,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -9312,7 +9471,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -9438,7 +9598,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -9522,7 +9683,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -9629,7 +9791,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -9713,7 +9876,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -9836,7 +10000,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -9920,7 +10085,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -10027,7 +10193,8 @@
           "rank": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 1.0
               },
               {
                 "type": "null"

--- a/tests/integration/router_refresh_test.py
+++ b/tests/integration/router_refresh_test.py
@@ -1,0 +1,273 @@
+"""
+Tests the refresh-token flow (#246): issuing, rotation, replay detection,
+sign-out revocation, and expiry.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from app.auth import refresh_tokens
+from app.db.models import DbRefreshToken
+
+PROBE = '/v1/users/me/notifications/unread-count'
+
+
+def _sign_in(client: TestClient) -> dict:
+    """Password sign-in, returning the full token payload."""
+    user = client.first_user
+    response = client.post(
+        '/v1/auth/token',
+        files={
+            'username': (None, user.email),
+            'password': (None, user.plain_password),
+        },
+    )
+    assert response.status_code == 200
+    return response.json()
+
+
+def _authed(client: TestClient, access_token: str):
+    return client.get(PROBE, headers={'Authorization': f'Bearer {access_token}'})
+
+
+def test_sign_in_returns_a_refresh_token(test_client: TestClient):
+    """Password sign-in hands back a refresh token and the access lifetime."""
+    data = _sign_in(test_client)
+    assert data['refresh_token'].startswith(refresh_tokens.REFRESH_TOKEN_PREFIX)
+    assert data['expires_in'] > 0
+    assert data['refresh_expires_in'] > data['expires_in']
+    assert data['token_type'] == 'bearer'
+
+
+def test_refresh_returns_a_working_access_token(test_client: TestClient):
+    """A refresh mints an access token that authenticates real requests."""
+    signed_in = _sign_in(test_client)
+    response = test_client.post(
+        '/v1/auth/refresh', json={'refresh_token': signed_in['refresh_token']}
+    )
+    assert response.status_code == 200
+    refreshed = response.json()
+    assert refreshed['user_id'] == signed_in['user_id']
+    assert refreshed['email'] == signed_in['email']
+    assert _authed(test_client, refreshed['access_token']).status_code == 200
+
+
+def test_refresh_rotates_the_refresh_token(test_client: TestClient):
+    """The returned refresh token is a new one, and it works in turn."""
+    first = _sign_in(test_client)['refresh_token']
+    second = test_client.post('/v1/auth/refresh', json={'refresh_token': first}).json()[
+        'refresh_token'
+    ]
+    assert second != first
+
+    third = test_client.post('/v1/auth/refresh', json={'refresh_token': second})
+    assert third.status_code == 200
+    assert third.json()['refresh_token'] not in (first, second)
+
+
+def _age_out_reuse_window(client: TestClient, token: str) -> None:
+    """Backdate a spent token past the concurrent-refresh grace window."""
+    session = client.test_db_session
+    row = (
+        session.query(DbRefreshToken)
+        .filter(DbRefreshToken.token_hash == refresh_tokens.hash_refresh_token(token))
+        .first()
+    )
+    row.used_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    session.commit()
+
+
+def test_concurrent_refresh_is_not_treated_as_a_replay(test_client: TestClient):
+    """
+    Two requests racing past the same expiry both get a working token.
+
+    A page render fans out several API calls at once; reading the loser of
+    that race as theft would sign people out at random, which is precisely
+    the experience this story exists to remove.
+    """
+    first = _sign_in(test_client)['refresh_token']
+    winner = test_client.post('/v1/auth/refresh', json={'refresh_token': first})
+    racer = test_client.post('/v1/auth/refresh', json={'refresh_token': first})
+
+    assert winner.status_code == 200
+    assert racer.status_code == 200
+    # Both successors work — neither request poisoned the other's session.
+    for response in (winner, racer):
+        assert _authed(test_client, response.json()['access_token']).status_code == 200
+
+
+def test_spent_refresh_token_cannot_be_replayed(test_client: TestClient):
+    """Re-presenting a rotated token after the grace window is rejected."""
+    first = _sign_in(test_client)['refresh_token']
+    test_client.post('/v1/auth/refresh', json={'refresh_token': first})
+    _age_out_reuse_window(test_client, first)
+
+    replay = test_client.post('/v1/auth/refresh', json={'refresh_token': first})
+    assert replay.status_code == 401
+
+
+def test_replay_revokes_the_whole_family(test_client: TestClient):
+    """
+    A replayed token means the chain leaked, so the live token dies too.
+
+    This is the case that makes rotation worth having: the thief's use and
+    the real client's next refresh can't both succeed.
+    """
+    first = _sign_in(test_client)['refresh_token']
+    live = test_client.post('/v1/auth/refresh', json={'refresh_token': first}).json()[
+        'refresh_token'
+    ]
+    _age_out_reuse_window(test_client, first)
+
+    # The attacker replays the token they stole before rotation.
+    assert (
+        test_client.post('/v1/auth/refresh', json={'refresh_token': first}).status_code
+        == 401
+    )
+    # The legitimate client is now locked out as well.
+    assert (
+        test_client.post('/v1/auth/refresh', json={'refresh_token': live}).status_code
+        == 401
+    )
+
+
+def test_sign_out_cannot_be_undone_inside_the_grace_window(test_client: TestClient):
+    """
+    An already-spent token can't resurrect a signed-out session.
+
+    The grace window forgives a race, but signing out ends the family — so
+    replaying the token that was rotated moments before sign-out gets a 401
+    rather than a fresh session.
+    """
+    first = _sign_in(test_client)['refresh_token']
+    live = test_client.post('/v1/auth/refresh', json={'refresh_token': first}).json()[
+        'refresh_token'
+    ]
+    test_client.post('/v1/auth/logout', json={'refresh_token': live})
+
+    resurrect = test_client.post('/v1/auth/refresh', json={'refresh_token': first})
+    assert resurrect.status_code == 401
+
+
+def test_replay_lockout_survives_the_grace_window(test_client: TestClient):
+    """After theft is detected, no token in the family gets a second chance."""
+    first = _sign_in(test_client)['refresh_token']
+    second = test_client.post('/v1/auth/refresh', json={'refresh_token': first}).json()[
+        'refresh_token'
+    ]
+    third = test_client.post('/v1/auth/refresh', json={'refresh_token': second}).json()[
+        'refresh_token'
+    ]
+    _age_out_reuse_window(test_client, first)
+
+    # Detected replay revokes the family...
+    assert (
+        test_client.post('/v1/auth/refresh', json={'refresh_token': first}).status_code
+        == 401
+    )
+    # ...and the recently-rotated tokens can't slip back in on the leeway.
+    for token in (second, third):
+        assert (
+            test_client.post(
+                '/v1/auth/refresh', json={'refresh_token': token}
+            ).status_code
+            == 401
+        )
+
+
+def test_logout_beats_a_concurrent_refresh(test_client: TestClient):
+    """
+    Sign-out is never excused by the race window.
+
+    The grace period keys off ``used_at``, which only rotation sets — so a
+    token killed at sign-out is rejected immediately, not 30 seconds later.
+    """
+    token = _sign_in(test_client)['refresh_token']
+    assert (
+        test_client.post('/v1/auth/logout', json={'refresh_token': token}).status_code
+        == 204
+    )
+
+    assert (
+        test_client.post('/v1/auth/refresh', json={'refresh_token': token}).status_code
+        == 401
+    )
+
+
+def test_logout_revokes_the_refresh_token(test_client: TestClient):
+    """Signing out kills the token server-side, not just the client cookie."""
+    token = _sign_in(test_client)['refresh_token']
+    logout = test_client.post('/v1/auth/logout', json={'refresh_token': token})
+    assert logout.status_code == 204
+
+    after = test_client.post('/v1/auth/refresh', json={'refresh_token': token})
+    assert after.status_code == 401
+
+
+def test_logout_is_idempotent_for_unknown_tokens(test_client: TestClient):
+    """Sign-out succeeds even when the client's token is already dead."""
+    response = test_client.post(
+        '/v1/auth/logout', json={'refresh_token': 'drr_never-existed'}
+    )
+    assert response.status_code == 204
+
+
+def test_expired_refresh_token_is_rejected(test_client: TestClient):
+    """Expiry is enforced against the stored timestamp."""
+    token = _sign_in(test_client)['refresh_token']
+    session = test_client.test_db_session
+    row = (
+        session.query(DbRefreshToken)
+        .filter(DbRefreshToken.token_hash == refresh_tokens.hash_refresh_token(token))
+        .first()
+    )
+    row.expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+    session.commit()
+
+    response = test_client.post('/v1/auth/refresh', json={'refresh_token': token})
+    assert response.status_code == 401
+
+
+def test_unknown_refresh_token_is_rejected(test_client: TestClient):
+    """An invented token gets the same flat 401 as an expired one."""
+    response = test_client.post(
+        '/v1/auth/refresh', json={'refresh_token': 'drr_made-up-token'}
+    )
+    assert response.status_code == 401
+
+
+def test_refresh_token_is_not_a_bearer_credential(test_client: TestClient):
+    """A refresh token can't stand in for an access token on the API."""
+    token = _sign_in(test_client)['refresh_token']
+    assert _authed(test_client, token).status_code == 401
+
+
+def test_deleting_a_user_takes_their_tokens(test_client: TestClient):
+    """Sessions don't outlive their owner — the rows go, not just the FK."""
+    user = test_client.first_user
+    _sign_in(test_client)
+    session = test_client.test_db_session
+    assert (
+        session.query(DbRefreshToken).filter(DbRefreshToken.user_id == user.pk).count()
+    )
+
+    test_client.delete(
+        f'/v1/users/{user.id}',
+        headers={'Authorization': f'Bearer {test_client.admin_user.token}'},
+    )
+    assert (
+        session.query(DbRefreshToken).filter(DbRefreshToken.user_id == user.pk).count()
+        == 0
+    )
+
+
+def test_only_the_hash_is_stored(test_client: TestClient):
+    """The plaintext token never lands in the database."""
+    token = _sign_in(test_client)['refresh_token']
+    rows = test_client.test_db_session.query(DbRefreshToken).all()
+    assert rows
+    assert all(row.token_hash != token for row in rows)
+    assert any(
+        row.token_hash == refresh_tokens.hash_refresh_token(token) for row in rows
+    )


### PR DESCRIPTION
Closes #246.

## Why

The access token was the whole session. At a 30-minute expiry that meant re-authenticating with Google constantly — worst in the installed PWA, which can sit closed for days.

Per the decision on the issue, this is a real refresh-token flow rather than a longer-lived JWT: a bare long-lived token can't be revoked short of rotating `JWT_SECRET_KEY`, which signs everyone out.

## What

- `refresh_tokens` table — opaque random token, stored as a SHA-256 hash, never in plaintext. `family_id` ties a sign-in's rotation chain together.
- `POST /v1/auth/refresh` — spends the presented token and returns a new access + refresh pair.
- `POST /v1/auth/logout` — revokes the token and its family server-side. 204 either way, so sign-out never depends on the client still holding a valid credential.
- `/token` and `/google` now return `refresh_token`, `expires_in`, and `refresh_expires_in`, so clients size cookies off the response instead of hardcoding guesses that drift from the settings.
- Alembic `b4c8d21e9f57`.

## Two things the straightforward version gets wrong

**Rotation breaks under concurrency.** One page render fans out several API calls; after an expiry they race to refresh, and whichever loses looks exactly like a replay. Re-presenting a token within 30s of its rotation (`REFRESH_TOKEN_REUSE_LEEWAY_SECONDS`) is treated as a race. Beyond that it's theft, and the family dies.

Sign-out and detected replays are never forgiven by that window. Both revoke tokens that were never spent, and a revoked-but-unspent row is the signal that the family ended deliberately — which also closes a hole where a token spent moments before sign-out could resurrect the session.

**Refresh is rate-limited per user, not per IP.** The web BFF calls the API server-to-server, so an IP bucket would be one shared bucket for every browser on the site. The cap is checked *before* rotation — throttling a rotation that already spent the token would destroy the session the cap exists to protect.

## Out of scope

API keys are untouched. They authenticate directly and stay out of this flow, with a distinct `drr_` prefix so a refresh token can never be probed against the API key table.

## Session lifetime

Expiry slides on every rotation, so an active user never re-authenticates and one who disappears for 30 days does. There is deliberately no absolute cap — worth a look if you'd rather have a ceiling.

## Verified

407 tests pass (16 new). Beyond the suite, checked against the local dev stack on Postgres with seeded catalog data: silent refresh across an expiry, rotation, replay killing the family, sign-out revocation surviving the grace window, and API-key auth unaffected.

Web side is druthers-web#109 — the two need to land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
