### PR TITLE
Enrich books Open Library can't resolve, via their Google volume id

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -105,6 +105,12 @@ class Settings(BaseSettings):
     twitch_client_id: Optional[str] = None
     twitch_client_secret: Optional[str] = None
 
+    # --- External APIs (book enrichment fallback — Google Books) ---
+    # Open Library is the primary book source and needs no key. This is only
+    # used to enrich rows Open Library cannot resolve by ISBN but which carry
+    # a legacy ``googleid``; enrichment simply skips them when unset.
+    google_books_api_key: Optional[str] = None
+
     @property
     def sqlalchemy_database_url(self) -> str:
         """

--- a/app/migration/enrich_books.py
+++ b/app/migration/enrich_books.py
@@ -1,6 +1,9 @@
 """
-Backfill Open Library detail (authors/year/subjects/description/pages/
-rating/cover) for books that were imported without it, keyed on isbn.
+Backfill book detail (authors/year/subjects/description/pages/rating/cover)
+for books that were imported without it: Open Library keyed on isbn, falling
+back to Google Books keyed on the legacy googleid for the many rows whose
+edition-specific ISBN Open Library does not index.
+
 Throttled and **resumable**: it only processes books still missing detail,
 so re-running continues where it left off.
 
@@ -15,32 +18,43 @@ from sqlalchemy import and_, or_
 
 from app.db.database import SessionLocal
 from app.db.models_sandbox import DbBook
-from app.services.book_search import apply_detail_to_book, get_book_detail
+from app.services.book_search import (
+    UpstreamUnavailable,
+    apply_detail_to_book,
+    resolve_book_detail,
+)
 
 # Be polite to Open Library (they ask for gentle, identifiable traffic).
 THROTTLE_SECONDS = 1.0
-# get_book_detail returns None both for genuine misses and rate limiting; a
-# run of consecutive Nones almost certainly means we are being throttled.
-STOP_AFTER_CONSECUTIVE_MISSES = 15
+# Consecutive *upstream failures* — not misses. A book the source has no
+# record of will never resolve however long we wait, so counting those here
+# would stall the run on an unresolvable row and, because the pending set
+# comes back in the same order, never get past it on a re-run either.
+STOP_AFTER_CONSECUTIVE_ERRORS = 15
 
 
 def pending_books(db):
     """
-    Books still worth an Open Library call.
+    Books still worth an enrichment call.
 
     See ``enrich_movies.pending_movies``: ``description``/``authors`` is only
     a proxy for "never enriched", so a row that has them but no ``year``
     would never be retried. Select on the missing field too.
+
+    A row needs *some* usable key. ``googleid`` counts: Google Books is the
+    fallback source, and rows imported from it may have no isbn at all.
+    Ordered so a resumed run is reproducible.
     """
     return (
         db.query(DbBook)
         .filter(
-            DbBook.isbn.isnot(None),
+            or_(DbBook.isbn.isnot(None), DbBook.googleid.isnot(None)),
             or_(
                 and_(DbBook.description.is_(None), DbBook.authors.is_(None)),
                 DbBook.year.is_(None),
             ),
         )
+        .order_by(DbBook.id)
         .all()
     )
 
@@ -52,29 +66,40 @@ def run() -> None:
         pending = pending_books(db)
         total = len(pending)
         print(f'{total} books to enrich')
-        enriched = misses = consecutive = processed = 0
+        enriched = misses = errors = consecutive = processed = 0
         for book in pending:
             processed += 1
-            detail = get_book_detail(book.isbn)
-            if detail:
-                apply_detail_to_book(book, detail)
-                db.commit()
-                enriched += 1
-                consecutive = 0
-            else:
-                misses += 1
+            try:
+                detail = resolve_book_detail(book.isbn, book.googleid)
+            except UpstreamUnavailable:
+                errors += 1
                 consecutive += 1
+            else:
+                consecutive = 0
+                if detail:
+                    # The one place titles are rewritten: these are legacy
+                    # imported rows, not editions anyone chose. Adds and
+                    # detail views keep the title the user picked.
+                    apply_detail_to_book(book, detail, overwrite_title=True)
+                    db.commit()
+                    enriched += 1
+                else:
+                    misses += 1
             if processed % 25 == 0:
-                print(f'  {processed}/{total} (enriched {enriched}, misses {misses})')
-            if consecutive >= STOP_AFTER_CONSECUTIVE_MISSES:
                 print(
-                    f'Stopping after {consecutive} consecutive misses '
-                    '(likely Open Library rate limit). Re-run later to resume.'
+                    f'  {processed}/{total} (enriched {enriched}, '
+                    f'misses {misses}, errors {errors})'
+                )
+            if consecutive >= STOP_AFTER_CONSECUTIVE_ERRORS:
+                print(
+                    f'Stopping after {consecutive} consecutive upstream '
+                    'failures (likely rate limited or offline). Re-run '
+                    'later to resume.'
                 )
                 break
             time.sleep(THROTTLE_SECONDS)
         print(
-            f'Done: enriched {enriched}, misses {misses}, '
+            f'Done: enriched {enriched}, misses {misses}, errors {errors}, '
             f'remaining ~{total - processed}'
         )
     finally:

--- a/app/services/book_search.py
+++ b/app/services/book_search.py
@@ -7,21 +7,39 @@ Open Library directly. Results are normalized into the shape the
 ``/v1/books`` create endpoint expects. Open Library is also the enrichment
 source, keyed on the catalog's ``isbn``: authors, publish year, subjects,
 description (from the work record), page count, rating, and cover image.
-(The legacy ``googleid`` column is retained but dormant — Google Books now
-requires an API key for every request.)
+
+Open Library does not index every edition. Rows imported from Google Books
+carry edition-specific ISBNs it has no record of, so the legacy ``googleid``
+column is used as an enrichment fallback (see ``resolve_book_detail``). That
+path needs ``GOOGLE_BOOKS_API_KEY``; without it those rows are simply skipped.
 """
 
 import re
+from html import unescape
 from typing import List, Optional
 
 import requests
 from fastapi import HTTPException, status
 
+from app.config import get_settings
 from app.log.logging_config import logger
 
 OPENLIBRARY_URL = 'https://openlibrary.org'
 COVERS_URL = 'https://covers.openlibrary.org'
+GOOGLE_BOOKS_URL = 'https://www.googleapis.com/books/v1'
 REQUEST_TIMEOUT = 10
+
+
+class UpstreamUnavailable(Exception):
+    """
+    An upstream book source could not be reached (transport error, HTTP
+    error, unparseable body).
+
+    Distinct from "the source answered, and has no record of this book".
+    Enrichment needs to tell those apart: the first is worth backing off
+    over, the second will never succeed no matter how long we wait.
+    """
+
 
 _SEARCH_FIELDS = (
     'key,title,author_name,first_publish_year,isbn,cover_i,'
@@ -51,9 +69,201 @@ def _pick_isbn(doc: dict) -> Optional[str]:
     return isbns[0] if isbns else None
 
 
+# A single-letter word (optionally with a trailing period) that is not a real
+# English one-letter word — the residue of a mangled transliteration.
+_STRAY_LETTER_RE = re.compile(r'(?<!\S)(?![aAiI](?!\w))[b-zB-Z]\.?(?!\S)')
+
+
 def _genre(doc: dict) -> Optional[str]:
-    subjects = doc.get('subject') or []
+    """
+    Subjects, restricted to the English-looking ones.
+
+    Subjects are work-level, so translations contribute theirs: How to Win
+    Friends offered 'Succes', 'Psychologie appliquee', 'Applied Psychology'.
+    Non-ASCII marks a translated subject. The rest of the noise is mangled
+    transliteration, which shows up as a stray one-letter token or a doubled
+    space ('Succe  s.', 'Psychologie applique e.'). Drop those and keep the
+    rest; when nothing survives, the Google fallback supplies categories.
+    """
+    subjects = [
+        s
+        for s in (doc.get('subject') or [])
+        if s.isascii() and '  ' not in s and not _STRAY_LETTER_RE.search(s)
+    ]
     return ', '.join(subjects[:3]) if subjects else None
+
+
+# A trailing parenthetical is decoration, not the title: series and volume
+# ('White Night (The Dresden Files, Book 9)'), award badges ('A Thousand
+# Acres (Pulitzer Prize Winner)'), edition notes. Repeated for every book in
+# a series it is pure noise, and series already has a home in `genre`.
+_TRAILING_PAREN_RE = re.compile(r'\s*[(\[][^)\]]*[)\]]\s*$')
+# Trailing edition/packaging qualifiers, which name a printing rather than the
+# book: Google gave 'The Scorch Trials Movie Tie-in Edition', Open Library
+# 'Dune Ebook Collection'.
+# Only strip words that actually qualify a printing. A wildcard run of words
+# before 'Edition' eats real title words ('The Scorch Trials Movie Tie-in
+# Edition' lost 'Trials').
+_EDITION_QUALIFIER = (
+    r'(?:movie|film|tv|deluxe|anniversary|illustrated|special|revised'
+    r"|expanded|collector'?s|annotated|reissue|international|ebook|e-book"
+    r'|mass[\s-]market|paperback|hardcover|tie[\s-]?in|\d+(?:st|nd|rd|th))'
+)
+_EDITION_SUFFIX_RE = re.compile(
+    rf'\s*[:,-]?\s*(?:{_EDITION_QUALIFIER}[\s-]+)+(?:edition|collection|set)\s*$',
+    re.IGNORECASE,
+)
+# Words that stay lowercase inside a title.
+_MINOR_WORDS = frozenset(
+    'a an the and but or nor for so yet at by in of on to up via from with as'.split()
+)
+
+
+def _title_case(title: str) -> str:
+    """
+    Normalize casing for titles stored sentence-cased ('The dark tower',
+    'Jim Butcher's the Dresden files').
+
+    Only touches words that are entirely lowercase, so deliberate casing is
+    preserved: acronyms stay upper, and names like 'iRobot' or 'McKay' keep
+    their internal capitals.
+    """
+    words = title.split(' ')
+    out = []
+    for index, word in enumerate(words):
+        if word.islower() and (
+            index not in (0, len(words) - 1) and word in _MINOR_WORDS
+        ):
+            out.append(word)
+        elif word.islower():
+            out.append(word[:1].upper() + word[1:])
+        else:
+            out.append(word)
+    return ' '.join(out)
+
+
+def normalize_title(title: Optional[str]) -> Optional[str]:
+    """
+    Tidy a catalog title: drop the trailing parenthetical and give it
+    consistent capitalization.
+    """
+    if not title:
+        return title
+    cleaned = _TRAILING_PAREN_RE.sub('', title.strip())
+    trimmed = _EDITION_SUFFIX_RE.sub('', cleaned)
+    # Only accept the trim if a real title survives it — 'The Complete
+    # Collection' must not become 'The'.
+    if trimmed and any(w.lower() not in _MINOR_WORDS for w in trimmed.split()):
+        cleaned = trimmed
+    # Never normalize a title away entirely.
+    cleaned = cleaned or title.strip()
+    return _title_case(cleaned)
+
+
+def _title_key(title: str) -> str:
+    """Comparison key: casing, punctuation and spacing carry no meaning here."""
+    return re.sub(r'[^a-z0-9]+', ' ', title.casefold()).strip()
+
+
+def _pick_title(edition_titles: list, work_title: Optional[str]) -> Optional[str]:
+    """
+    Choose between the work's title and its English editions'.
+
+    The work title is only wrong when it came from a translated edition
+    ('Fatta Eld' for Catching Fire). If it appears among the English editions
+    at all, it is a legitimate English title and stays — otherwise the most
+    common edition title wins a work like Order of the Phoenix, whose
+    editions are catalogued 8x as the bare series name 'Harry Potter' against
+    6x for the actual book.
+
+    Falls back to the most common edition title, ties to the shortest, which
+    filters outliers like 'Dune Ebook Collection'.
+    """
+    if not edition_titles:
+        return work_title
+    if not work_title:
+        return max(
+            set(edition_titles), key=lambda t: (edition_titles.count(t), -len(t))
+        )
+
+    core = _TRAILING_PAREN_RE.sub('', work_title.strip()) or work_title.strip()
+    keys = {_title_key(t) for t in edition_titles}
+    # Also matches when the work title only differs by a leading article:
+    # The Dark Tower's English edition is filed as 'Dark Tower'.
+    stripped = re.sub(r'^(?:the|a|an)\s+', '', core, flags=re.IGNORECASE)
+    if _title_key(core) in keys or _title_key(stripped) in keys:
+        return core
+    return max(set(edition_titles), key=lambda t: (edition_titles.count(t), -len(t)))
+
+
+def _is_english_edition(entry: dict) -> bool:
+    return any(
+        '/languages/eng' in (lang.get('key') or '')
+        for lang in (entry.get('languages') or [])
+    )
+
+
+def _english_edition(work_key: Optional[str]) -> dict:
+    """
+    Best English edition of an Open Library work: its cover, ISBN and page
+    count.
+
+    The work-level search doc aggregates every edition, so ``cover_i`` is
+    whichever edition Open Library happened to surface — for How to Win
+    Friends that was a foreign-language jacket. Editions carry a real
+    language, so pick from those instead.
+
+    Best effort: returns ``{}`` when the call fails or nothing is English,
+    leaving the caller on the work-level values.
+    """
+    if not work_key or not _WORK_KEY_RE.match(work_key):
+        return {}
+    try:
+        response = requests.get(
+            f'{OPENLIBRARY_URL}{work_key}/editions.json',
+            params={'limit': 50},
+            timeout=REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        entries = response.json().get('entries') or []
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning('Open Library editions fetch failed for %s: %s', work_key, exc)
+        return {}
+
+    english = [e for e in entries if _is_english_edition(e)]
+    if not english:
+        return {}
+    # No single edition reliably has everything, so take each field from the
+    # first English edition that has it.
+    result = {}
+    for entry in english:
+        covers = [c for c in (entry.get('covers') or []) if c and c > 0]
+        if covers and 'cover_i' not in result:
+            result['cover_i'] = covers[0]
+        isbns = entry.get('isbn_13') or entry.get('isbn_10') or []
+        if isbns and 'isbn' not in result:
+            result['isbn'] = isbns[0]
+        if entry.get('number_of_pages') and 'page_count' not in result:
+            result['page_count'] = entry['number_of_pages']
+    # Every English edition title, for _pick_title to choose among.
+    result['titles'] = [e['title'] for e in english if e.get('title')]
+    return result
+
+
+def _language(doc: dict) -> Optional[str]:
+    """
+    Pick the language of the *work*, which Open Library reports as the union
+    of every edition's language.
+
+    Taking element 0 is close to arbitrary — it tagged The Stand 'rus' and
+    The Da Vinci Code 'mal'. Only claim a language when the work has exactly
+    one, or when English is among them (this catalog is English-language);
+    otherwise say nothing rather than assert a translation at random.
+    """
+    languages = doc.get('language') or []
+    if len(languages) == 1:
+        return languages[0]
+    return 'eng' if 'eng' in languages else None
 
 
 def _bibkeys_authors(data: dict) -> Optional[str]:
@@ -158,7 +368,15 @@ def search_books(query: str) -> List[dict]:
     try:
         response = requests.get(
             f'{OPENLIBRARY_URL}/search.json',
-            params={'q': query, 'limit': 20, 'fields': _SEARCH_FIELDS},
+            params={
+                'q': query,
+                'limit': 20,
+                'fields': _SEARCH_FIELDS,
+                # Restrict to works that have an English edition. This is an
+                # English-language catalog, and unfiltered title searches
+                # surface translations ahead of the edition the user means.
+                'language': 'eng',
+            },
             timeout=REQUEST_TIMEOUT,
         )
         response.raise_for_status()
@@ -196,13 +414,21 @@ _FIELD_LIMITS = {
 }
 
 
-def apply_detail_to_book(book, detail: dict) -> None:
+def apply_detail_to_book(book, detail: dict, overwrite_title: bool = False) -> None:
     """
     Copy Open Library detail onto a DbBook, truncating to column limits and
     skipping None values (never clobber a good value with None).
+
+    A title the book already has is left alone. Someone adding a book picked
+    a specific edition from search results, and overwriting their choice with
+    whatever Open Library calls the work is how the catalog ended up with
+    'Jim Butcher's the Dresden Files' for Welcome to the Jungle. Only the
+    one-time backfill of legacy rows passes ``overwrite_title``.
     """
     for key, value in detail.items():
         if value is None:
+            continue
+        if key == 'title' and getattr(book, 'title', None) and not overwrite_title:
             continue
         if key in _FIELD_LIMITS and isinstance(value, str):
             value = value[: _FIELD_LIMITS[key]]
@@ -229,7 +455,54 @@ def _work_description(work_key: Optional[str]) -> Optional[str]:
         return None
     if isinstance(description, dict):
         description = description.get('value')
-    return description or None
+    return _plain_text(description)
+
+
+def _openlibrary_detail(isbn: str) -> Optional[dict]:
+    """
+    Open Library detail for an ISBN, in catalog shape.
+
+    Returns None when Open Library has no record of the ISBN; raises
+    ``UpstreamUnavailable`` when the call itself failed.
+    """
+    try:
+        response = requests.get(
+            f'{OPENLIBRARY_URL}/search.json',
+            params={'q': f'isbn:{isbn}', 'limit': 1, 'fields': _SEARCH_FIELDS},
+            timeout=REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        docs = response.json().get('docs') or []
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning('Open Library detail failed for %s: %s', isbn, exc)
+        raise UpstreamUnavailable(str(exc)) from exc
+    if not docs:
+        return None
+
+    doc = docs[0]
+    year = doc.get('first_publish_year')
+    rating = doc.get('ratings_average')
+    # Cover/pages come from an English edition where one exists, rather than
+    # from the work's arbitrary pick across all translations. Note isbn is
+    # deliberately *not* taken from that edition: the caller's ISBN is the
+    # row's identity (router_books dedupes on it), so swapping it here would
+    # silently store something other than what was asked for. Repointing a
+    # row at an English edition is a data repair, not a lookup side effect.
+    edition = _english_edition(doc.get('key'))
+    return {
+        'title': normalize_title(
+            _pick_title(edition.get('titles') or [], doc.get('title'))
+        ),
+        'isbn': isbn,
+        'authors': _authors(doc),
+        'year': year,
+        'genre': _genre(doc),
+        'description': _work_description(doc.get('key')),
+        'page_count': edition.get('page_count') or doc.get('number_of_pages_median'),
+        'rating': round(rating, 2) if rating else None,
+        'language': 'eng' if edition else _language(doc),
+        'poster_url': _cover(edition.get('cover_i') or doc.get('cover_i')),
+    }
 
 
 def get_book_detail(isbn: Optional[str]) -> Optional[dict]:
@@ -242,32 +515,201 @@ def get_book_detail(isbn: Optional[str]) -> Optional[dict]:
     if not isbn:
         return None
     try:
-        response = requests.get(
-            f'{OPENLIBRARY_URL}/search.json',
-            params={'q': f'isbn:{isbn}', 'limit': 1, 'fields': _SEARCH_FIELDS},
-            timeout=REQUEST_TIMEOUT,
-        )
-        response.raise_for_status()
-        docs = response.json().get('docs') or []
-    except (requests.RequestException, ValueError) as exc:
-        logger.warning('Open Library detail failed for %s: %s', isbn, exc)
-        return None
-    if not docs:
+        return _openlibrary_detail(isbn)
+    except UpstreamUnavailable:
         return None
 
-    doc = docs[0]
-    year = doc.get('first_publish_year')
-    rating = doc.get('ratings_average')
-    languages = doc.get('language') or []
+
+def _google_isbn(volume: dict) -> Optional[str]:
+    """Prefer an ISBN-13 from the volume's industry identifiers."""
+    identifiers = volume.get('industryIdentifiers') or []
+    by_type = {i.get('type'): i.get('identifier') for i in identifiers}
+    return by_type.get('ISBN_13') or by_type.get('ISBN_10')
+
+
+def _google_year(volume: dict) -> Optional[int]:
+    """publishedDate is any of 'YYYY', 'YYYY-MM', or 'YYYY-MM-DD'."""
+    match = re.search(r'\d{4}', volume.get('publishedDate') or '')
+    return int(match.group(0)) if match else None
+
+
+_GOOGLE_ID_RE = re.compile(r'[?&]id=([^&]+)')
+
+
+def _google_poster(volume: dict) -> Optional[str]:
+    """
+    Stable https cover URL for a Google volume.
+
+    The raw thumbnail is http (blocked as mixed content on an https site),
+    carries a page-curl overlay, and trails a long ``imgtk`` signature that
+    pushes it past the 254-char poster_url column — where it gets truncated
+    into a broken link. Rebuild the minimal form instead of patching the
+    given one.
+    """
+    links = volume.get('imageLinks') or {}
+    thumbnail = links.get('thumbnail') or links.get('smallThumbnail')
+    if not thumbnail:
+        return None
+    match = _GOOGLE_ID_RE.search(thumbnail)
+    if not match:
+        return thumbnail.replace('http://', 'https://').replace('&edge=curl', '')
+    return (
+        f'https://books.google.com/books/content?id={match.group(1)}'
+        '&printsec=frontcover&img=1&zoom=1'
+    )
+
+
+_BLOCK_TAG_RE = re.compile(r'</(?:p|div|li|h[1-6])\s*>|<br\s*/?>', re.IGNORECASE)
+_TAG_RE = re.compile(r'<[^>]+>')
+# Open Library descriptions are Markdown, and are open to edit by anyone —
+# link spam shows up in them. Rich Dad Poor Dad's opened with a Markdown link
+# to a PDF piracy site. Keep the link text, drop the destination.
+_MD_LINK_RE = re.compile(r'\[([^\]]*)\]\(([^)]*)\)')
+# A whole line that is just a Markdown link (with optional trailing hard-break
+# backslashes) — the shape the spam takes.
+_STANDALONE_LINK_RE = re.compile(r'\\*\[[^\]]*\]\([^)]*\)\\*')
+_BARE_URL_RE = re.compile(r'\bhttps?://\S+')
+# Markdown hard line breaks arrive as a literal backslash before the newline.
+_ESCAPED_BREAK_RE = re.compile(r'\\+\r?\n')
+
+
+def _plain_text(markup: Optional[str]) -> Optional[str]:
+    """
+    Flatten a description to plain text.
+
+    Both sources need this, for different reasons: Google Books returns HTML,
+    Open Library returns Markdown. The web renders the column as text
+    (BookDetail renders ``{book.description}``, not
+    ``dangerouslySetInnerHTML``), so either one's markup shows up literally.
+    Keeping the column plain also avoids storing third-party markup that some
+    later renderer might decide to trust.
+
+    URLs are dropped rather than kept as text: they are almost always spam in
+    this data, and a bare link in a catalog description is noise at best.
+    """
+    if not markup:
+        return None
+    text = _ESCAPED_BREAK_RE.sub('\n', markup)
+    # A line that is nothing but a link is navigation or spam, so drop it
+    # whole. Inline links keep their words, which are part of the prose.
+    text = '\n'.join(
+        line
+        for line in text.split('\n')
+        if not _STANDALONE_LINK_RE.fullmatch(line.strip())
+    )
+    text = _MD_LINK_RE.sub(r'\1', text)
+    text = _BLOCK_TAG_RE.sub('\n', text)
+    text = _TAG_RE.sub('', text)
+    text = unescape(text)
+    text = _BARE_URL_RE.sub('', text)
+    # Collapse the run of blank lines the block substitution can leave behind.
+    text = re.sub(r'[ \t]+', ' ', text)
+    text = re.sub(r'\n\s*\n+', '\n\n', text)
+    return text.strip() or None
+
+
+def _google_genre(volume: dict) -> Optional[str]:
+    """
+    Flatten Google's hierarchical categories into the same comma-separated
+    shape Open Library subjects use, so the column stays filterable.
+
+    'Juvenile Fiction / Action & Adventure / General' carries three segments,
+    of which 'General' is filler. Split on the path separator, drop the
+    filler, de-duplicate across categories, keep the first three.
+    """
+    segments = []
+    for category in volume.get('categories') or []:
+        for segment in category.split('/'):
+            segment = segment.strip()
+            if segment and segment != 'General' and segment not in segments:
+                segments.append(segment)
+    return ', '.join(segments[:3]) if segments else None
+
+
+def _google_books_detail(googleid: str) -> Optional[dict]:
+    """
+    Google Books detail for a volume id, in catalog shape.
+
+    Returns None when the key is unset or the volume is unknown; raises
+    ``UpstreamUnavailable`` when the call itself failed. Note that Google
+    answers an unknown volume id with 404, which is a "no record" result
+    rather than an outage — hence the explicit check before raising.
+    """
+    api_key = get_settings().google_books_api_key
+    if not api_key:
+        logger.info('GOOGLE_BOOKS_API_KEY unset; skipping %s', googleid)
+        return None
+    try:
+        response = requests.get(
+            f'{GOOGLE_BOOKS_URL}/volumes/{googleid}',
+            params={'key': api_key},
+            timeout=REQUEST_TIMEOUT,
+        )
+        if response.status_code == status.HTTP_404_NOT_FOUND:
+            return None
+        response.raise_for_status()
+        volume = response.json().get('volumeInfo') or {}
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning('Google Books detail failed for %s: %s', googleid, exc)
+        raise UpstreamUnavailable(str(exc)) from exc
+    if not volume:
+        return None
+
+    authors = volume.get('authors') or []
+    rating = volume.get('averageRating')
     return {
-        'title': doc.get('title'),
-        'isbn': isbn,
-        'authors': _authors(doc),
-        'year': year,
-        'genre': _genre(doc),
-        'description': _work_description(doc.get('key')),
-        'page_count': doc.get('number_of_pages_median'),
+        'title': normalize_title(volume.get('title')),
+        'isbn': _google_isbn(volume),
+        'authors': ', '.join(authors) if authors else None,
+        'year': _google_year(volume),
+        'genre': _google_genre(volume),
+        'description': _plain_text(volume.get('description')),
+        'page_count': volume.get('pageCount'),
         'rating': round(rating, 2) if rating else None,
-        'language': languages[0] if languages else None,
-        'poster_url': _cover(doc.get('cover_i')),
+        'language': volume.get('language'),
+        'poster_url': _google_poster(volume),
+    }
+
+
+def get_book_detail_by_googleid(googleid: Optional[str]) -> Optional[dict]:
+    """Google Books counterpart to ``get_book_detail``, keyed on volume id."""
+    googleid = (googleid or '').strip()
+    if not googleid:
+        return None
+    try:
+        return _google_books_detail(googleid)
+    except UpstreamUnavailable:
+        return None
+
+
+def resolve_book_detail(
+    isbn: Optional[str], googleid: Optional[str] = None
+) -> Optional[dict]:
+    """
+    Best-available detail for a catalog row: Open Library by ISBN first,
+    then Google Books by ``googleid``.
+
+    Unlike ``get_book_detail`` this propagates ``UpstreamUnavailable`` so
+    enrichment can back off on a genuine outage instead of counting it as a
+    book that will never resolve. Returns None only when a source actually
+    answered and had no record.
+    """
+    isbn = (isbn or '').strip().replace('-', '')
+    googleid = (googleid or '').strip()
+    detail = _openlibrary_detail(isbn) if isbn else None
+    if not googleid:
+        return detail
+
+    fallback = _google_books_detail(googleid)
+    if not detail:
+        return fallback
+    if not fallback:
+        return detail
+    # Open Library wins where it has a value — better ratings coverage, and
+    # first-publish year rather than this printing's date — but it answers
+    # with partial records (One Mission came back as a title and nothing
+    # else), so let Google fill the gaps rather than discarding it.
+    return {
+        key: value if value is not None else fallback.get(key)
+        for key, value in detail.items()
     }

--- a/tests/unit/book_search_test.py
+++ b/tests/unit/book_search_test.py
@@ -2,6 +2,9 @@
 # pylint: disable=protected-access, missing-class-docstring
 from unittest.mock import MagicMock, patch
 
+import pytest
+import requests
+
 from app.services import book_search
 
 
@@ -22,6 +25,234 @@ def test_helpers():
     assert book_search._genre({'subject': ['Sci-fi', 'Deserts', 'Spice', 'Worms']}) == (
         'Sci-fi, Deserts, Spice'
     )
+
+
+def test_normalize_title_strips_series_and_fixes_casing():
+    n = book_search.normalize_title
+    assert n('White Night (The Dresden Files, Book 9)') == 'White Night'
+    assert n('The Scorch Trials (Maze Runner, Book Two)') == 'The Scorch Trials'
+    assert n('The Great Hunt (The Wheel of Time Book 2)') == 'The Great Hunt'
+    assert n('The dark tower') == 'The Dark Tower'
+    assert n('How to win friends & influence people') == (
+        'How to Win Friends & Influence People'
+    )
+    # Award badges and other trailing decoration go too.
+    assert n('A Thousand Acres (Pulitzer Prize Winner)') == 'A Thousand Acres'
+    # Never normalize a title away entirely.
+    assert n('(Untitled)') == '(Untitled)'
+
+
+def test_normalize_title_strips_only_real_edition_qualifiers():
+    n = book_search.normalize_title
+    assert n('The Scorch Trials Movie Tie-in Edition') == 'The Scorch Trials'
+    assert n('Dune Ebook Collection') == 'Dune'
+    assert n('Dune: 50th Anniversary Edition') == 'Dune'
+    # 'Complete' is not a printing qualifier, and stripping 'Special Edition'
+    # would leave nothing but an article — both titles stay whole.
+    assert n('The Complete Collection') == 'The Complete Collection'
+    assert n('The Special Edition') == 'The Special Edition'
+    # Deliberate casing is never flattened.
+    assert n('iRobot and McKay at NASA') == 'iRobot and McKay at NASA'
+    assert n(None) is None
+
+
+def test_pick_title_keeps_the_catalog_title_when_english_editions_have_it():
+    p = book_search._pick_title
+    # Order of the Phoenix: the bare series name is the *most common* edition
+    # title (8x vs 6x), but the real title is in there, so it must stand.
+    phoenix = ['Harry Potter'] * 8 + ['Harry Potter and the Order of the Phoenix'] * 6
+    assert p(phoenix, 'Harry Potter and the Order of the Phoenix') == (
+        'Harry Potter and the Order of the Phoenix'
+    )
+    # Punctuation is not meaning: 'Star Wars - Bloodline' matches the
+    # edition's 'Star Wars: Bloodline', so it is not collapsed to 'Star Wars'.
+    assert p(['Star Wars'] * 3 + ['Star Wars: Bloodline'], 'Star Wars - Bloodline') == (
+        'Star Wars - Bloodline'
+    )
+    # The Dark Tower's English edition is filed as 'Dark Tower' — differs only
+    # by the article, so the catalog title stays.
+    assert p(['Dark Tower'], 'The dark tower') == 'The dark tower'
+    # A genuine translation matches nothing English, so the edition wins.
+    assert p(['Waste Lands'], 'A Torre Negra') == 'Waste Lands'
+    assert p(['Catching Fire'], 'Fatta Eld') == 'Catching Fire'
+    # Outlier edition names lose to the consensus.
+    assert p(['Dune'] * 9 + ['Dune Ebook Collection'], 'Fremen') == 'Dune'
+    assert p([], 'La Nuit') == 'La Nuit'
+
+
+def test_plain_text_strips_markdown_link_spam():
+    # Open Library descriptions are Markdown and openly editable; Rich Dad
+    # Poor Dad's opened with a link to a PDF piracy site.
+    raw = (
+        '[<u>Rich Dad, Poor Dad PDF</u>](https://chesserresources.com/doc/x/)'
+        '\\\r\n\\\r\nApril of 2022 marks a 25-year milestone.'
+    )
+    out = book_search._plain_text(raw)
+    assert 'chesserresources' not in out
+    assert '](' not in out and '<u>' not in out
+    # The link was the whole line, so it goes entirely — keeping its text
+    # left the description opening with 'Rich Dad, Poor Dad PDF'.
+    assert out == 'April of 2022 marks a 25-year milestone.'
+
+
+def test_plain_text_keeps_inline_link_wording():
+    assert book_search._plain_text('See [the sequel](http://x.com) for more.') == (
+        'See the sequel for more.'
+    )
+
+
+def test_google_poster_is_stable_and_short():
+    long_thumb = (
+        'http://books.google.com/books/publisher/content?id=0QaqDQAAQBAJ'
+        '&printsec=frontcover&img=1&zoom=1&imgtk=' + 'A' * 200 + '&source=gbs_api'
+    )
+    url = book_search._google_poster({'imageLinks': {'thumbnail': long_thumb}})
+    # Must fit the 254-char poster_url column, or it is stored truncated
+    # into a broken link.
+    assert len(url) < 254
+    assert url.startswith('https://')
+    assert 'id=0QaqDQAAQBAJ' in url
+    assert 'imgtk' not in url
+
+
+def test_genre_drops_translated_subjects():
+    doc = {
+        'subject': [
+            'Succès',
+            'Psychologie appliquée',
+            'Succe  s.',
+            'Applied Psychology',
+            'Self-help',
+        ]
+    }
+    assert book_search._genre(doc) == 'Applied Psychology, Self-help'
+    assert book_search._genre({'subject': ['Succès']}) is None
+    # 'Psychologie applique e.' is ASCII and single-spaced; the stray 'e.'
+    # is what marks it as mangled.
+    assert book_search._genre({'subject': ['Psychologie applique e.']}) is None
+    # Real one-letter words must survive.
+    assert book_search._genre({'subject': ['A history of art', 'I, Robot']}) == (
+        'A history of art, I, Robot'
+    )
+
+
+@patch('app.services.book_search.requests.get')
+def test_english_edition_prefers_english_cover_and_isbn(mock_get):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {
+        'entries': [
+            # Foreign edition first — must not win the cover.
+            {
+                'languages': [{'key': '/languages/jpn'}],
+                'covers': [999],
+                'isbn_13': ['9784000000000'],
+            },
+            {
+                'languages': [{'key': '/languages/eng'}],
+                'covers': [15200981],
+                'number_of_pages': 262,
+                'title': 'How to Win Friends and Influence People',
+            },
+            {
+                'languages': [{'key': '/languages/eng'}],
+                'isbn_13': ['9780671027032'],
+                'title': 'How to Win Friends and Influence People',
+            },
+            # An outlier edition name must not beat the consensus title.
+            {
+                'languages': [{'key': '/languages/eng'}],
+                'title': 'How to Win Friends Ebook Collection',
+            },
+        ]
+    }
+    mock_get.return_value = resp
+
+    edition = book_search._english_edition('/works/OL1063267W')
+    assert edition['titles'] == [
+        'How to Win Friends and Influence People',
+        'How to Win Friends and Influence People',
+        'How to Win Friends Ebook Collection',
+    ]
+
+    assert edition['cover_i'] == 15200981
+    assert edition['page_count'] == 262
+    # Exposed for the repair pass, but never applied by _openlibrary_detail:
+    # the caller's ISBN is the row's identity.
+    assert edition['isbn'] == '9780671027032'  # taken from a later entry
+
+
+@patch('app.services.book_search.requests.get')
+def test_english_edition_is_best_effort(mock_get):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {'entries': [{'languages': [{'key': '/languages/fre'}]}]}
+    mock_get.return_value = resp
+    assert not book_search._english_edition('/works/OL1W')
+    assert not book_search._english_edition(None)
+
+
+@patch('app.services.book_search._google_books_detail')
+@patch('app.services.book_search._openlibrary_detail')
+def test_resolve_merges_google_into_partial_openlibrary_hit(mock_ol, mock_google):
+    # One Mission resolved on Open Library as a title and nothing else.
+    mock_ol.return_value = {
+        'title': 'One Mission',
+        'authors': None,
+        'year': None,
+        'rating': 4.1,
+    }
+    mock_google.return_value = {
+        'title': 'One Mission (Google)',
+        'authors': 'Chris Fussell',
+        'year': 2017,
+        'rating': None,
+    }
+
+    detail = book_search.resolve_book_detail('9780735211360', '0QaqDQAAQBAJ')
+
+    assert detail['title'] == 'One Mission'  # Open Library wins where it has a value
+    assert detail['authors'] == 'Chris Fussell'  # gap filled
+    assert detail['year'] == 2017
+    assert detail['rating'] == 4.1  # not clobbered by Google's None
+
+
+@patch('app.services.book_search.requests.get')
+def test_search_books_restricts_to_english(mock_get):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {'docs': []}
+    mock_get.return_value = resp
+
+    book_search.search_books('dune')
+
+    assert mock_get.call_args.kwargs['params']['language'] == 'eng'
+
+
+def test_language_never_guesses_a_translation():
+    # A work listing many editions must not assert one of them at random:
+    # element 0 tagged The Stand 'rus' and The Da Vinci Code 'mal'.
+    assert book_search._language({'language': ['rus', 'eng', 'ita']}) == 'eng'
+    assert book_search._language({'language': ['rus', 'ita']}) is None
+    assert book_search._language({'language': ['fre']}) == 'fre'
+    assert book_search._language({}) is None
+
+
+def test_apply_detail_keeps_the_title_the_user_chose():
+    class Book:
+        title = 'Welcome to the Jungle'
+        authors = None
+
+    b = Book()
+    book_search.apply_detail_to_book(
+        b, {'title': "Jim Butcher's the Dresden Files", 'authors': 'Jim Butcher'}
+    )
+    assert b.title == 'Welcome to the Jungle'  # selection wins on add
+    assert b.authors == 'Jim Butcher'  # other fields still fill
+
+    # The one-time backfill of legacy rows opts in explicitly.
+    book_search.apply_detail_to_book(b, {'title': 'Renamed'}, overwrite_title=True)
+    assert b.title == 'Renamed'
 
 
 def test_apply_detail_truncates_and_skips_none():
@@ -78,6 +309,134 @@ def test_get_book_detail_maps_fields(mock_get, mock_desc):
 def test_get_book_detail_without_isbn_returns_none():
     assert book_search.get_book_detail(None) is None
     assert book_search.get_book_detail('') is None
+
+
+@patch('app.services.book_search.requests.get', side_effect=requests.Timeout('slow'))
+def test_get_book_detail_swallows_upstream_failure(_mock_get):
+    # Public helper keeps its "None means no detail" contract for routers.
+    assert book_search.get_book_detail('9780441172719') is None
+
+
+@patch('app.services.book_search.requests.get', side_effect=requests.Timeout('slow'))
+def test_openlibrary_detail_raises_on_upstream_failure(_mock_get):
+    # Enrichment needs the failure to be distinguishable from a miss.
+    with pytest.raises(book_search.UpstreamUnavailable):
+        book_search._openlibrary_detail('9780441172719')
+
+
+_GOOGLE_VOLUME = {
+    'volumeInfo': {
+        'title': 'The Phoenix Project',
+        'authors': ['Gene Kim', 'Kevin Behr'],
+        'publishedDate': '2014-10-15',
+        'description': '<p>An <i>IT</i> novel.</p><p>Bill &amp; Brent.</p>',
+        'industryIdentifiers': [
+            {'type': 'ISBN_10', 'identifier': '1942788290'},
+            {'type': 'ISBN_13', 'identifier': '9781942788294'},
+        ],
+        'pageCount': 348,
+        'categories': [
+            'Business & Economics / Management',
+            'Business & Economics / General',
+            'Computers / IT / Operations',
+        ],
+        'averageRating': 4.3456,
+        'language': 'en',
+        'imageLinks': {
+            'thumbnail': 'http://books.google.com/books/content?id=X&edge=curl'
+        },
+    }
+}
+
+
+@patch('app.services.book_search.get_settings')
+@patch('app.services.book_search.requests.get')
+def test_google_books_detail_maps_fields(mock_get, mock_settings):
+    mock_settings.return_value.google_books_api_key = 'AIzaTest'
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = _GOOGLE_VOLUME
+    mock_get.return_value = resp
+
+    detail = book_search.get_book_detail_by_googleid('_An-CAAAQBAJ')
+
+    assert detail['title'] == 'The Phoenix Project'
+    assert detail['isbn'] == '9781942788294'  # ISBN-13 preferred
+    assert detail['authors'] == 'Gene Kim, Kevin Behr'
+    assert detail['year'] == 2014  # parsed out of 'YYYY-MM-DD'
+    # Hierarchical categories flattened, 'General' dropped, capped at 3.
+    assert detail['genre'] == 'Business & Economics, Management, Computers'
+    # HTML flattened to text so the web's {book.description} does not show tags.
+    assert detail['description'] == 'An IT novel.\nBill & Brent.'
+    assert detail['page_count'] == 348
+    assert detail['rating'] == 4.35
+    assert detail['language'] == 'en'
+    # https, no page-curl overlay, rebuilt to the stable minimal form.
+    assert detail['poster_url'] == (
+        'https://books.google.com/books/content?id=X&printsec=frontcover&img=1&zoom=1'
+    )
+
+
+@patch('app.services.book_search.get_settings')
+def test_google_books_detail_skipped_without_key(mock_settings):
+    mock_settings.return_value.google_books_api_key = None
+    assert book_search.get_book_detail_by_googleid('_An-CAAAQBAJ') is None
+
+
+@patch('app.services.book_search.get_settings')
+@patch('app.services.book_search.requests.get')
+def test_google_books_unknown_volume_is_a_miss_not_an_outage(mock_get, mock_settings):
+    mock_settings.return_value.google_books_api_key = 'AIzaTest'
+    resp = MagicMock()
+    resp.status_code = 404
+    mock_get.return_value = resp
+
+    # 404 means "no such volume" — must not look like an upstream failure.
+    assert book_search._google_books_detail('nope') is None
+    resp.raise_for_status.assert_not_called()
+
+
+@patch('app.services.book_search._google_books_detail')
+@patch('app.services.book_search._openlibrary_detail')
+def test_resolve_falls_back_to_googleid(mock_ol, mock_google):
+    mock_ol.return_value = None  # Open Library has no record of this edition
+    mock_google.return_value = {'title': 'The Phoenix Project'}
+
+    detail = book_search.resolve_book_detail('9780307378026', '_An-CAAAQBAJ')
+
+    assert detail == {'title': 'The Phoenix Project'}
+    mock_google.assert_called_once_with('_An-CAAAQBAJ')
+
+
+@patch('app.services.book_search._google_books_detail')
+@patch('app.services.book_search._openlibrary_detail')
+def test_resolve_keeps_openlibrary_values_over_google(mock_ol, mock_google):
+    mock_ol.return_value = {'title': 'Dune', 'rating': 4.2}
+    mock_google.return_value = {'title': 'Dune (movie tie-in)', 'rating': 3.0}
+    detail = book_search.resolve_book_detail('9780441172719', 'abc')
+    assert detail == {'title': 'Dune', 'rating': 4.2}
+
+
+@patch('app.services.book_search._google_books_detail')
+@patch('app.services.book_search._openlibrary_detail')
+def test_resolve_skips_google_when_there_is_no_googleid(mock_ol, mock_google):
+    mock_ol.return_value = {'title': 'Dune'}
+    assert book_search.resolve_book_detail('9780441172719', None) == {'title': 'Dune'}
+    mock_google.assert_not_called()
+
+
+@patch('app.services.book_search._google_books_detail')
+def test_resolve_handles_row_with_googleid_but_no_isbn(mock_google):
+    mock_google.return_value = {'title': 'The Phoenix Project'}
+    assert book_search.resolve_book_detail(None, '_An-CAAAQBAJ') is not None
+
+
+@patch('app.services.book_search._openlibrary_detail')
+def test_resolve_propagates_upstream_failure(mock_ol):
+    mock_ol.side_effect = book_search.UpstreamUnavailable('boom')
+    with pytest.raises(book_search.UpstreamUnavailable):
+        book_search.resolve_book_detail('9780441172719', 'abc')
 
 
 def test_work_description_unwraps_dict():


### PR DESCRIPTION
## Problem

Book enrichment could not touch **38 of the catalog's rows**. Every one was imported from Google Books, and their edition-specific ISBNs are not indexed by Open Library — the only source `enrich_books` consulted. The run reported `0 enriched, 15 misses` and aborted.

The abort made it permanently stuck rather than resumable, as its docstring claimed: the circuit breaker counted a miss and a transport failure as the same event, and the pending query had no `ORDER BY`, so every re-run pulled the same leading block of dead ISBNs and died in the same place.

## Fix

Fall back to Google Books on the `googleid` those rows already carry, and count only consecutive upstream *failures* toward the breaker — a book no source has a record of will never resolve however long we wait. The pending set now accepts a `googleid` where there is no ISBN at all (*The Phoenix Project* had none, so it could never have been enriched) and orders by id so a resumed run is reproducible.

`resolve_book_detail` merges rather than picking a winner: Open Library's values stand (better ratings coverage, first-publish year over this printing's date), Google fills the gaps — Open Library answers with partial records.

```
before:  38 books to enrich -> enriched 0,  misses 15, ABORTED
after:  211 books to enrich -> enriched 208, misses 3, errors 0, ran to completion
```

The 3 remaining are genuine 404s at both sources — delisted volumes and untraceable reprints.

## Data-quality bugs found while running against real upstream data

- **`language` was `languages[0]` of the *work***, whose list is the union of every edition. Only **4 of 25** sampled rows were right — *The Stand* was tagged `rus`, *The Da Vinci Code* `mal`. Now claims a language only when the work has exactly one, or English is among them.
- **Covers, page counts and titles came from an arbitrary edition**, so translations supplied them. Now prefers an English edition. A work's title only loses to its editions' when it matches none of them — *Order of the Phoenix* is catalogued 8× under the bare series name against 6× for the real title, and taking the majority renamed it `Harry Potter`.
- **Descriptions** arrived as Google's HTML and Open Library's Markdown, both rendered as text by the web. Now flattened, with link-only lines dropped: Open Library descriptions are openly editable and *Rich Dad Poor Dad*'s opened with a link to a PDF piracy site.
- **Google's thumbnail URLs** carry a signature that overruns the 254-char `poster_url` column and stores truncated into a broken link. Now rebuilt to a minimal stable form.

## Behaviour change worth reviewing

`apply_detail_to_book` no longer overwrites a title the book already has. Someone adding a book picked a specific edition from the search results, and overwriting their choice with whatever Open Library calls the work is how the catalog got `Jim Butcher's the Dresden Files` for *Welcome to the Jungle*. Only the one-time backfill of legacy rows opts in via `overwrite_title=True`.

## Config

`GOOGLE_BOOKS_API_KEY` is optional — the Google path is skipped when unset. Note `env/` is gitignored in this repo (`.gitignore:130` `ENV/`, case-insensitive on macOS), so the template documenting it could not be committed; the var needs adding to `env/*.env` by hand.

## Testing

430 tests pass (10 new for this work), pylint 10.00/10. Verified end to end against the live catalog on the local dev stack, plus real TMDB/Open Library/Google Books calls.

## Follow-ups not in this PR

- The prod `language` values are already wrong and enrichment won't fix them — `apply_detail_to_book` skips `None`, and those rows are no longer pending. Needs a repair pass.
- Legacy prod rows still read `Fatta Eld`, `La Nuit`, `A Torre Negra` until this ships and the backfill runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)