### PR TITLE
Say when the Google fallback is off, instead of counting it as misses

### DIFF
--- a/.github/workflows/deploy_cloud_run.yaml
+++ b/.github/workflows/deploy_cloud_run.yaml
@@ -76,6 +76,13 @@ jobs:
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
           TWITCH_CLIENT_ID: ${{ secrets.TWITCH_CLIENT_ID }}
           TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}
+          # Books whose edition-specific ISBN Open Library does not index are
+          # reachable only through their Google volume id. Without this,
+          # enrich_books below leaves every one of them unenriched and reports
+          # them as ordinary misses — which is exactly what a QA deploy did.
+          # Optional, like the Twitch creds: enrich_books says so itself and
+          # keeps going rather than blocking a release.
+          GOOGLE_BOOKS_API_KEY: ${{ secrets.GOOGLE_BOOKS_API_KEY }}
           ENV: prod
         run: |
           set -euo pipefail

--- a/.github/workflows/deploy_qa.yaml
+++ b/.github/workflows/deploy_qa.yaml
@@ -70,6 +70,9 @@ jobs:
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
           TWITCH_CLIENT_ID: ${{ secrets.TWITCH_CLIENT_ID }}
           TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}
+          # See the prod workflow: without this, enrich_books cannot reach the
+          # books Open Library has no record of, and reports them as misses.
+          GOOGLE_BOOKS_API_KEY: ${{ secrets.GOOGLE_BOOKS_API_KEY }}
           ENV: qa
         run: |
           set -euo pipefail

--- a/app/migration/enrich_books.py
+++ b/app/migration/enrich_books.py
@@ -16,6 +16,7 @@ import time
 
 from sqlalchemy import and_, or_
 
+from app.config import get_settings
 from app.db.database import SessionLocal
 from app.db.models_sandbox import DbBook
 from app.services.book_search import (
@@ -66,6 +67,18 @@ def run() -> None:
         pending = pending_books(db)
         total = len(pending)
         print(f'{total} books to enrich')
+        # Without the key the Google fallback returns None, which is
+        # indistinguishable from "no source has this book" in the totals. Say
+        # so once, up front, rather than leaving an operator to read a wall of
+        # misses as a data problem when it is a config one.
+        needs_google = sum(1 for b in pending if b.googleid)
+        if needs_google and not get_settings().google_books_api_key:
+            print(
+                f'  WARNING: GOOGLE_BOOKS_API_KEY is not set, so the Google '
+                f'fallback is disabled. {needs_google} of these books carry a '
+                f'googleid and most will be counted as misses. Set the key and '
+                f're-run to enrich them.'
+            )
         enriched = misses = errors = consecutive = processed = 0
         for book in pending:
             processed += 1

--- a/app/services/book_search.py
+++ b/app/services/book_search.py
@@ -637,7 +637,9 @@ def _google_books_detail(googleid: str) -> Optional[dict]:
     """
     api_key = get_settings().google_books_api_key
     if not api_key:
-        logger.info('GOOGLE_BOOKS_API_KEY unset; skipping %s', googleid)
+        # Once per book would be a wall of noise on a bulk run; enrich_books
+        # reports the disabled fallback once, up front.
+        logger.debug('GOOGLE_BOOKS_API_KEY unset; skipping %s', googleid)
         return None
     try:
         response = requests.get(

--- a/tests/unit/enrich_books_run_test.py
+++ b/tests/unit/enrich_books_run_test.py
@@ -1,0 +1,56 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+"""
+A missing GOOGLE_BOOKS_API_KEY disables the Google fallback silently: every
+book that needs it returns None, which lands in the same "miss" bucket as a
+book no source has ever heard of. A QA run read as "38 misses" when it was
+really an unset variable, so the run has to say so itself.
+"""
+
+from unittest.mock import patch
+
+from app.db.models_sandbox import DbBook
+from app.migration import enrich_books
+
+
+def _pending_book(session):
+    session.add(
+        DbBook(
+            title='The Phoenix Project',
+            isbn=None,
+            googleid='_An-CAAAQBAJ',
+            authors=None,
+            year=None,
+        )
+    )
+    session.commit()
+
+
+def _run_capturing(session, capsys, api_key):
+    with patch.object(enrich_books, 'SessionLocal', return_value=session), patch.object(
+        enrich_books, 'resolve_book_detail', return_value=None
+    ), patch.object(enrich_books.time, 'sleep'), patch.object(
+        enrich_books, 'get_settings'
+    ) as settings:
+        settings.return_value.google_books_api_key = api_key
+        session.close = lambda: None  # run() closes its own session
+        enrich_books.run()
+    return capsys.readouterr().out
+
+
+def test_run_warns_when_the_google_key_is_missing(test_client, capsys):
+    session = test_client.test_db_session
+    _pending_book(session)
+
+    out = _run_capturing(session, capsys, api_key=None)
+
+    assert 'GOOGLE_BOOKS_API_KEY is not set' in out
+    assert '1 of these books carry a googleid' in out
+
+
+def test_run_stays_quiet_when_the_key_is_present(test_client, capsys):
+    session = test_client.test_db_session
+    _pending_book(session)
+
+    out = _run_capturing(session, capsys, api_key='AIzaTest')
+
+    assert 'GOOGLE_BOOKS_API_KEY' not in out


### PR DESCRIPTION
## What happened

A QA run on the freshly deployed #251 reported:

```
40 books to enrich
  25/40 (enriched 2, misses 23, errors 0)
Done: enriched 2, misses 38, errors 0, remaining ~0
```

That is the shape of the bug #251 fixed, from an environment that has the fix. The cause was an **unset `GOOGLE_BOOKS_API_KEY`**, not the code.

Verified directly — same volume, same code, key toggled:

```
key unset -> None
key set   -> Harry Potter and the Sorcerer's Stone | J.K. Rowling | 2015
```

`_google_books_detail` returns `None` when the key is missing, which lands in the same bucket as "no source has a record of this book". So a config problem and a data problem produce identical totals, and the operator has no way to tell them apart. The `backfill:covers` output in the same run said `no Open Library cover` 47 times for the same reason.

## Fix

Report it once, up front, naming how many pending books actually depend on the fallback:

```
40 books to enrich
  WARNING: GOOGLE_BOOKS_API_KEY is not set, so the Google fallback is
  disabled. 38 of these books carry a googleid and most will be counted as
  misses. Set the key and re-run to enrich them.
```

The per-book log drops from `info` to `debug` — on a bulk run it was 38 lines saying the same thing.

## Why this keeps biting

`env/` is gitignored in this repo (`.gitignore:130` `ENV/`, which matches `env/` on case-insensitive macOS), so no template documents the variable and nothing fails when it is absent. Each environment needs it added by hand. Worth fixing separately; this PR only makes the absence visible.

## Testing

432 tests pass (2 new), pylint 10.00/10.