### PR TITLE
Take page count from the work median, not one English edition

### DIFF
--- a/app/services/book_search.py
+++ b/app/services/book_search.py
@@ -498,7 +498,12 @@ def _openlibrary_detail(isbn: str) -> Optional[dict]:
         'year': year,
         'genre': _genre(doc),
         'description': _work_description(doc.get('key')),
-        'page_count': edition.get('page_count') or doc.get('number_of_pages_median'),
+        # Median across editions, not the English edition's own count. Unlike
+        # the cover and title there is no language dimension here, and picking
+        # one edition is a lottery between abridgements and omnibuses: The
+        # Phoenix Project resolved to a 104-page edition of a 345-page book,
+        # Robinson Crusoe to a 93-page one. The median resists both.
+        'page_count': doc.get('number_of_pages_median') or edition.get('page_count'),
         'rating': round(rating, 2) if rating else None,
         'language': 'eng' if edition else _language(doc),
         'poster_url': _cover(edition.get('cover_i') or doc.get('cover_i')),

--- a/tests/unit/book_search_test.py
+++ b/tests/unit/book_search_test.py
@@ -299,6 +299,7 @@ def test_get_book_detail_maps_fields(mock_get, mock_desc):
     assert detail['year'] == 1965
     assert detail['genre'] == 'Science fiction, Deserts'
     assert detail['description'] == 'A desert planet.'
+    # The work-level median, not an arbitrary edition's own count.
     assert detail['page_count'] == 592
     assert detail['rating'] == 4.23
     assert detail['language'] == 'eng'


### PR DESCRIPTION
## Problem

#251 taught `_openlibrary_detail` to prefer an English edition for the cover and title, and swept `page_count` along with them. That was wrong: unlike the cover and the title, page count has no language dimension, so picking one edition is a lottery between abridgements and omnibuses.

Found while repointing two books by ISBN:

| | picked edition | work median | Google |
|---|---|---|---|
| The Phoenix Project | **104** | 345 | 348 |
| Robinson Crusoe | **93** | 274 | 607 |

The Phoenix Project is a ~345-page book. The 104-page figure also beat Google's correct 348 through `resolve_book_detail`'s merge, since Open Library wins wherever it has a value — so the merge propagated the wrong number rather than catching it.

## Fix

Prefer `number_of_pages_median`, which Open Library already publishes across the whole work and which resists both abridgements and omnibuses. The English edition's own count stays as the fallback for works that have no median.

Verified against live data after the change:

```
Robinson Crusoe      1686 | 274pp
The Phoenix Project  2013 | 345pp
How to Win Friends   1936 | 276pp
```

## Scope

Cover and title still come from the English edition — that part of #251 is correct and unchanged.

## Testing

432 tests pass, pylint 10.00/10.

## Note

Both affected rows were already corrected by hand in prod and QA, so this is about the next book to be enriched rather than a repair. It missed the v2.7.0 cut.