### PR TITLE
Add ability to favorite TV episodes

### DIFF
--- a/alembic/versions/c1e6a92f7b48_episode_favorited.py
+++ b/alembic/versions/c1e6a92f7b48_episode_favorited.py
@@ -1,0 +1,42 @@
+"""episode favorited
+
+Favorite an episode independent of watched status (#262): a standout episode
+flag, separate from the watch mark. Mirrors watched/watched_at.
+
+Revision ID: c1e6a92f7b48
+Revises: b4c8d21e9f57
+Create Date: 2026-08-02 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'c1e6a92f7b48'
+down_revision: Union[str, Sequence[str], None] = 'b4c8d21e9f57'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('user_tv_episodes', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                'favorited',
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+        batch_op.add_column(sa.Column('favorited_at', sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('user_tv_episodes', schema=None) as batch_op:
+        batch_op.drop_column('favorited_at')
+        batch_op.drop_column('favorited')

--- a/app/db/models_sandbox.py
+++ b/app/db/models_sandbox.py
@@ -251,6 +251,9 @@ class DbUserTVEpisode(DBBaseModel):
     # When the episode was actually watched (#160): stamped on mark, restored
     # from orion's g_first for pre-cutover history. Activity orders by this.
     watched_at = Column(DateTime, nullable=True)
+    # Independent of watched (#262): a standout episode, not a watch mark.
+    favorited = Column(Boolean, nullable=False, default=False)
+    favorited_at = Column(DateTime, nullable=True)
 
     episode = relationship('DbTVEpisode', back_populates='user_episodes')
     user = relationship('DbUser', backref='user_tv_episodes')

--- a/app/router/v1/router_tv.py
+++ b/app/router/v1/router_tv.py
@@ -865,6 +865,85 @@ def unmark_episode_watched(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail='Episode not marked'
         )
-    db.delete(tracker)
+    # A favorited episode keeps its row (and the favorite) even once
+    # unwatched (#262) — only drop the row entirely once nothing's left on it.
+    if tracker.favorited:
+        tracker.watched = 0
+        tracker.watched_at = None
+        db.commit()
+    else:
+        db.delete(tracker)
+        db.commit()
+    return None
+
+
+@router.post(
+    '/users/me/episodes/{episode_id}/favorite',
+    response_model=UserTVEpisodeResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def mark_episode_favorited(
+    episode_id: str,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """Favorite an episode, independent of watched status (idempotent)."""
+    user_pk = current_user[0].pk
+    episode = _get_episode(db, episode_id)
+
+    tracker = (
+        db.query(DbUserTVEpisode)
+        .filter(
+            DbUserTVEpisode.user_id == user_pk,
+            DbUserTVEpisode.episode_id == episode.pk,
+        )
+        .first()
+    )
+    if tracker is None:
+        tracker = DbUserTVEpisode(
+            user_id=user_pk,
+            episode_id=episode.pk,
+            favorited=True,
+            favorited_at=utc_now(),
+        )
+        db.add(tracker)
+    else:
+        tracker.favorited = True
+        if tracker.favorited_at is None:
+            tracker.favorited_at = utc_now()
     db.commit()
+    db.refresh(tracker)
+    return tracker
+
+
+@router.delete(
+    '/users/me/episodes/{episode_id}/favorite', status_code=status.HTTP_204_NO_CONTENT
+)
+def unmark_episode_favorited(
+    episode_id: str,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    user_pk = current_user[0].pk
+    episode = _get_episode(db, episode_id)
+    tracker = (
+        db.query(DbUserTVEpisode)
+        .filter(
+            DbUserTVEpisode.user_id == user_pk,
+            DbUserTVEpisode.episode_id == episode.pk,
+        )
+        .first()
+    )
+    if not tracker or not tracker.favorited:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail='Episode not favorited'
+        )
+    # Mirror unmark_episode_watched: only drop the row once nothing's left on it.
+    if tracker.watched:
+        tracker.favorited = False
+        tracker.favorited_at = None
+        db.commit()
+    else:
+        db.delete(tracker)
+        db.commit()
     return None

--- a/app/schemas/schemas_sandbox.py
+++ b/app/schemas/schemas_sandbox.py
@@ -385,6 +385,8 @@ class TVEpisodeResponse(TVEpisodeBase):
 class UserTVEpisodeBase(BaseModel):
     watched: Optional[int] = 0
     watched_at: Optional[datetime] = None
+    favorited: Optional[bool] = False
+    favorited_at: Optional[datetime] = None
 
 
 class UserTVEpisodeResponse(UserTVEpisodeBase):

--- a/tests/integration/router_episode_favorite_test.py
+++ b/tests/integration/router_episode_favorite_test.py
@@ -1,0 +1,108 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+from fastapi.testclient import TestClient
+
+
+def _auth(test_client: TestClient) -> dict:
+    return {'Authorization': f'Bearer {test_client.first_user.token}'}
+
+
+def _show_with_episode(test_client: TestClient):
+    admin = {'Authorization': f'Bearer {test_client.admin_user.token}'}
+    show_id = test_client.post(
+        '/v1/tv-shows',
+        headers=admin,
+        json={'title': 'Rick and Morty', 'imdb': 'tt2861424'},
+    ).json()['id']
+    episode_id = test_client.post(
+        f'/v1/tv-shows/{show_id}/episodes',
+        headers=admin,
+        json={'title': 'Mortgully', 'season': 9, 'season_number': 6},
+    ).json()['id']
+    return show_id, episode_id
+
+
+def _get_mark(test_client: TestClient, show_id: str, episode_id: str) -> dict | None:
+    marks = test_client.get(
+        f'/v1/users/me/tv-shows/{show_id}/episodes', headers=_auth(test_client)
+    ).json()
+    return next((m for m in marks if m['episode']['id'] == episode_id), None)
+
+
+def test_favoriting_stamps_favorited_at(test_client: TestClient):
+    _, episode_id = _show_with_episode(test_client)
+    body = test_client.post(
+        f'/v1/users/me/episodes/{episode_id}/favorite', headers=_auth(test_client)
+    ).json()
+    assert body['favorited'] is True
+    assert body['favorited_at'] is not None
+
+
+def test_refavoriting_preserves_original_favorited_at(test_client: TestClient):
+    _, episode_id = _show_with_episode(test_client)
+    first = test_client.post(
+        f'/v1/users/me/episodes/{episode_id}/favorite', headers=_auth(test_client)
+    ).json()['favorited_at']
+    second = test_client.post(
+        f'/v1/users/me/episodes/{episode_id}/favorite', headers=_auth(test_client)
+    ).json()['favorited_at']
+    assert second == first
+
+
+def test_favorite_does_not_mark_watched(test_client: TestClient):
+    _, episode_id = _show_with_episode(test_client)
+    body = test_client.post(
+        f'/v1/users/me/episodes/{episode_id}/favorite', headers=_auth(test_client)
+    ).json()
+    assert not body['watched']
+
+
+def test_unwatching_a_favorited_episode_keeps_the_favorite(test_client: TestClient):
+    show_id, episode_id = _show_with_episode(test_client)
+    test_client.post(f'/v1/users/me/episodes/{episode_id}', headers=_auth(test_client))
+    test_client.post(
+        f'/v1/users/me/episodes/{episode_id}/favorite', headers=_auth(test_client)
+    )
+    resp = test_client.delete(
+        f'/v1/users/me/episodes/{episode_id}', headers=_auth(test_client)
+    )
+    assert resp.status_code == 204
+    mark = _get_mark(test_client, show_id, episode_id)
+    assert mark is not None
+    assert mark['favorited'] is True
+    assert not mark['watched']
+
+
+def test_unfavoriting_a_watched_episode_keeps_watched(test_client: TestClient):
+    show_id, episode_id = _show_with_episode(test_client)
+    test_client.post(f'/v1/users/me/episodes/{episode_id}', headers=_auth(test_client))
+    test_client.post(
+        f'/v1/users/me/episodes/{episode_id}/favorite', headers=_auth(test_client)
+    )
+    resp = test_client.delete(
+        f'/v1/users/me/episodes/{episode_id}/favorite', headers=_auth(test_client)
+    )
+    assert resp.status_code == 204
+    mark = _get_mark(test_client, show_id, episode_id)
+    assert mark is not None
+    assert mark['watched'] == 1
+    assert mark['favorited'] is False
+
+
+def test_unfavoriting_the_only_mark_drops_the_row(test_client: TestClient):
+    show_id, episode_id = _show_with_episode(test_client)
+    test_client.post(
+        f'/v1/users/me/episodes/{episode_id}/favorite', headers=_auth(test_client)
+    )
+    resp = test_client.delete(
+        f'/v1/users/me/episodes/{episode_id}/favorite', headers=_auth(test_client)
+    )
+    assert resp.status_code == 204
+    assert _get_mark(test_client, show_id, episode_id) is None
+
+
+def test_unfavoriting_when_not_favorited_returns_404(test_client: TestClient):
+    _, episode_id = _show_with_episode(test_client)
+    resp = test_client.delete(
+        f'/v1/users/me/episodes/{episode_id}/favorite', headers=_auth(test_client)
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- Adds `favorited`/`favorited_at` to `DbUserTVEpisode`, independent of watched status
- New endpoints: `POST`/`DELETE /v1/users/me/episodes/{id}/favorite` (idempotent, same pattern as the existing watch endpoints)
- `unmark_episode_watched` now preserves the tracker row when the episode is favorited (only unwatches it), and the new unfavorite endpoint mirrors that for watched rows — a row is only dropped once nothing's left on it

Closes #262. Cross-reference: druthers-web PR (episode list star toggle).

## Test plan
- [x] 7 new integration tests covering idempotency, independence from watched status, and row-cleanup edge cases
- [x] Full suite: 439 passed, no regressions
- [x] Verified locally end-to-end against real TVMaze data (Rick and Morty, added via search + episode sync) — favorited S9E7 "Mortgully: The Last Rickforest" via the API and confirmed it renders correctly in the web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5XeUgZ2SfbrPoL2VJSy3P