### PR TITLE
Validate the resolved DB host, not POSTGRES_HOST, before seeding

### DIFF
--- a/app/migration/README.md
+++ b/app/migration/README.md
@@ -68,8 +68,9 @@ land on, rank order, completion dates — not the content itself.
   since once a title is real there's no such thing as a "fake" catalog row
   to clean up — see `DbUserMovie.is_seed_data`'s docstring.
 - **Refuses to run against anything but the local dev Postgres** (checks
-  `ENV`/`POSTGRES_HOST`) — this script performs bulk writes and must never
-  be able to reach QA or prod.
+  `ENV` and the *resolved* connection host — `DATABASE_URL` when set, not
+  just `POSTGRES_HOST`, see #257) — this script performs bulk writes and
+  must never be able to reach QA or prod.
 - Re-runnable: each run wipes the tracker rows it previously created for the
   target user, then reseeds. `--wipe` clears them without reseeding.
   `--count N` controls movie volume (default 270); TV/books/games scale off

--- a/app/migration/seed_dev.py
+++ b/app/migration/seed_dev.py
@@ -19,8 +19,10 @@ testing). Only the *tracker* rows this script creates are marked
 real either way and a wipe leaves them alone.
 
 **Refuses to run against anything but the local dev Postgres** (checks
-``ENV``/``POSTGRES_HOST``) -- same guard the old Faker-based seeder used,
-since this script performs bulk writes and must never reach QA or prod.
+``ENV`` and the *resolved* connection host, i.e. ``DATABASE_URL`` when set,
+not just ``POSTGRES_HOST`` -- see #257) -- same guard the old Faker-based
+seeder used, since this script performs bulk writes and must never reach
+QA or prod.
 
 Usage::
 
@@ -39,6 +41,7 @@ import random
 import sys
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from sqlalchemy.orm import Session
 
@@ -82,15 +85,21 @@ _LEGACY_FAKE_ID_BASE = 900_000
 def _assert_local_dev() -> None:
     """Refuse to run against anything but the local dev Postgres."""
     settings = get_settings()
-    host = (settings.postgres_host or '').lower()
-    is_safe_host = host in ('localhost', '127.0.0.1') or host.endswith('_dev')
+    # Validate the host actually being connected to (settings.sqlalchemy_database_url
+    # prefers DATABASE_URL over the discrete POSTGRES_* parts), not a variable that
+    # may not be in play (#257).
+    url = settings.sqlalchemy_database_url
+    host = (urlsplit(url).hostname or '').lower()
+    is_safe_host = (
+        host in ('localhost', '127.0.0.1') or host.endswith('_dev')
+    ) and 'neon.tech' not in host
     if settings.env != 'dev' or not is_safe_host:
         logger.error(
-            'seed_dev refuses to run: ENV=%s POSTGRES_HOST=%s does not look '
+            'seed_dev refuses to run: ENV=%s resolved host=%s does not look '
             'like the local dev Postgres. This script performs bulk writes '
             'and must never touch QA or prod.',
             settings.env,
-            settings.postgres_host,
+            host,
         )
         sys.exit(2)
 

--- a/tests/unit/seed_dev_test.py
+++ b/tests/unit/seed_dev_test.py
@@ -1,4 +1,7 @@
 # pylint: disable=missing-module-docstring, missing-function-docstring, protected-access
+import pytest
+
+from app.config import Settings
 from app.db.models_sandbox import DbMovie, DbTVShow, DbUserMovie, DbUserTVShow
 from app.migration import seed_dev
 
@@ -208,3 +211,45 @@ def test_run_seed_wipe_only_does_not_reseed(test_client, monkeypatch):
     assert (
         session.query(DbUserMovie).filter(DbUserMovie.user_id == user.pk).count() == 0
     )
+
+
+def test_assert_local_dev_refuses_when_database_url_overrides_safe_postgres_host(
+    monkeypatch,
+):
+    # #257: POSTGRES_HOST=localhost looked safe, but sqlalchemy_database_url
+    # prefers DATABASE_URL whenever it is set -- the guard must validate the
+    # host actually being connected to, not a variable that may not be in play.
+    settings = Settings(
+        env='dev',
+        postgres_host='localhost',
+        database_url='postgresql://user:pw@ep-prod-db.us-east-2.aws.neon.tech/druthers',
+    )
+    monkeypatch.setattr(seed_dev, 'get_settings', lambda: settings)
+
+    with pytest.raises(SystemExit):
+        seed_dev._assert_local_dev()
+
+
+def test_assert_local_dev_allows_local_postgres_host_with_no_database_url(monkeypatch):
+    settings = Settings(env='dev', postgres_host='localhost', database_url=None)
+    monkeypatch.setattr(seed_dev, 'get_settings', lambda: settings)
+
+    seed_dev._assert_local_dev()  # does not raise
+
+
+def test_assert_local_dev_allows_dev_suffixed_docker_host_via_database_url(monkeypatch):
+    settings = Settings(
+        env='dev',
+        database_url='postgresql://user:pw@m3_druthers_db_dev:5432/druthers',
+    )
+    monkeypatch.setattr(seed_dev, 'get_settings', lambda: settings)
+
+    seed_dev._assert_local_dev()  # does not raise
+
+
+def test_assert_local_dev_refuses_non_dev_env_even_with_safe_host(monkeypatch):
+    settings = Settings(env='prod', postgres_host='localhost')
+    monkeypatch.setattr(seed_dev, 'get_settings', lambda: settings)
+
+    with pytest.raises(SystemExit):
+        seed_dev._assert_local_dev()


### PR DESCRIPTION
## Summary
- `seed_dev._assert_local_dev()` checked `POSTGRES_HOST`, but the actual connection comes from `settings.sqlalchemy_database_url`, which prefers `DATABASE_URL` when set — so `ENV=dev POSTGRES_HOST=localhost DATABASE_URL=<prod>` passed the guard while writing to prod.
- Validates the *resolved* connection's hostname instead, and hard-blocks any `neon.tech` host outright.

## Test plan
- [x] 4 new unit tests: DATABASE_URL-overrides-safe-host (refuses), plain localhost (allows), `*_dev` Docker hostname via DATABASE_URL (allows), non-dev ENV with an otherwise-safe host (refuses)
- [x] Reproduced the exact bug scenario against the local dev container (`ENV=dev POSTGRES_HOST=localhost DATABASE_URL=<neon-lookalike>`) — confirmed old code would pass, new code exits 2 and refuses
- [x] Confirmed normal `task seed:dev` still runs and writes rows with the fixed guard
- [x] Full unit suite (195) passes

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5XeUgZ2SfbrPoL2VJSy3P