### PR TITLE
Bake GIT_SHA into deploy images and ship env templates

### DIFF
--- a/.github/workflows/deploy_cloud_run.yaml
+++ b/.github/workflows/deploy_cloud_run.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Build and push image
         run: |
           gcloud auth configure-docker ${{ vars.GCP_REGION }}-docker.pkg.dev --quiet
-          docker build -t "$IMAGE" .
+          docker build --build-arg GIT_SHA="${{ github.sha }}" -t "$IMAGE" .
           docker push "$IMAGE"
 
       - name: Run database migrations

--- a/.github/workflows/deploy_qa.yaml
+++ b/.github/workflows/deploy_qa.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Build and push image
         run: |
           gcloud auth configure-docker ${{ vars.GCP_REGION }}-docker.pkg.dev --quiet
-          docker build -t "$IMAGE" .
+          docker build --build-arg GIT_SHA="${{ github.sha }}" -t "$IMAGE" .
           docker push "$IMAGE"
 
       - name: Run database migrations

--- a/.gitignore
+++ b/.gitignore
@@ -127,7 +127,10 @@ celerybeat.pid
 env/*
 !env/*.env.template
 venv/
-ENV/
+# ENV/ removed (#256): on macOS's case-insensitive filesystem it also matched
+# env/, re-ignoring the whole directory and silencing the !env/*.env.template
+# negation above -- so no env template ever made it into the repo. .venv/ and
+# venv/ above already cover Python virtualenvs; nothing here used an ENV/ dir.
 env.bak/
 venv.bak/
 

--- a/env/dev.env.template
+++ b/env/dev.env.template
@@ -1,0 +1,57 @@
+# Copy to env/dev.env and fill in real values. env/dev.env is gitignored.
+# Landing zone (m3 = local Mac, gs = homelab server) and environment.
+LZ=m3
+ENV=dev
+LOG_LEVEL=INFO
+
+# Auth: REQUIRED in dev/prod. Generate with: openssl rand -hex 32
+JWT_SECRET_KEY=
+
+# Session lifetimes (#246). The access token stays short because the refresh
+# token renews it silently; drop ACCESS_TOKEN_EXPIRE_MINUTES to 2 if you want
+# to actually watch a refresh happen locally.
+ACCESS_TOKEN_EXPIRE_MINUTES=720
+REFRESH_TOKEN_EXPIRE_DAYS=30
+# Window in which re-presenting a just-rotated token counts as two requests
+# racing rather than a replay. Raise only if you see spurious sign-outs.
+REFRESH_TOKEN_REUSE_LEEWAY_SECONDS=30
+
+# Seed admin user (created on startup if absent)
+ADMIN_DISPLAY_NAME=Adam
+ADMIN_EMAIL=you@example.com
+ADMIN_PASSWORD=change-me
+
+# Database (PostgreSQL). POSTGRES_HOST is the compose service name.
+COMPOSE_PROJECT_NAME=druthers_dev
+POSTGRES_USER=druthers_dev
+POSTGRES_PASSWORD=change-me
+POSTGRES_HOST=m3_druthers_db_dev
+POSTGRES_DB=druthers
+POSTGRES_EXPOSED_PORT=5430
+POSTGRES_PORT=5432
+POSTGRES_CONNECTION_PORT=5432
+
+# Observability
+LOKI_URL=http://loki:3100
+
+# Google Sign-In (non-prod OAuth client, localhost:3000 authorized — see
+# google-oauth-clients-aleonard memory). Must match NEXT_PUBLIC_GOOGLE_CLIENT_ID
+# in druthers-web/env/dev.env.
+GOOGLE_CLIENT_ID=
+
+# External APIs (movies/TV/games search proxy — optional, search/enrich
+# return empty/503 without these, not a bug)
+TMDB_API_KEY=
+TWITCH_CLIENT_ID=
+TWITCH_CLIENT_SECRET=
+
+# Book enrichment fallback. Open Library is the primary book source and needs
+# no key; this only covers rows it cannot resolve by ISBN but which carry a
+# legacy googleid. Books API key from the GCP project holding the OAuth
+# clients above. Enrichment skips those rows when unset.
+GOOGLE_BOOKS_API_KEY=
+
+# Optional: additional OAuth client ids accepted at sign-in, comma-separated.
+# Native clients need their own client id (an iOS client is keyed to the bundle
+# id and cannot share the web one). Leave unset for web-only deployments.
+GOOGLE_ADDITIONAL_CLIENT_IDS=

--- a/env/prod.env.template
+++ b/env/prod.env.template
@@ -1,0 +1,29 @@
+# Copy to env/prod.env and fill in real values. env/prod.env is gitignored.
+# NOTE: variable names below match what the app actually reads (app/config.py).
+# The legacy env/prod.env used API_ENV / POSTGRES_URL / POSTGRES_DATABASE, which
+# the application does NOT read — use these names instead.
+LZ=gs
+ENV=prod
+LOG_LEVEL=INFO
+
+# Auth: REQUIRED. Generate with: openssl rand -hex 32
+JWT_SECRET_KEY=
+
+# Seed admin user
+ADMIN_DISPLAY_NAME=Adam
+ADMIN_EMAIL=you@example.com
+ADMIN_PASSWORD=change-me
+
+# Database (PostgreSQL). Either set DATABASE_URL directly, or the parts below.
+# DATABASE_URL=postgresql://user:pass@host:5432/druthers
+POSTGRES_USER=druthers
+POSTGRES_PASSWORD=change-me
+POSTGRES_HOST=gs_druthers_db_prod
+POSTGRES_DB=druthers
+POSTGRES_CONNECTION_PORT=5432
+
+# Observability
+LOKI_URL=http://loki:3100
+
+# External APIs (movies search proxy)
+TMDB_API_KEY=


### PR DESCRIPTION
## Summary
- **#255**: `deploy_cloud_run.yaml`/`deploy_qa.yaml` built without `--build-arg GIT_SHA`, so `/health` permanently reported `git_sha: "unknown"` in prod/QA — the one mechanism for checking a running container against the working tree didn't work in either environment.
- **#256**: `.gitignore`'s `ENV/` rule matches `env/` on macOS's case-insensitive filesystem, re-ignoring the whole directory and silencing the `!env/*.env.template` negation above it — so no env template ever shipped with the repo. Removed the redundant rule (`.venv/`/`venv/` already cover virtualenvs) and committed `env/dev.env.template` + `env/prod.env.template`.

## Test plan
- [x] Locally built the image with `--build-arg GIT_SHA=<test-sha>` and confirmed it lands in the container env
- [x] Confirmed `env/dev.env.template`/`env/prod.env.template` are now trackable while the real `env/dev.env`, `env/prod.env`, `env/local.env` (secrets) remain ignored — verified with `git check-ignore -v`
- [x] Templates contain only placeholders (`change-me`, empty), no real secrets
- [x] Full unit suite (195) passes

Closes #255, closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5XeUgZ2SfbrPoL2VJSy3P