### PR TITLE
Rank book search hits by canonical-edition signals

### DIFF
--- a/app/services/book_search.py
+++ b/app/services/book_search.py
@@ -43,7 +43,8 @@ class UpstreamUnavailable(Exception):
 
 _SEARCH_FIELDS = (
     'key,title,author_name,first_publish_year,isbn,cover_i,'
-    'number_of_pages_median,subject,ratings_average,language'
+    'number_of_pages_median,subject,ratings_average,ratings_count,'
+    'readinglog_count,language'
 )
 
 # ISBN-10 (last check digit may be 'X') or ISBN-13, after stripping any
@@ -342,6 +343,26 @@ def _search_by_isbn(isbn: str) -> List[dict]:
     ]
 
 
+def _canonical_score(doc: dict) -> tuple:
+    """
+    How much a search hit looks like the edition a person means, highest
+    first (#260). ``search_books`` sorts on this so a movie tie-in or a
+    work-level hit missing the basics (no cover, no page count, no year)
+    doesn't outrank the book someone actually searched for. Not a format
+    preference -- ``physical_format`` is missing on most editions and
+    wouldn't have caught the cases this was written for.
+    """
+    title = doc.get('title') or ''
+    return (
+        doc.get('cover_i') is not None,
+        doc.get('number_of_pages_median') is not None,
+        doc.get('first_publish_year') is not None,
+        not _EDITION_SUFFIX_RE.search(title),
+        doc.get('readinglog_count') or 0,
+        doc.get('ratings_count') or 0,
+    )
+
+
 def search_books(query: str) -> List[dict]:
     """
     Search Open Library for books matching ``query``.
@@ -388,8 +409,9 @@ def search_books(query: str) -> List[dict]:
             detail='Upstream book search failed',
         ) from exc
 
+    docs = sorted(payload.get('docs') or [], key=_canonical_score, reverse=True)
     results = []
-    for doc in payload.get('docs') or []:
+    for doc in docs:
         year = doc.get('first_publish_year')
         results.append(
             {

--- a/tests/unit/book_search_test.py
+++ b/tests/unit/book_search_test.py
@@ -229,6 +229,74 @@ def test_search_books_restricts_to_english(mock_get):
     assert mock_get.call_args.kwargs['params']['language'] == 'eng'
 
 
+def test_canonical_score_prefers_a_complete_non_edition_hit():
+    # #260: 'The Scorch Trials' -> a movie tie-in hit must not outrank the
+    # novel's own hit just because Open Library returned it first.
+    novel = {
+        'title': 'The Scorch Trials',
+        'cover_i': 1,
+        'number_of_pages_median': 360,
+        'first_publish_year': 2010,
+        'readinglog_count': 5000,
+        'ratings_count': 4000,
+    }
+    movie_tie_in = {
+        'title': 'The Scorch Trials Movie Tie-in Edition',
+        'cover_i': 2,
+        'number_of_pages_median': 360,
+        'first_publish_year': 2015,
+        'readinglog_count': 50,
+        'ratings_count': 10,
+    }
+    assert book_search._canonical_score(novel) > book_search._canonical_score(
+        movie_tie_in
+    )
+
+
+def test_canonical_score_prefers_hits_with_more_metadata():
+    complete = {'cover_i': 1, 'number_of_pages_median': 300, 'first_publish_year': 2000}
+    sparse = {'title': 'Some Obscure Printing'}
+    assert book_search._canonical_score(complete) > book_search._canonical_score(sparse)
+
+
+def test_canonical_score_breaks_ties_on_popularity():
+    popular = {'readinglog_count': 5000, 'ratings_count': 4000}
+    obscure = {'readinglog_count': 10, 'ratings_count': 5}
+    assert book_search._canonical_score(popular) > book_search._canonical_score(obscure)
+
+
+@patch('app.services.book_search.requests.get')
+def test_search_books_reorders_a_movie_tie_in_below_the_novel(mock_get):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    # Open Library hands the movie tie-in back first; search_books must not
+    # just pass that order through.
+    resp.json.return_value = {
+        'docs': [
+            {
+                'title': 'The Scorch Trials Movie Tie-in Edition',
+                'isbn': ['9780553538410'],
+                'readinglog_count': 50,
+                'ratings_count': 10,
+            },
+            {
+                'title': 'The Scorch Trials',
+                'isbn': ['9780062287642'],
+                'cover_i': 1,
+                'number_of_pages_median': 360,
+                'first_publish_year': 2010,
+                'readinglog_count': 5000,
+                'ratings_count': 4000,
+            },
+        ]
+    }
+    mock_get.return_value = resp
+
+    results = book_search.search_books('The Scorch Trials')
+
+    assert [r['isbn'] for r in results] == ['9780062287642', '9780553538410']
+
+
 def test_language_never_guesses_a_translation():
     # A work listing many editions must not assert one of them at random:
     # element 0 tagged The Stand 'rus' and The Da Vinci Code 'mal'.


### PR DESCRIPTION
## Summary
`search_books` returns work-level hits and passed them straight through in whatever order Open Library returned them:
```
search 'Measure What Matters' -> 9780525536222   (canonical)
search 'The Scorch Trials'    -> 9780553538410   (movie tie-in, not the novel's own ISBN)
```
Whichever hit search handed over became the row's identity, cover, page count, and rating on add.

Sorts hits by how much they look like the edition a person means: has a cover, a page count, and a first-publish year; title carries no edition qualifier (`_EDITION_SUFFIX_RE`, already added in #251); higher `readinglog_count`/`ratings_count` (newly requested from Open Library's `search.json`). Deliberately **not** a format preference — `physical_format` is missing on 69–100% of English editions across sampled works and wouldn't have caught the cases this was written for.

Out of scope (per the issue): an edition picker/change-edition UI, and the arbitrary ISBN-within-a-single-hit's-isbn-list selection (`_pick_isbn`) — the ten prior hand-fixes were legacy import artifacts, not from a user picking a search result, so the ceiling on this particular fix is a hit-ordering improvement, not a full resolution.

## Test plan
- [x] 4 new unit tests: movie tie-in ranks below the novel, complete hits outrank sparse ones, popularity breaks ties, `search_books` actually reorders when Open Library hands back the tie-in first
- [x] Live-verified against real Open Library: "Measure What Matters" still returns the canonical John Doerr edition first; "The Scorch Trials" now ranks the novel's own hit above "The Maze Runner and The Scorch Trials" bundle and other noise
- [x] Full unit suite (195) passes

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5XeUgZ2SfbrPoL2VJSy3P