### PR TITLE
Add opt-in watchlist visibility to the public profile

### DIFF
--- a/alembic/versions/5361d31e8e2b_watchlist_visibility_flags.py
+++ b/alembic/versions/5361d31e8e2b_watchlist_visibility_flags.py
@@ -1,0 +1,47 @@
+"""watchlist visibility flags
+
+Opt-in per-category watchlist visibility (#236), independent of the
+existing public_* ranked-list flags. NULL flags read as private.
+
+Revision ID: 5361d31e8e2b
+Revises: df0fd3ee8b03
+Create Date: 2026-08-02 21:51:38.290968
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '5361d31e8e2b'
+down_revision: Union[str, Sequence[str], None] = 'df0fd3ee8b03'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column('public_watchlist_movies', sa.Boolean(), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column('public_watchlist_tv', sa.Boolean(), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column('public_watchlist_books', sa.Boolean(), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column('public_watchlist_games', sa.Boolean(), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.drop_column('public_watchlist_games')
+        batch_op.drop_column('public_watchlist_books')
+        batch_op.drop_column('public_watchlist_tv')
+        batch_op.drop_column('public_watchlist_movies')

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -49,6 +49,14 @@ class DbUser(DBBaseModel):
     public_books = Column(Boolean, nullable=True, default=False)
     public_games = Column(Boolean, nullable=True, default=False)
 
+    # Opt-in watchlist visibility (#236): independent of the ranked-list
+    # flags above. The public endpoint only serves a category's watchlist
+    # when both this flag AND the matching public_* flag are set.
+    public_watchlist_movies = Column(Boolean, nullable=True, default=False)
+    public_watchlist_tv = Column(Boolean, nullable=True, default=False)
+    public_watchlist_books = Column(Boolean, nullable=True, default=False)
+    public_watchlist_games = Column(Boolean, nullable=True, default=False)
+
 
 class DbApiKey(DBBaseModel):
     """

--- a/app/router/v1/router_visibility.py
+++ b/app/router/v1/router_visibility.py
@@ -87,12 +87,14 @@ def update_visibility(
         user.handle = handle
 
     for shelf in SHELVES:
-        flag = shelf.visibility_flag
-        if flag in data and data[flag] is not None:
-            setattr(user, flag, bool(data[flag]))
+        for flag in (shelf.visibility_flag, shelf.watchlist_visibility_flag):
+            if flag in data and data[flag] is not None:
+                setattr(user, flag, bool(data[flag]))
 
     if not user.handle and any(
-        getattr(user, shelf.visibility_flag) for shelf in SHELVES
+        getattr(user, shelf.visibility_flag)
+        or getattr(user, shelf.watchlist_visibility_flag)
+        for shelf in SHELVES
     ):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
@@ -148,21 +150,52 @@ def public_profile(handle: str, db: Session = Depends(get_db)):
             .limit(PROFILE_SHELF_LIMIT)
             .all()
         )
-        shelves.append(
-            {
-                'category': shelf.label,
-                'ranked_count': ranked_count,
-                'items': [
-                    {
-                        'rank': rank,
-                        'title': item.title,
-                        'year': item.year,
-                        'poster_url': item.poster_url,
-                    }
-                    for rank, item in rows
-                ],
-            }
-        )
+        shelf_out = {
+            'category': shelf.label,
+            # Stable URL segment for a per-shelf profile page (#93), distinct
+            # from the display label above.
+            'slug': shelf.category,
+            'ranked_count': ranked_count,
+            'items': [
+                {
+                    'rank': rank,
+                    'title': item.title,
+                    'year': item.year,
+                    'poster_url': item.poster_url,
+                }
+                for rank, item in rows
+            ],
+        }
+
+        # Watchlist visibility (#236) rides on top of the ranked-list opt-in
+        # above: a category's watchlist is only public when both flags are
+        # set, so there's no way to expose a watchlist without also having
+        # opted the ranked list in.
+        if getattr(user, shelf.watchlist_visibility_flag):
+            watchlist_rows = (
+                db.query(catalog_model)
+                .join(
+                    tracker_model,
+                    getattr(tracker_model, shelf.join_col) == catalog_model.pk,
+                )
+                .filter(
+                    tracker_model.user_id == user.pk,
+                    tracker_model.on_watchlist.is_(True),
+                )
+                .order_by(tracker_model.created_at.desc())
+                .limit(PROFILE_SHELF_LIMIT)
+                .all()
+            )
+            shelf_out['watchlist'] = [
+                {
+                    'title': item.title,
+                    'year': item.year,
+                    'poster_url': item.poster_url,
+                }
+                for item in watchlist_rows
+            ]
+
+        shelves.append(shelf_out)
 
     if not shelves:
         raise not_found

--- a/app/schemas/model_schemas.py
+++ b/app/schemas/model_schemas.py
@@ -138,6 +138,10 @@ class InVisibilityUpdate(BaseModel):
     public_tv: Optional[bool] = None
     public_books: Optional[bool] = None
     public_games: Optional[bool] = None
+    public_watchlist_movies: Optional[bool] = None
+    public_watchlist_tv: Optional[bool] = None
+    public_watchlist_books: Optional[bool] = None
+    public_watchlist_games: Optional[bool] = None
 
 
 class OutVisibility(BaseModel):
@@ -150,6 +154,10 @@ class OutVisibility(BaseModel):
     public_tv: Optional[bool] = False
     public_books: Optional[bool] = False
     public_games: Optional[bool] = False
+    public_watchlist_movies: Optional[bool] = False
+    public_watchlist_tv: Optional[bool] = False
+    public_watchlist_books: Optional[bool] = False
+    public_watchlist_games: Optional[bool] = False
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/app/services/shelves.py
+++ b/app/services/shelves.py
@@ -31,6 +31,9 @@ class Shelf(NamedTuple):
     label: str
     # Attribute on DbUser holding this shelf's public opt-in flag.
     visibility_flag: str
+    # Attribute on DbUser holding this shelf's opt-in *watchlist* visibility
+    # flag (#236) — only takes effect when visibility_flag is also set.
+    watchlist_visibility_flag: str
     tracker_model: Type
     catalog_model: Type
     # Tracker column joining to ``catalog_model.pk``.
@@ -38,13 +41,38 @@ class Shelf(NamedTuple):
 
 
 SHELVES: Tuple[Shelf, ...] = (
-    Shelf('movies', 'Movies', 'public_movies', DbUserMovie, DbMovie, 'movie_id'),
-    Shelf('tv', 'TV', 'public_tv', DbUserTVShow, DbTVShow, 'tv_show_id'),
-    Shelf('books', 'Books', 'public_books', DbUserBook, DbBook, 'book_id'),
+    Shelf(
+        'movies',
+        'Movies',
+        'public_movies',
+        'public_watchlist_movies',
+        DbUserMovie,
+        DbMovie,
+        'movie_id',
+    ),
+    Shelf(
+        'tv',
+        'TV',
+        'public_tv',
+        'public_watchlist_tv',
+        DbUserTVShow,
+        DbTVShow,
+        'tv_show_id',
+    ),
+    Shelf(
+        'books',
+        'Books',
+        'public_books',
+        'public_watchlist_books',
+        DbUserBook,
+        DbBook,
+        'book_id',
+    ),
     Shelf(
         'games',
         'Video Games',
         'public_games',
+        'public_watchlist_games',
         DbUserVideoGame,
         DbVideoGame,
         'game_id',

--- a/tests/integration/router_visibility_test.py
+++ b/tests/integration/router_visibility_test.py
@@ -23,13 +23,37 @@ def _rank_a_movie(test_client: TestClient, token: str, title='Heat', imdb='tt011
     )
 
 
+def _watchlist_a_movie(
+    test_client: TestClient, token: str, title='Sicario', imdb='tt3397884'
+):
+    admin = _auth(test_client.admin_user.token)
+    movie_id = test_client.post(
+        '/v1/movies', headers=admin, json={'title': title, 'imdb': imdb, 'year': 2015}
+    ).json()['id']
+    test_client.post(
+        f'/v1/users/me/movies/{movie_id}',
+        headers=_auth(token),
+        json={'on_watchlist': True, 'notes': 'private note!'},
+    )
+
+
 def test_defaults_are_fully_private(test_client: TestClient):
     body = test_client.get(
         '/v1/users/me/visibility', headers=_auth(test_client.first_user.token)
     ).json()
     assert body['handle'] is None
     assert not any(
-        body[f] for f in ('public_movies', 'public_tv', 'public_books', 'public_games')
+        body[f]
+        for f in (
+            'public_movies',
+            'public_tv',
+            'public_books',
+            'public_games',
+            'public_watchlist_movies',
+            'public_watchlist_tv',
+            'public_watchlist_books',
+            'public_watchlist_games',
+        )
     )
 
 
@@ -126,3 +150,48 @@ def test_toggling_a_category_off_removes_it(test_client: TestClient):
         '/v1/users/me/visibility', headers=_auth(token), json={'public_movies': False}
     )
     assert test_client.get('/v1/public/avery').status_code == 404
+
+
+def test_watchlist_flag_alone_exposes_nothing(test_client: TestClient):
+    # Watchlist visibility (#236) is independent of the ranked-list flag to
+    # set, but only takes effect once the ranked-list flag is also on.
+    token = test_client.first_user.token
+    _rank_a_movie(test_client, token)
+    _watchlist_a_movie(test_client, token)
+    test_client.put(
+        '/v1/users/me/visibility',
+        headers=_auth(token),
+        json={'handle': 'avery', 'public_watchlist_movies': True},
+    )
+
+    assert test_client.get('/v1/public/avery').status_code == 404
+
+
+def test_watchlist_shown_only_when_both_flags_set(test_client: TestClient):
+    token = test_client.first_user.token
+    _rank_a_movie(test_client, token)
+    _watchlist_a_movie(test_client, token)
+    test_client.put(
+        '/v1/users/me/visibility',
+        headers=_auth(token),
+        json={'handle': 'avery', 'public_movies': True},
+    )
+
+    # Ranked-list flag alone: no watchlist key at all.
+    shelf = test_client.get('/v1/public/avery').json()['shelves'][0]
+    assert 'watchlist' not in shelf
+
+    test_client.put(
+        '/v1/users/me/visibility',
+        headers=_auth(token),
+        json={'public_watchlist_movies': True},
+    )
+
+    shelf = test_client.get('/v1/public/avery').json()['shelves'][0]
+    assert shelf['watchlist'] == [
+        {'title': 'Sicario', 'year': 2015, 'poster_url': None}
+    ]
+    # Redacted the same way ranked items are: no notes, no watch state.
+    flat = str(shelf['watchlist'])
+    assert 'private note!' not in flat
+    assert 'on_watchlist' not in flat


### PR DESCRIPTION
## Summary
- Adds independent, opt-in `public_watchlist_movies/tv/books/games` flags alongside the existing `public_movies/tv/books/games` ranked-list flags — default private, extended via `GET/PUT /v1/users/me/visibility`.
- `GET /v1/public/{handle}` now includes a shelf's watchlist only when **both** its ranked-list flag and its watchlist flag are set, capped at `PROFILE_SHELF_LIMIT` (25) and redacted the same way ranked items already are (title/year/poster only — no notes, no watch state).
- Adds a `slug` field per shelf in the public profile response, giving druthers-web#93 a stable URL segment distinct from the display label.

Closes #236.

## Test plan
- [x] `pytest tests/` — 458 passed, including 2 new tests covering the watchlist gating (`test_watchlist_flag_alone_exposes_nothing`, `test_watchlist_shown_only_when_both_flags_set`)
- [x] Manually verified `PUT`/`GET` visibility and `GET /v1/public/{handle}` end-to-end against local dev Postgres
- [x] Demoed locally with druthers-web#93/#107 before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5XeUgZ2SfbrPoL2VJSy3P