### PR TITLE
Backfill IGDB time-to-beat for games (#234)

### DIFF
--- a/app/migration/backfill_time_to_beat.py
+++ b/app/migration/backfill_time_to_beat.py
@@ -1,0 +1,74 @@
+"""
+Backfill IGDB "time to beat" (main story, whole hours) for games missing
+it, keyed on the ``igdb`` id. Requires
+``TWITCH_CLIENT_ID``/``TWITCH_CLIENT_SECRET``. Throttled and **resumable**:
+it only processes games still missing a value, so re-running continues
+where it left off, including for games added since the last run.
+
+Usage::
+
+    TWITCH_CLIENT_ID=... TWITCH_CLIENT_SECRET=... \\
+    DATABASE_URL=... ENV=prod python -m app.migration.backfill_time_to_beat
+"""
+
+import time
+
+from app.db.database import SessionLocal
+from app.db.models_sandbox import DbVideoGame
+from app.services.game_search import get_time_to_beat
+
+# IGDB allows 4 requests/second; stay well under it.
+THROTTLE_SECONDS = 0.5
+# get_time_to_beat returns None both for genuine misses (no community data)
+# and rate limiting; a run of consecutive Nones almost certainly means
+# throttling or bad creds.
+STOP_AFTER_CONSECUTIVE_MISSES = 15
+
+
+def pending_games(db):
+    """Games with an IGDB id but no time-to-beat value yet."""
+    return (
+        db.query(DbVideoGame)
+        .filter(DbVideoGame.igdb.isnot(None), DbVideoGame.time_to_beat.is_(None))
+        .all()
+    )
+
+
+def run() -> None:
+    """Backfill time-to-beat for all games still missing it."""
+    db = SessionLocal()
+    try:
+        pending = pending_games(db)
+        total = len(pending)
+        print(f'{total} games to backfill')
+        filled = misses = consecutive = processed = 0
+        for game in pending:
+            processed += 1
+            hours = get_time_to_beat(game.igdb)
+            if hours is not None:
+                game.time_to_beat = hours
+                db.commit()
+                filled += 1
+                consecutive = 0
+            else:
+                misses += 1
+                consecutive += 1
+            if processed % 25 == 0:
+                print(f'  {processed}/{total} (filled {filled}, misses {misses})')
+            if consecutive >= STOP_AFTER_CONSECUTIVE_MISSES:
+                print(
+                    f'Stopping after {consecutive} consecutive misses '
+                    '(rate limit or missing Twitch creds). Re-run later to resume.'
+                )
+                break
+            time.sleep(THROTTLE_SECONDS)
+        print(
+            f'Done: filled {filled}, misses {misses}, '
+            f'remaining ~{total - processed}'
+        )
+    finally:
+        db.close()
+
+
+if __name__ == '__main__':
+    run()

--- a/app/services/game_search.py
+++ b/app/services/game_search.py
@@ -294,6 +294,32 @@ def get_game_detail(igdb_id: Optional[int]) -> Optional[dict]:
     return _detail_from_game(payload[0])
 
 
+def get_time_to_beat(igdb_id: Optional[int]) -> Optional[int]:
+    """
+    Fetch the "normally" (main story) completion time for a game by IGDB
+    id, in whole hours. IGDB reports this on a separate endpoint from game
+    detail, keyed by the same id, in seconds. Returns None when unavailable
+    (no community data, unconfigured, or upstream failure) so callers can
+    leave the column null rather than treating a miss as zero.
+    """
+    if not igdb_id:
+        return None
+    try:
+        payload = _igdb_query(
+            'game_time_to_beats',
+            f'fields normally; where game_id = {int(igdb_id)};',
+        )
+    except HTTPException:
+        return None
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning('IGDB time-to-beat failed for %s: %s', igdb_id, exc)
+        return None
+    if not payload:
+        return None
+    seconds = payload[0].get('normally')
+    return round(seconds / 3600) if seconds else None
+
+
 def list_popular_games(limit: int = 500) -> List[dict]:
     """
     The ``limit`` highest-rated-by-volume games, in full catalog-field shape

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -83,6 +83,11 @@ tasks:
     cmds:
       - python -m app.migration.enrich_games
 
+  backfill:time_to_beat:
+    desc: "Backfill IGDB time-to-beat for existing games (needs TWITCH_CLIENT_ID/SECRET)"
+    cmds:
+      - python -m app.migration.backfill_time_to_beat
+
   import:orion:
     desc: "Import legacy orion (MySQL) data into druthers. Usage: task import:orion -- --dry-run"
     cmds:

--- a/tests/unit/backfill_time_to_beat_test.py
+++ b/tests/unit/backfill_time_to_beat_test.py
@@ -1,0 +1,56 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+from unittest.mock import patch
+
+from app.db.models_sandbox import DbVideoGame
+from app.migration import backfill_time_to_beat
+
+
+def _game(session, igdb, time_to_beat=None):
+    game = DbVideoGame(title='A Game', igdb=igdb, time_to_beat=time_to_beat)
+    session.add(game)
+    session.commit()
+    return game
+
+
+def _run_capturing(session, capsys, get_time_to_beat_return):
+    with patch.object(
+        backfill_time_to_beat, 'SessionLocal', return_value=session
+    ), patch.object(
+        backfill_time_to_beat, 'get_time_to_beat', return_value=get_time_to_beat_return
+    ), patch.object(
+        backfill_time_to_beat.time, 'sleep'
+    ):
+        session.close = lambda: None  # run() closes its own session
+        backfill_time_to_beat.run()
+    return capsys.readouterr().out
+
+
+def test_pending_games_excludes_already_filled_and_igdb_less_rows(test_client):
+    session = test_client.test_db_session
+    _game(session, igdb=1, time_to_beat=None)
+    _game(session, igdb=2, time_to_beat=12)
+    _game(session, igdb=None, time_to_beat=None)
+
+    pending = backfill_time_to_beat.pending_games(session)
+
+    assert [g.igdb for g in pending] == [1]
+
+
+def test_run_fills_time_to_beat_when_igdb_has_data(test_client, capsys):
+    session = test_client.test_db_session
+    game = _game(session, igdb=1)
+
+    out = _run_capturing(session, capsys, get_time_to_beat_return=9)
+
+    assert game.time_to_beat == 9
+    assert 'filled 1, misses 0' in out
+
+
+def test_run_leaves_null_on_a_genuine_miss(test_client, capsys):
+    session = test_client.test_db_session
+    game = _game(session, igdb=1)
+
+    out = _run_capturing(session, capsys, get_time_to_beat_return=None)
+
+    assert game.time_to_beat is None
+    assert 'filled 0, misses 1' in out

--- a/tests/unit/game_search_test.py
+++ b/tests/unit/game_search_test.py
@@ -68,6 +68,16 @@ def test_get_game_detail_unconfigured_returns_none(mock_settings):
 
 
 @patch('app.services.game_search.get_settings')
+def test_get_time_to_beat_unconfigured_returns_none(mock_settings):
+    _reset_token_cache()
+    mock_settings.return_value = Settings(
+        twitch_client_id=None, twitch_client_secret=None, env='github'
+    )
+    assert game_search.get_time_to_beat(1234) is None
+    assert game_search.get_time_to_beat(None) is None
+
+
+@patch('app.services.game_search.get_settings')
 @patch('app.services.game_search.requests.post')
 def test_search_games_returns_results(mock_post, mock_settings):
     _reset_token_cache()
@@ -227,4 +237,44 @@ def test_get_game_detail_maps_fields_and_caches_token(mock_post, mock_settings):
     # Second call reuses the cached token (no extra OAuth POST).
     assert game_search.get_game_detail(9999) is None
     assert mock_post.call_count == 3  # 1 token + 2 queries
+    _reset_token_cache()
+
+
+@patch('app.services.game_search.get_settings')
+@patch('app.services.game_search.requests.post')
+def test_get_time_to_beat_converts_seconds_to_hours(mock_post, mock_settings):
+    _reset_token_cache()
+    mock_settings.return_value = Settings(
+        twitch_client_id='cid', twitch_client_secret='secret', env='github'
+    )
+    token_resp = MagicMock()
+    token_resp.raise_for_status.return_value = None
+    token_resp.json.return_value = {'access_token': 'tok', 'expires_in': 5000000}
+    ttb_resp = MagicMock()
+    ttb_resp.raise_for_status.return_value = None
+    ttb_resp.json.return_value = [{'game_id': 1234, 'normally': 61200}]  # 17h
+    mock_post.side_effect = [token_resp, ttb_resp]
+
+    assert game_search.get_time_to_beat(1234) == 17
+    query_call = mock_post.call_args_list[1]
+    assert 'where game_id = 1234' in query_call.kwargs['data']
+    _reset_token_cache()
+
+
+@patch('app.services.game_search.get_settings')
+@patch('app.services.game_search.requests.post')
+def test_get_time_to_beat_no_community_data_returns_none(mock_post, mock_settings):
+    _reset_token_cache()
+    mock_settings.return_value = Settings(
+        twitch_client_id='cid', twitch_client_secret='secret', env='github'
+    )
+    token_resp = MagicMock()
+    token_resp.raise_for_status.return_value = None
+    token_resp.json.return_value = {'access_token': 'tok', 'expires_in': 5000000}
+    ttb_resp = MagicMock()
+    ttb_resp.raise_for_status.return_value = None
+    ttb_resp.json.return_value = []
+    mock_post.side_effect = [token_resp, ttb_resp]
+
+    assert game_search.get_time_to_beat(1234) is None
     _reset_token_cache()


### PR DESCRIPTION
## Summary
- `video_games.time_to_beat` existed on the model and was already exposed through the API, but was 0% populated (0 of 42 games). Adds `get_time_to_beat()` — IGDB's `game_time_to_beats` endpoint (note: **plural**, unlike `game_time_to_beat` guessed in the issue — confirmed the real name against live IGDB), pulling the `normally` (main-story) completion time in whole hours.
- Adds `app/migration/backfill_time_to_beat.py`, a resumable/idempotent backfill following the `enrich_games.py` pattern: only processes games with an `igdb` id and null `time_to_beat`, throttled, stops after 15 consecutive misses (rate-limit guard). Wired up as `task backfill:time_to_beat`.
- Chose the `normally` metric over `hastily`/`completely` per product call — matches the filter's intent ("what can I finish in the time I have") and is the standard default on how-long-to-beat sites.

## Test plan
- [x] 464 tests pass (`task test`), Black/pylint clean
- [x] Verified against the local dev stack with real IGDB data: seeded 60 real games, ran the backfill — 57/60 filled, 3 genuine misses (no community data, e.g. StarCraft) correctly left `null` rather than `0`
- [x] Re-ran the backfill a second time — touched only the 3 remaining games, left the other 57 alone (idempotent)

Out of scope: the issue's AC also calls for a "max hours to beat" filter in `druthers-web` — that's explicitly scoped to the web repo per the issue notes, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5XeUgZ2SfbrPoL2VJSy3P