### PR TITLE
Notify a user when they receive a friend request (#282)

### DIFF
--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -13,7 +13,9 @@ from typing import List
 
 from sqlalchemy.orm import Session
 
+from app.db.db_friendship import list_with_other_party
 from app.db.models_sandbox import DbMovie, DbNotification, DbUserMovie
+from app.services.friendships import FriendshipStatus
 
 RELEASE_WINDOW_DAYS = 7
 
@@ -79,9 +81,104 @@ def sweep_movie_releases(db: Session, user_pk: int) -> int:
     return created
 
 
-def sweep_all(db: Session, user_pk: int) -> int:
-    """Run every generator for one user. Commits if anything was created."""
-    created = sweep_movie_releases(db, user_pk)
-    if created:
-        db.commit()
+def _raise_friend_notifications(db: Session, user_pk: int, spec: dict, rows) -> int:
+    """
+    Upsert one notification per (friendship, other-user) row, by dedupe_key.
+
+    ``spec`` carries ``type``, ``title``, and ``body_for(other_user)`` — a
+    dict rather than three parameters so the two call sites in
+    :func:`sweep_friend_requests` read as one shape apiece.
+    """
+    if not rows:
+        return 0
+    notif_type = spec['type']
+    keys = [f'{notif_type}:{friendship.id}' for friendship, _ in rows]
+    existing = _existing_keys(db, user_pk, keys)
+    created = 0
+    for friendship, other in rows:
+        key = f'{notif_type}:{friendship.id}'
+        if key in existing:
+            continue
+        db.add(
+            DbNotification(
+                user_id=user_pk,
+                type=notif_type,
+                title=spec['title'],
+                body=spec['body_for'](other),
+                category='friend_request',
+                entity_id=friendship.id,
+                dedupe_key=key,
+            )
+        )
+        created += 1
     return created
+
+
+def sweep_friend_requests(db: Session, user_pk: int) -> int:
+    """
+    Friend-request notifications (#282): an incoming request notifies the
+    recipient; acceptance notifies the original sender. Declining or
+    cancelling notifies nobody.
+
+    #275 deletes the friendship row outright on decline or cancel rather than
+    recording a terminal status — there is nothing to sweep a "declined"
+    event from. That also means a pending-request notification can outlive
+    the request it points at (declined/cancelled, or simply accepted by the
+    recipient themselves). Rather than let it deep-link into nothing, this
+    sweep deletes any pending notification whose friendship is no longer in
+    the live incoming set *before* raising anything new. Returns the number
+    of notifications created or removed, so the caller knows to commit.
+    """
+    incoming = list_with_other_party(
+        db, user_pk, FriendshipStatus.PENDING, requested_by_me=False
+    )
+    live_keys = {f'friend_request:{friendship.id}' for friendship, _ in incoming}
+
+    stale_filters = [
+        DbNotification.user_id == user_pk,
+        DbNotification.type == 'friend_request',
+    ]
+    if live_keys:
+        stale_filters.append(DbNotification.dedupe_key.notin_(live_keys))
+    removed = 0
+    for notification in db.query(DbNotification).filter(*stale_filters):
+        db.delete(notification)
+        removed += 1
+
+    def _name(user):
+        return user.display_name or user.handle or 'Someone'
+
+    created = _raise_friend_notifications(
+        db,
+        user_pk,
+        {
+            'type': 'friend_request',
+            'title': 'New friend request',
+            'body_for': lambda sender: f'{_name(sender)} wants to be friends.',
+        },
+        incoming,
+    )
+
+    accepted = list_with_other_party(
+        db, user_pk, FriendshipStatus.ACCEPTED, requested_by_me=True
+    )
+    created += _raise_friend_notifications(
+        db,
+        user_pk,
+        {
+            'type': 'friend_request_accepted',
+            'title': 'Friend request accepted',
+            'body_for': lambda other: f'{_name(other)} accepted your friend request.',
+        },
+        accepted,
+    )
+
+    return removed + created
+
+
+def sweep_all(db: Session, user_pk: int) -> int:
+    """Run every generator for one user. Commits if anything changed."""
+    changed = sweep_movie_releases(db, user_pk) + sweep_friend_requests(db, user_pk)
+    if changed:
+        db.commit()
+    return changed

--- a/tests/integration/friend_request_notifications_test.py
+++ b/tests/integration/friend_request_notifications_test.py
@@ -1,0 +1,117 @@
+# pylint: disable=missing-function-docstring
+"""
+Friend-request notifications (#282).
+
+An incoming request notifies the recipient; acceptance notifies the sender;
+decline/cancel notify nobody and leave no live notification behind.
+"""
+
+from fastapi.testclient import TestClient
+
+
+def _auth(token: str) -> dict:
+    return {'Authorization': f'Bearer {token}'}
+
+
+def _claim_handle(test_client: TestClient, token: str, handle: str) -> str:
+    response = test_client.put(
+        '/v1/users/me/visibility', headers=_auth(token), json={'handle': handle}
+    )
+    assert response.status_code == 200, response.text
+    return response.json()['handle']
+
+
+def _send(test_client: TestClient, token: str, handle: str):
+    return test_client.post(
+        '/v1/users/me/friends/requests', headers=_auth(token), json={'handle': handle}
+    )
+
+
+def _notifications(test_client: TestClient, token: str):
+    return test_client.get('/v1/users/me/notifications', headers=_auth(token)).json()
+
+
+def test_incoming_request_raises_exactly_one_notification(test_client: TestClient):
+    _claim_handle(test_client, test_client.second_user.token, 'blake')
+    assert _send(test_client, test_client.first_user.token, 'blake').status_code == 202
+
+    items = _notifications(test_client, test_client.second_user.token)
+    assert len(items) == 1
+    assert items[0]['type'] == 'friend_request'
+    assert items[0]['category'] == 'friend_request'
+    assert items[0]['read'] is False
+
+    # Nothing for the sender yet — only the recipient is notified.
+    assert _notifications(test_client, test_client.first_user.token) == []
+
+
+def test_repeated_sweeps_add_no_duplicates(test_client: TestClient):
+    _claim_handle(test_client, test_client.second_user.token, 'blake')
+    _send(test_client, test_client.first_user.token, 'blake')
+
+    _notifications(test_client, test_client.second_user.token)
+    items = _notifications(test_client, test_client.second_user.token)
+    assert len(items) == 1
+
+
+def test_accept_notifies_the_original_sender(test_client: TestClient):
+    _claim_handle(test_client, test_client.second_user.token, 'blake')
+    _send(test_client, test_client.first_user.token, 'blake')
+    incoming = _notifications(test_client, test_client.second_user.token)
+    request_id = test_client.get(
+        '/v1/users/me/friends/requests', headers=_auth(test_client.second_user.token)
+    ).json()['incoming'][0]['id']
+
+    accepted = test_client.put(
+        f'/v1/users/me/friends/requests/{request_id}/accept',
+        headers=_auth(test_client.second_user.token),
+    )
+    assert accepted.status_code == 200
+
+    sender_items = _notifications(test_client, test_client.first_user.token)
+    assert len(sender_items) == 1
+    assert sender_items[0]['type'] == 'friend_request_accepted'
+    assert sender_items[0]['category'] == 'friend_request'
+
+    # The recipient's original "wants to be friends" notification is
+    # resolved — it would deep-link into a friendship they already acted on.
+    recipient_items = _notifications(test_client, test_client.second_user.token)
+    assert not any(item['type'] == 'friend_request' for item in recipient_items)
+    assert incoming  # (sanity: there was something to resolve)
+
+
+def test_decline_notifies_nobody_and_leaves_no_live_notification(
+    test_client: TestClient,
+):
+    _claim_handle(test_client, test_client.second_user.token, 'blake')
+    _send(test_client, test_client.first_user.token, 'blake')
+    request_id = test_client.get(
+        '/v1/users/me/friends/requests', headers=_auth(test_client.second_user.token)
+    ).json()['incoming'][0]['id']
+
+    declined = test_client.put(
+        f'/v1/users/me/friends/requests/{request_id}/decline',
+        headers=_auth(test_client.second_user.token),
+    )
+    assert declined.status_code == 200
+
+    assert _notifications(test_client, test_client.first_user.token) == []
+    assert _notifications(test_client, test_client.second_user.token) == []
+
+
+def test_cancel_leaves_no_live_notification(test_client: TestClient):
+    _claim_handle(test_client, test_client.second_user.token, 'blake')
+    _send(test_client, test_client.first_user.token, 'blake')
+    # Recipient reads once so the pending notification actually gets created.
+    _notifications(test_client, test_client.second_user.token)
+    request_id = test_client.get(
+        '/v1/users/me/friends/requests', headers=_auth(test_client.first_user.token)
+    ).json()['outgoing'][0]['id']
+
+    cancelled = test_client.delete(
+        f'/v1/users/me/friends/requests/{request_id}',
+        headers=_auth(test_client.first_user.token),
+    )
+    assert cancelled.status_code == 204
+
+    assert _notifications(test_client, test_client.second_user.token) == []


### PR DESCRIPTION
## Summary
- New `sweep_friend_requests` generator, following the `sweep_movie_releases` shape: idempotent, upserts on `dedupe_key`, runs lazily whenever a client reads its notifications.
- An incoming pending request notifies the recipient; acceptance notifies the original sender; decline and cancel notify nobody, matching #275's no-terminal-status design.
- Because decline/cancel delete the friendship row outright, a pending notification can outlive the request it points at. The sweep deletes any notification whose friendship has left the live incoming set before raising anything new, so a client never has a notification that deep-links into nothing.

Closes ALeonard9/druthers-api#282. Companion to ALeonard9/druthers-web#127. Part of the epic ALeonard9/druthers-api#272.

## Test plan
- [x] New tests cover: exactly-one notification per request, idempotent repeated sweeps, accept notifies sender, decline notifies nobody, deleted request leaves no live notification
- [x] Full suite (767 tests), pylint 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)