### PR TITLE
Add a ranked-list-length display preference (#122 companion)

### DIFF
--- a/alembic/versions/4fe7bd675954_ranked_list_length_preference.py
+++ b/alembic/versions/4fe7bd675954_ranked_list_length_preference.py
@@ -1,0 +1,54 @@
+"""ranked list length preference
+
+Viewer display preference (api#122): how many entries of a ranked list to
+show by default. NULL means unset, read as the default (25) everywhere via
+``app.services.preferences.coerce`` — nothing here backfills existing rows,
+since NULL already means the right thing.
+
+The unrelated index/constraint drift autogenerate also detected (an existing
+mismatch between a handful of tracker/movie indexes and the current models,
+predating this change) is deliberately left out of this migration — it
+belongs to whichever change introduced it, not to this one.
+
+Revision ID: 4fe7bd675954
+Revises: 16ad1155c69d
+Create Date: 2026-08-03 18:37:35.583225
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '4fe7bd675954'
+down_revision: Union[str, Sequence[str], None] = '16ad1155c69d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add the ranked_list_length preference column."""
+    op.add_column(
+        'users',
+        sa.Column(
+            'ranked_list_length',
+            sa.Enum(
+                '25',
+                '50',
+                '100',
+                'all',
+                name='ck_users_ranked_list_length',
+                native_enum=False,
+                create_constraint=True,
+                length=4,
+            ),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop the ranked_list_length preference column."""
+    op.drop_column('users', 'ranked_list_length')

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import backref, relationship
 
 from app.db.database import Base
 from app.services.friendships import DEFAULT_STATUS, FriendshipStatus
+from app.services.preferences import RankedListLength
 from app.services.visibility import DEFAULT_TIER, VisibilityTier
 
 
@@ -36,7 +37,7 @@ def tier_column(name: str) -> Column:
         name,
         Enum(
             VisibilityTier,
-            name=f'ck_users_{name}',
+            name=f"ck_users_{name}",
             native_enum=False,
             create_constraint=True,
             length=16,
@@ -101,6 +102,21 @@ class DbUser(DBBaseModel):
     visibility_watchlist_tv = tier_column('visibility_watchlist_tv')
     visibility_watchlist_books = tier_column('visibility_watchlist_books')
     visibility_watchlist_games = tier_column('visibility_watchlist_games')
+
+    # --- Display preferences (#122). Viewer-controlled, not visibility —
+    # how much of a ranked list to read, remembered across sessions and
+    # devices. NULL means "unset", read as the default (25) everywhere.
+    ranked_list_length = Column(
+        Enum(
+            RankedListLength,
+            name='ck_users_ranked_list_length',
+            native_enum=False,
+            create_constraint=True,
+            length=4,
+            values_callable=lambda members: [member.value for member in members],
+        ),
+        nullable=True,
+    )
 
 
 class DbApiKey(DBBaseModel):

--- a/app/router/v1/router_preferences.py
+++ b/app/router/v1/router_preferences.py
@@ -1,0 +1,41 @@
+# pylint: disable=missing-function-docstring
+"""
+Display preferences (#122): today, just how many entries of a ranked list to
+show by default. A viewer setting, not a sharing one — see
+:mod:`app.services.preferences` for why it lives apart from visibility.
+"""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.auth.oauth2 import get_current_user
+from app.db.database import get_db
+from app.schemas.model_schemas import InPreferencesUpdate, OutPreferences
+from app.services import preferences
+
+router = APIRouter(prefix='/v1', tags=['Preferences'])
+
+
+@router.get('/users/me/preferences', response_model=OutPreferences)
+def get_preferences(current_user: list = Depends(get_current_user)):
+    user = current_user[0]
+    return OutPreferences(
+        ranked_list_length=preferences.coerce(user.ranked_list_length)
+    )
+
+
+@router.put('/users/me/preferences', response_model=OutPreferences)
+def update_preferences(
+    request: InPreferencesUpdate,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    user = current_user[0]
+    data = request.model_dump(exclude_unset=True)
+    if 'ranked_list_length' in data and data['ranked_list_length'] is not None:
+        user.ranked_list_length = data['ranked_list_length']
+        db.commit()
+        db.refresh(user)
+    return OutPreferences(
+        ranked_list_length=preferences.coerce(user.ranked_list_length)
+    )

--- a/app/run.py
+++ b/app/run.py
@@ -29,6 +29,7 @@ from .router.v1 import (
     router_friends,
     router_import,
     router_notifications,
+    router_preferences,
     router_search,
     router_summary,
     router_visibility,
@@ -126,7 +127,7 @@ async def log_request_latency(request, call_next):
         },
     )
     # Lets the browser's network panel attribute the time without a log dive.
-    response.headers['Server-Timing'] = f'app;dur={elapsed_ms:.1f}'
+    response.headers['Server-Timing'] = f"app;dur={elapsed_ms:.1f}"
     return response
 
 
@@ -145,6 +146,7 @@ app.include_router(router_import.router)
 app.include_router(router_visibility.router)
 app.include_router(router_friends.router)
 app.include_router(router_follows.router)
+app.include_router(router_preferences.router)
 app.include_router(router_summary.router)
 
 # Serve static files

--- a/app/schemas/model_schemas.py
+++ b/app/schemas/model_schemas.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
+from app.services.preferences import RankedListLength
 from app.services.visibility import VisibilityTier
 
 
@@ -267,6 +268,20 @@ class OutFollow(BaseModel):
     id: str
     user: OutFollowUser
     followed_at: datetime
+
+
+class InPreferencesUpdate(BaseModel):
+    """Request body for display preferences (#122). Only sent fields change."""
+
+    ranked_list_length: Optional[RankedListLength] = None
+
+
+class OutPreferences(BaseModel):
+    """The caller's display preferences, defaulted where unset."""
+
+    ranked_list_length: RankedListLength = RankedListLength.TWENTY_FIVE
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class OutSummaryEntry(BaseModel):

--- a/app/services/preferences.py
+++ b/app/services/preferences.py
@@ -1,0 +1,30 @@
+"""
+Viewer display preferences (#122).
+
+Today, just how many entries of a ranked list to show by default. Kept
+apart from :mod:`app.services.visibility` on purpose: this is a reading
+preference the *viewer* controls, not a sharing setting the *owner*
+controls, and it never touches the tier ladder.
+"""
+
+from enum import StrEnum
+
+
+class RankedListLength(StrEnum):
+    """25/50/100/all. 25 is the default, applied whenever the column is NULL."""
+
+    TWENTY_FIVE = '25'
+    FIFTY = '50'
+    HUNDRED = '100'
+    ALL = 'all'
+
+
+DEFAULT_RANKED_LIST_LENGTH = RankedListLength.TWENTY_FIVE
+
+
+def coerce(value) -> RankedListLength:
+    """Read a stored length defensively: NULL or anything unrecognised is the default."""
+    try:
+        return RankedListLength(value)
+    except ValueError:
+        return DEFAULT_RANKED_LIST_LENGTH

--- a/tests/integration/router_preferences_test.py
+++ b/tests/integration/router_preferences_test.py
@@ -1,0 +1,60 @@
+# pylint: disable=missing-function-docstring
+"""Display preferences (#122)."""
+
+from fastapi.testclient import TestClient
+
+
+def _auth(token: str) -> dict:
+    return {'Authorization': f"Bearer {token}"}
+
+
+def test_default_is_25(test_client: TestClient):
+    body = test_client.get(
+        '/v1/users/me/preferences', headers=_auth(test_client.first_user.token)
+    ).json()
+    assert body == {'ranked_list_length': '25'}
+
+
+def test_set_and_read_back(test_client: TestClient):
+    token = test_client.first_user.token
+    updated = test_client.put(
+        '/v1/users/me/preferences',
+        headers=_auth(token),
+        json={'ranked_list_length': 'all'},
+    )
+    assert updated.status_code == 200
+    assert updated.json() == {'ranked_list_length': 'all'}
+
+    fetched = test_client.get('/v1/users/me/preferences', headers=_auth(token))
+    assert fetched.json() == {'ranked_list_length': 'all'}
+
+
+def test_invalid_length_rejected(test_client: TestClient):
+    response = test_client.put(
+        '/v1/users/me/preferences',
+        headers=_auth(test_client.first_user.token),
+        json={'ranked_list_length': '37'},
+    )
+    assert response.status_code == 422
+
+
+def test_preferences_are_per_user(test_client: TestClient):
+    test_client.put(
+        '/v1/users/me/preferences',
+        headers=_auth(test_client.first_user.token),
+        json={'ranked_list_length': '100'},
+    )
+    other = test_client.get(
+        '/v1/users/me/preferences', headers=_auth(test_client.second_user.token)
+    ).json()
+    assert other == {'ranked_list_length': '25'}
+
+
+def test_preferences_require_auth(test_client: TestClient):
+    assert test_client.get('/v1/users/me/preferences').status_code == 401
+    assert (
+        test_client.put(
+            '/v1/users/me/preferences', json={'ranked_list_length': '50'}
+        ).status_code
+        == 401
+    )


### PR DESCRIPTION
## Summary
- `GET/PUT /v1/users/me/preferences`: today just `ranked_list_length` (25/50/100/all, default 25) — the cross-device storage the web client needs to remember a viewer's chosen depth per #122's "remembered across sessions and devices" requirement. localStorage alone only covers one device.
- Deliberately separate from visibility: this is a reading preference the viewer controls, not a sharing setting the owner controls.

Stacked on #287 (feat/279) — review the diff against that branch, not main.

Not itself a filed issue — a small piece of plumbing #122 (ALeonard9/druthers-web#122) needs and didn't have anywhere to live yet. Part of ALeonard9/druthers-api#272.

## Test plan
- [x] New tests cover: default is 25, set-and-read-back, invalid value rejected, per-user isolation, auth required
- [x] Full suite (767 tests), pylint 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)