### PR TITLE
Auto-rank first item added to an empty list as #1

### DIFF
--- a/app/router/v1/router_books.py
+++ b/app/router/v1/router_books.py
@@ -360,10 +360,15 @@ def mark_book(
 
     # A book only holds a rank while it's on the ranked list AND was already
     # placed. Entering Rankings (or leaving it) resets to unplaced so it lands
-    # in the "to rank" bucket rather than at a stale/leftover position.
+    # in the "to rank" bucket rather than at a stale/leftover position —
+    # unless it's the first ranked book, which auto-places at #1 (#289).
     enforce_single_home(tracker, data)
     default_completed_at(tracker, was_on_rankings)
-    if not tracker.on_rankings or not was_on_rankings:
+    entering_rankings = tracker.on_rankings and not was_on_rankings
+    if entering_rankings and _placed_count(db, user_pk) == 0:
+        tracker.rank = 1
+        tracker.ranked_at = utc_now()
+    elif not tracker.on_rankings or not was_on_rankings:
         tracker.rank = None
         tracker.ranked_at = None
     if old_rank is not None and tracker.rank is None:

--- a/app/router/v1/router_games.py
+++ b/app/router/v1/router_games.py
@@ -372,10 +372,15 @@ def mark_game(
 
     # A game only holds a rank while it's on the ranked list AND was already
     # placed. Entering Rankings (or leaving it) resets to unplaced so it lands
-    # in the "to rank" bucket rather than at a stale/leftover position.
+    # in the "to rank" bucket rather than at a stale/leftover position —
+    # unless it's the first ranked game, which auto-places at #1 (#289).
     enforce_single_home(tracker, data)
     default_completed_at(tracker, was_on_rankings)
-    if not tracker.on_rankings or not was_on_rankings:
+    entering_rankings = tracker.on_rankings and not was_on_rankings
+    if entering_rankings and _placed_count(db, user_pk) == 0:
+        tracker.rank = 1
+        tracker.ranked_at = utc_now()
+    elif not tracker.on_rankings or not was_on_rankings:
         tracker.rank = None
         tracker.ranked_at = None
     if old_rank is not None and tracker.rank is None:

--- a/app/router/v1/router_movies.py
+++ b/app/router/v1/router_movies.py
@@ -402,10 +402,15 @@ def mark_movie(
 
     # A movie only holds a rank while it's on the ranked list AND was already
     # placed. Entering Rankings (or leaving it) resets to unplaced so it lands
-    # in the "to rank" bucket rather than at a stale/leftover position.
+    # in the "to rank" bucket rather than at a stale/leftover position —
+    # unless it's the first ranked movie, which auto-places at #1 (#289).
     enforce_single_home(tracker, data)
     default_completed_at(tracker, was_on_rankings)
-    if not tracker.on_rankings or not was_on_rankings:
+    entering_rankings = tracker.on_rankings and not was_on_rankings
+    if entering_rankings and _placed_count(db, user_pk) == 0:
+        tracker.rank = 1
+        tracker.ranked_at = utc_now()
+    elif not tracker.on_rankings or not was_on_rankings:
         tracker.rank = None
         tracker.ranked_at = None
     if old_rank is not None and tracker.rank is None:

--- a/app/router/v1/router_tv.py
+++ b/app/router/v1/router_tv.py
@@ -643,10 +643,15 @@ def mark_tv_show(
 
     # A show only holds a rank while it's on the ranked list AND was already
     # placed. Entering Rankings (or leaving it) resets to unplaced so it lands
-    # in the "to rank" bucket rather than at a stale/leftover position.
+    # in the "to rank" bucket rather than at a stale/leftover position —
+    # unless it's the first ranked show, which auto-places at #1 (#289).
     enforce_single_home(tracker, data)
     default_completed_at(tracker, was_on_rankings)
-    if not tracker.on_rankings or not was_on_rankings:
+    entering_rankings = tracker.on_rankings and not was_on_rankings
+    if entering_rankings and _placed_count(db, user_pk) == 0:
+        tracker.rank = 1
+        tracker.ranked_at = utc_now()
+    elif not tracker.on_rankings or not was_on_rankings:
         tracker.rank = None
         tracker.ranked_at = None
     if old_rank is not None and tracker.rank is None:

--- a/tests/integration/router_books_test.py
+++ b/tests/integration/router_books_test.py
@@ -113,7 +113,8 @@ def test_search_books_returns_results(mock_get, test_client: TestClient):
 
 
 # --- Trackers (Movies-parity lists) ---
-def test_mark_book_to_rankings_is_unplaced(test_client: TestClient):
+def test_mark_first_book_to_rankings_auto_places_at_one(test_client: TestClient):
+    """First book into an empty ranked list auto-places at #1 (#289)."""
     book_id = _make_book(test_client)
     headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
     response = test_client.post(
@@ -125,8 +126,26 @@ def test_mark_book_to_rankings_is_unplaced(test_client: TestClient):
     data = response.json()
     assert data['on_rankings'] is True
     assert data['on_watchlist'] is False
-    assert data['rank'] is None
+    assert data['rank'] == 1
     assert data['notes'] == 'A masterpiece.'
+
+
+def test_mark_second_book_to_rankings_is_unplaced(test_client: TestClient):
+    """Once a book is already ranked, the next one lands unplaced pending a duel."""
+    first_id = _make_book(test_client)
+    second_id = _make_book(test_client, title='Also Ranked')
+    headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
+
+    test_client.post(
+        f"/v1/users/me/books/{first_id}", headers=headers, json={'on_rankings': True}
+    )
+    response = test_client.post(
+        f"/v1/users/me/books/{second_id}", headers=headers, json={'on_rankings': True}
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data['on_rankings'] is True
+    assert data['rank'] is None
 
 
 def test_lists_are_exclusive(test_client: TestClient):
@@ -143,7 +162,8 @@ def test_lists_are_exclusive(test_client: TestClient):
     assert r.json()['on_watchlist'] is True
     assert r.json()['on_rankings'] is False
 
-    # Promote to rankings -> leaves the watchlist (unplaced until positioned).
+    # Promote to rankings -> leaves the watchlist. It's the only ranked book,
+    # so it auto-places at #1 (#289).
     r = test_client.post(
         f"/v1/users/me/books/{book_id}",
         headers=headers,
@@ -151,7 +171,7 @@ def test_lists_are_exclusive(test_client: TestClient):
     )
     assert r.json()['on_rankings'] is True
     assert r.json()['on_watchlist'] is False
-    assert r.json()['rank'] is None
+    assert r.json()['rank'] == 1
 
     # Leave rankings -> on neither list, so the tracker is dropped entirely.
     test_client.put(

--- a/tests/integration/router_games_test.py
+++ b/tests/integration/router_games_test.py
@@ -105,7 +105,8 @@ def test_search_games_returns_results(mock_search, test_client: TestClient):
 
 
 # --- Trackers (Movies-parity lists + 100% flag) ---
-def test_mark_game_to_rankings_is_unplaced(test_client: TestClient):
+def test_mark_first_game_to_rankings_auto_places_at_one(test_client: TestClient):
+    """First game into an empty ranked list auto-places at #1 (#289)."""
     game_id = _make_game(test_client)
     headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
     response = test_client.post(
@@ -117,8 +118,26 @@ def test_mark_game_to_rankings_is_unplaced(test_client: TestClient):
     data = response.json()
     assert data['on_rankings'] is True
     assert data['on_watchlist'] is False
-    assert data['rank'] is None
+    assert data['rank'] == 1
     assert data['is_100_percent'] is False
+
+
+def test_mark_second_game_to_rankings_is_unplaced(test_client: TestClient):
+    """Once a game is already ranked, the next one lands unplaced pending a duel."""
+    first_id = _make_game(test_client)
+    second_id = _make_game(test_client, title='Also Ranked')
+    headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
+
+    test_client.post(
+        f"/v1/users/me/games/{first_id}", headers=headers, json={'on_rankings': True}
+    )
+    response = test_client.post(
+        f"/v1/users/me/games/{second_id}", headers=headers, json={'on_rankings': True}
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data['on_rankings'] is True
+    assert data['rank'] is None
 
 
 def test_hundred_percent_flag(test_client: TestClient):
@@ -150,7 +169,8 @@ def test_lists_are_exclusive(test_client: TestClient):
     assert r.json()['on_watchlist'] is True
     assert r.json()['on_rankings'] is False
 
-    # Promote to rankings -> leaves the watchlist (unplaced until positioned).
+    # Promote to rankings -> leaves the watchlist. It's the only ranked game,
+    # so it auto-places at #1 (#289).
     r = test_client.post(
         f"/v1/users/me/games/{game_id}",
         headers=headers,
@@ -158,7 +178,7 @@ def test_lists_are_exclusive(test_client: TestClient):
     )
     assert r.json()['on_rankings'] is True
     assert r.json()['on_watchlist'] is False
-    assert r.json()['rank'] is None
+    assert r.json()['rank'] == 1
 
     # Leave rankings -> on neither list, so the tracker is dropped entirely.
     test_client.put(

--- a/tests/integration/router_movies_test.py
+++ b/tests/integration/router_movies_test.py
@@ -40,8 +40,8 @@ def _make_movie(test_client: TestClient, imdb='tt1375666', title='Inception') ->
     return resp.json()['id']
 
 
-def test_mark_movie_to_rankings_is_unplaced(test_client: TestClient):
-    """Adding to Rankings leaves the movie unplaced (rank None) until positioned."""
+def test_mark_first_movie_to_rankings_auto_places_at_one(test_client: TestClient):
+    """First movie into an empty ranked list auto-places at #1 (#289)."""
     movie_id = _make_movie(test_client)
     user_headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
 
@@ -54,8 +54,30 @@ def test_mark_movie_to_rankings_is_unplaced(test_client: TestClient):
     data = response.json()
     assert data['on_rankings'] is True
     assert data['on_watchlist'] is False
-    assert data['rank'] is None
+    assert data['rank'] == 1
     assert data['notes'] == 'Mind-bending!'
+
+
+def test_mark_second_movie_to_rankings_is_unplaced(test_client: TestClient):
+    """Once a movie is already ranked, the next one lands unplaced pending a duel."""
+    first_id = _make_movie(test_client)
+    second_id = _make_movie(test_client, imdb='tt7996', title='Also Ranked')
+    user_headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
+
+    test_client.post(
+        f"/v1/users/me/movies/{first_id}",
+        headers=user_headers,
+        json={'on_rankings': True},
+    )
+    response = test_client.post(
+        f"/v1/users/me/movies/{second_id}",
+        headers=user_headers,
+        json={'on_rankings': True},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data['on_rankings'] is True
+    assert data['rank'] is None
 
 
 def test_set_movie_rank_inserts_and_shifts(test_client: TestClient):
@@ -115,7 +137,8 @@ def test_lists_are_exclusive(test_client: TestClient):
     assert r.json()['on_watchlist'] is True
     assert r.json()['on_rankings'] is False
 
-    # Promote to rankings -> leaves the watchlist (unplaced until positioned).
+    # Promote to rankings -> leaves the watchlist. It's the only ranked movie,
+    # so it auto-places at #1 (#289).
     r = test_client.post(
         f"/v1/users/me/movies/{movie_id}",
         headers=headers,
@@ -123,7 +146,7 @@ def test_lists_are_exclusive(test_client: TestClient):
     )
     assert r.json()['on_rankings'] is True
     assert r.json()['on_watchlist'] is False
-    assert r.json()['rank'] is None
+    assert r.json()['rank'] == 1
 
     # Leave rankings -> on neither list, so the tracker is dropped entirely.
     test_client.put(
@@ -137,14 +160,19 @@ def test_lists_are_exclusive(test_client: TestClient):
 
 def test_reentering_rankings_starts_unplaced(test_client: TestClient):
     """Re-adding a movie to Rankings ignores any leftover rank (starts unplaced)."""
+    other_id = _make_movie(test_client, imdb='tt7995', title='Stays Ranked')
     movie_id = _make_movie(test_client)
     h = {'Authorization': f"Bearer {test_client.first_user.token}"}
-    # place it at #1
+    # rank `other` first so the list isn't empty when `movie_id` re-enters below.
+    test_client.post(
+        f"/v1/users/me/movies/{other_id}", headers=h, json={'on_rankings': True}
+    )
+    # place it at #2
     test_client.post(
         f"/v1/users/me/movies/{movie_id}", headers=h, json={'on_rankings': True}
     )
     test_client.put(
-        f"/v1/users/me/movies/{movie_id}/rank", headers=h, json={'position': 1}
+        f"/v1/users/me/movies/{movie_id}/rank", headers=h, json={'position': 2}
     )
     # remove from rankings, then re-add -> must be unplaced again, not at its old rank
     test_client.put(

--- a/tests/integration/router_tv_test.py
+++ b/tests/integration/router_tv_test.py
@@ -160,7 +160,8 @@ def test_search_tv_shows_returns_results(mock_get, test_client: TestClient):
 
 
 # --- Show trackers (Movies-parity lists) ---
-def test_mark_show_to_rankings_is_unplaced(test_client: TestClient):
+def test_mark_first_show_to_rankings_auto_places_at_one(test_client: TestClient):
+    """First show into an empty ranked list auto-places at #1 (#289)."""
     show_id = _make_show(test_client)
     headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
     response = test_client.post(
@@ -172,8 +173,30 @@ def test_mark_show_to_rankings_is_unplaced(test_client: TestClient):
     data = response.json()
     assert data['on_rankings'] is True
     assert data['on_watchlist'] is False
-    assert data['rank'] is None
+    assert data['rank'] == 1
     assert data['notes'] == 'Peak TV'
+
+
+def test_mark_second_show_to_rankings_is_unplaced(test_client: TestClient):
+    """Once a show is already ranked, the next one lands unplaced pending a duel."""
+    first_id = _make_show(test_client)
+    second_id = _make_show(test_client, title='Also Ranked')
+    headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
+
+    test_client.post(
+        f"/v1/users/me/tv-shows/{first_id}",
+        headers=headers,
+        json={'on_rankings': True},
+    )
+    response = test_client.post(
+        f"/v1/users/me/tv-shows/{second_id}",
+        headers=headers,
+        json={'on_rankings': True},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data['on_rankings'] is True
+    assert data['rank'] is None
 
 
 def test_lists_are_exclusive(test_client: TestClient):
@@ -190,7 +213,8 @@ def test_lists_are_exclusive(test_client: TestClient):
     assert r.json()['on_watchlist'] is True
     assert r.json()['on_rankings'] is False
 
-    # Promote to rankings -> leaves the watchlist (unplaced until positioned).
+    # Promote to rankings -> leaves the watchlist. It's the only ranked show,
+    # so it auto-places at #1 (#289).
     r = test_client.post(
         f"/v1/users/me/tv-shows/{show_id}",
         headers=headers,
@@ -198,7 +222,7 @@ def test_lists_are_exclusive(test_client: TestClient):
     )
     assert r.json()['on_rankings'] is True
     assert r.json()['on_watchlist'] is False
-    assert r.json()['rank'] is None
+    assert r.json()['rank'] == 1
 
     # Leave rankings -> on neither list, so the tracker is dropped entirely.
     test_client.put(
@@ -274,13 +298,19 @@ def test_reorder_rankings(test_client: TestClient):
 
 
 def test_reentering_rankings_starts_unplaced(test_client: TestClient):
+    """Re-adding a show to Rankings ignores any leftover rank (starts unplaced)."""
+    other_id = _make_show(test_client, title='Stays Ranked')
     show_id = _make_show(test_client)
     headers = {'Authorization': f"Bearer {test_client.first_user.token}"}
+    # rank `other` first so the list isn't empty when `show_id` re-enters below.
+    test_client.post(
+        f"/v1/users/me/tv-shows/{other_id}", headers=headers, json={'on_rankings': True}
+    )
     test_client.post(
         f"/v1/users/me/tv-shows/{show_id}", headers=headers, json={'on_rankings': True}
     )
     test_client.put(
-        f"/v1/users/me/tv-shows/{show_id}/rank", headers=headers, json={'position': 1}
+        f"/v1/users/me/tv-shows/{show_id}/rank", headers=headers, json={'position': 2}
     )
     test_client.put(
         f"/v1/users/me/tv-shows/{show_id}",


### PR DESCRIPTION
## Summary
- `mark_movie`/`mark_tv_show`/`mark_book`/`mark_game`: when a title enters Rankings and the domain currently has zero ranked items, it's placed at rank #1 immediately instead of landing unplaced in the "to rank" bucket.
- Behavior is unchanged once a domain already has at least one ranked item — the existing duel-required flow still applies.
- The existing explicit "Make it #1" duel flow (`RankingDuel.tsx` → `FirstOneIn`) is untouched; this only changes the plain mark/add path.

Closes #289.

## Test plan
- [x] New tests per domain: first item into an empty list lands at rank 1; second item still lands unplaced pending a duel
- [x] Full suite (771 tests), pylint 10.00/10, Black clean
- [x] Demoed against local dev stack; verified end-to-end with the companion druthers-web fix that skips the duel screen when the API already auto-placed the item

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pm3v16WNJpDn12gvG36TCo