### PR TITLE
Default new accounts to friends-visible instead of private

### DIFF
--- a/alembic/versions/3c45fe305813_friends_default_privacy_tier.py
+++ b/alembic/versions/3c45fe305813_friends_default_privacy_tier.py
@@ -1,0 +1,66 @@
+"""friends default privacy tier
+
+Moves the server-side default for every visibility tier column from
+``private`` to ``friends`` (web#156) — a fresh signup should be visible to
+the friends who invited them, not invisible by default. Mirrors the
+DEFAULT_TIER flip in app.services.visibility, which already changes the
+ORM-side default; this keeps the DB-level default in parity for any insert
+that bypasses the ORM.
+
+Only changes the column default for *future* inserts. Existing users' stored
+tier values are untouched.
+
+Revision ID: 3c45fe305813
+Revises: 4fe7bd675954
+Create Date: 2026-08-04 23:18:04.366154
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '3c45fe305813'
+down_revision: Union[str, Sequence[str], None] = '4fe7bd675954'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Same nine columns as alembic/versions/b7c1f4a9d2e3_visibility_tiers.py,
+# which introduced them.
+TIER_COLUMNS: Sequence[str] = (
+    'visibility_profile',
+    'visibility_movies',
+    'visibility_tv',
+    'visibility_books',
+    'visibility_games',
+    'visibility_watchlist_movies',
+    'visibility_watchlist_tv',
+    'visibility_watchlist_books',
+    'visibility_watchlist_games',
+)
+
+
+def upgrade() -> None:
+    """Default new tier columns to 'friends' instead of 'private'."""
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        for column in TIER_COLUMNS:
+            batch_op.alter_column(
+                column,
+                existing_type=sa.String(length=16),
+                existing_nullable=False,
+                server_default='friends',
+            )
+
+
+def downgrade() -> None:
+    """Restore the 'private' default."""
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        for column in TIER_COLUMNS:
+            batch_op.alter_column(
+                column,
+                existing_type=sa.String(length=16),
+                existing_nullable=False,
+                server_default='private',
+            )

--- a/app/services/visibility.py
+++ b/app/services/visibility.py
@@ -42,7 +42,12 @@ class ViewerRelationship(StrEnum):
     SELF = 'self'
 
 
-DEFAULT_TIER = VisibilityTier.PRIVATE
+# New accounts start visible to friends, not private (web#156) — a fresh
+# signup is otherwise invisible to the friends who invited them. This one
+# constant drives every tier_column() default in app/db/models.py, so the
+# profile's own default moves in lockstep with the shelves it fronts and the
+# "profile >= most-open shelf" floor invariant holds from account creation.
+DEFAULT_TIER = VisibilityTier.FRIENDS
 
 # The DbUser column governing the profile page itself (the ninth setting).
 PROFILE_TIER_FIELD = 'visibility_profile'

--- a/tests/integration/router_follows_test.py
+++ b/tests/integration/router_follows_test.py
@@ -211,7 +211,24 @@ def test_following_an_unknown_handle_404s(test_client: TestClient):
 
 
 def test_cannot_follow_a_private_profile(test_client: TestClient):
-    _set_visibility(test_client, test_client.second_user.token, handle='blake')
+    # Explicit: every tier now defaults to 'friends' (web#156), so a test of
+    # a genuinely *private* profile has to lower every shelf too — the floor
+    # invariant (#274) otherwise rejects a private profile under a friends
+    # shelf, and 'friends' alone would 404 here too, but for the wrong reason.
+    _set_visibility(
+        test_client,
+        test_client.second_user.token,
+        handle='blake',
+        visibility_profile='private',
+        visibility_movies='private',
+        visibility_tv='private',
+        visibility_books='private',
+        visibility_games='private',
+        visibility_watchlist_movies='private',
+        visibility_watchlist_tv='private',
+        visibility_watchlist_books='private',
+        visibility_watchlist_games='private',
+    )
     response = test_client.put(
         '/v1/users/me/following/blake', headers=_auth(test_client.first_user.token)
     )
@@ -393,11 +410,21 @@ def test_a_follow_survives_the_followee_going_private(test_client: TestClient):
 
     # Both in one update: #274's invariant rejects a private profile that
     # still has a public shelf under it, so the shelf has to come down too.
+    # Every other shelf now defaults to 'friends' (web#156) rather than
+    # 'private', so they need lowering explicitly as well, or the same
+    # invariant rejects this update on one of *them* instead.
     _set_visibility(
         test_client,
         owner_token,
         visibility_profile='private',
         visibility_movies='private',
+        visibility_tv='private',
+        visibility_books='private',
+        visibility_games='private',
+        visibility_watchlist_movies='private',
+        visibility_watchlist_tv='private',
+        visibility_watchlist_books='private',
+        visibility_watchlist_games='private',
     )
 
     # The row is untouched...

--- a/tests/integration/router_friends_test.py
+++ b/tests/integration/router_friends_test.py
@@ -372,11 +372,29 @@ def test_a_user_without_a_handle_cannot_be_reached(test_client: TestClient):
     takes the account back off the map.
     """
     _claim_handle(test_client, test_client.second_user.token, 'blake')
+    # Clearing a handle is only allowed while fully private, and every tier
+    # now defaults to 'friends' (web#156) — go there explicitly first.
     test_client.put(
+        '/v1/users/me/visibility',
+        headers=_auth(test_client.second_user.token),
+        json={
+            'visibility_profile': 'private',
+            'visibility_movies': 'private',
+            'visibility_tv': 'private',
+            'visibility_books': 'private',
+            'visibility_games': 'private',
+            'visibility_watchlist_movies': 'private',
+            'visibility_watchlist_tv': 'private',
+            'visibility_watchlist_books': 'private',
+            'visibility_watchlist_games': 'private',
+        },
+    )
+    cleared = test_client.put(
         '/v1/users/me/visibility',
         headers=_auth(test_client.second_user.token),
         json={'handle': None},
     )
+    assert cleared.status_code == 200, cleared.text
     assert _send(test_client, test_client.first_user.token, 'blake').status_code == 202
     assert (
         test_client.get(

--- a/tests/integration/router_visibility_test.py
+++ b/tests/integration/router_visibility_test.py
@@ -51,12 +51,12 @@ def _watchlist_a_movie(
     )
 
 
-def test_defaults_are_fully_private(test_client: TestClient):
+def test_defaults_are_fully_friends(test_client: TestClient):
     body = test_client.get(
         '/v1/users/me/visibility', headers=_auth(test_client.first_user.token)
     ).json()
     assert body['handle'] is None
-    assert [body[field] for field in TIER_FIELDS] == ['private'] * len(TIER_FIELDS)
+    assert [body[field] for field in TIER_FIELDS] == ['friends'] * len(TIER_FIELDS)
 
 
 def test_leaving_private_requires_a_handle(test_client: TestClient):
@@ -138,10 +138,13 @@ def test_clearing_a_handle_only_allowed_while_fully_private(test_client: TestCli
         == 'avery'
     )
 
+    # Every tier now defaults to 'friends' (web#156), so "fully private" must
+    # be reached explicitly rather than relying on the untouched fields'
+    # default — this PUT sets all nine, not just the two touched above.
     test_client.put(
         '/v1/users/me/visibility',
         headers=_auth(token),
-        json={'visibility_profile': 'private', 'visibility_movies': 'private'},
+        json={field: 'private' for field in TIER_FIELDS},
     )
     cleared = test_client.put(
         '/v1/users/me/visibility', headers=_auth(token), json={'handle': None}
@@ -175,6 +178,16 @@ def test_the_offending_shelf_is_named_for_watchlists_too(test_client: TestClient
         json={
             'handle': 'avery',
             'visibility_profile': 'private',
+            # Every other tier now defaults to 'friends' (web#156) — pin them
+            # private so visibility_watchlist_games is unambiguously the one
+            # field this update leaves in violation.
+            'visibility_movies': 'private',
+            'visibility_tv': 'private',
+            'visibility_books': 'private',
+            'visibility_games': 'private',
+            'visibility_watchlist_movies': 'private',
+            'visibility_watchlist_tv': 'private',
+            'visibility_watchlist_books': 'private',
             'visibility_watchlist_games': 'friends',
         },
     )
@@ -255,7 +268,7 @@ def test_partial_updates_only_touch_sent_fields(test_client: TestClient):
     assert body['visibility_movies'] == 'public'
     assert body['visibility_books'] == 'friends'
     assert body['visibility_tv'] == 'friends'
-    assert body['visibility_games'] == 'private'
+    assert body['visibility_games'] == 'friends'
 
 
 def test_public_profile_exposes_only_public_ranked_lists(test_client: TestClient):

--- a/tests/integration/router_visibility_viewer_test.py
+++ b/tests/integration/router_visibility_viewer_test.py
@@ -262,6 +262,12 @@ def test_a_friends_only_profile_is_a_404_for_everybody_else(
         handle=HANDLE,
         visibility_profile='friends',
         visibility_movies='friends',
+        # Every shelf now defaults to 'friends' too (web#156) — pin the other
+        # three closed so this stays a test of "only Movies is friends-tier",
+        # not an accident of the account-wide default.
+        visibility_tv='private',
+        visibility_books='private',
+        visibility_games='private',
     )
     _befriend(test_client, test_client.second_user.token, owner_token)
 
@@ -294,7 +300,16 @@ def test_nothing_visible_404s_even_when_the_profile_tier_admits_you(
     owner_token = test_client.first_user.token
     _stock_every_shelf(test_client, owner_token)
     _set_visibility(
-        test_client, owner_token, handle=HANDLE, visibility_profile='friends'
+        test_client,
+        owner_token,
+        handle=HANDLE,
+        visibility_profile='friends',
+        # Shelves default to 'friends' now (web#156) — pin them private so
+        # this test still exercises "profile open, every shelf closed".
+        visibility_movies='private',
+        visibility_tv='private',
+        visibility_books='private',
+        visibility_games='private',
     )
     _befriend(test_client, test_client.second_user.token, owner_token)
 
@@ -357,7 +372,23 @@ def test_unfriending_takes_the_shelves_back(test_client: TestClient):
 def test_the_owner_of_a_private_profile_still_sees_it(test_client: TestClient):
     owner_token = test_client.first_user.token
     _stock_every_shelf(test_client, owner_token)
-    _set_visibility(test_client, owner_token, handle=HANDLE)
+    # Explicit: every tier now defaults to 'friends' (web#156), so a test of
+    # a genuinely *private* profile has to lower every shelf too, or the
+    # floor invariant (#274) rejects a private profile under a friends shelf.
+    _set_visibility(
+        test_client,
+        owner_token,
+        handle=HANDLE,
+        visibility_profile='private',
+        visibility_movies='private',
+        visibility_tv='private',
+        visibility_books='private',
+        visibility_games='private',
+        visibility_watchlist_movies='private',
+        visibility_watchlist_tv='private',
+        visibility_watchlist_books='private',
+        visibility_watchlist_games='private',
+    )
 
     anonymous = test_client.get(f'/v1/public/{HANDLE}')
     assert anonymous.status_code == 404


### PR DESCRIPTION
## Summary
- Flips `DEFAULT_TIER` (`app/services/visibility.py`) from `private` to `friends` — drives every `tier_column()` default (profile + all 8 shelf fields) in lockstep, so the "profile >= most-open shelf" floor invariant holds for a fresh account with no extra code.
- New migration mirrors the DB-level `server_default` so non-ORM inserts stay in parity. Existing users' stored values are untouched.
- Updates tests that assumed private-by-default for untouched fields, and tightens a couple that were passing for the wrong reason (asserting a "private" profile without actually setting every shelf private).

Backend half of ALeonard9/druthers-web#156 — pairs with druthers-web#157, which adds the Default Sharing UI this feeds.

## Test plan
- [x] `pytest` — 771/771 passing
- [x] `black --check --skip-string-normalization` clean
- [x] Migration applies cleanly against local dev Postgres (`task migrate`)
- [x] Manually verified locally: fresh signup lands on `friends` across every tier, not `private`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8NWTysEsWaDuzu2g3VDhn