### PR TITLE
Return full release_date from movie search, not just year

### DIFF
--- a/app/schemas/schemas_sandbox.py
+++ b/app/schemas/schemas_sandbox.py
@@ -125,6 +125,7 @@ class MovieSearchResult(BaseModel):
     imdb: Optional[str] = None
     title: str
     year: Optional[str] = None
+    release_date: Optional[str] = None
     poster_url: Optional[str] = None
     type: Optional[str] = None
     popularity: Optional[float] = None

--- a/app/services/movie_search.py
+++ b/app/services/movie_search.py
@@ -62,6 +62,7 @@ def _normalize_hit(item: dict) -> dict:
         'imdb': item.get('imdb_id'),
         'title': item.get('title') or item.get('original_title'),
         'year': _year(item.get('release_date')),
+        'release_date': item.get('release_date'),
         'poster_url': tmdb.image_url(item.get('poster_path')),
         'type': 'movie',
         # TMDB supplies a real popularity score; search_ranking uses it as the

--- a/tests/integration/router_movies_test.py
+++ b/tests/integration/router_movies_test.py
@@ -335,6 +335,9 @@ def test_search_movies_returns_results(
     assert data[0]['poster_url'] == 'https://image.tmdb.org/t/p/w500/matrix.jpg'
     # TMDB title search carries no IMDb id.
     assert data[0]['imdb'] is None
+    # Full release_date, not just year, so the frontend can show unreleased
+    # titles a date instead of a rank affordance (web#180).
+    assert data[0]['release_date'] == '1999-03-30'
     # A missing poster_path becomes null rather than a URL that would 404.
     assert data[1]['poster_url'] is None
 

--- a/tests/unit/movie_search_test.py
+++ b/tests/unit/movie_search_test.py
@@ -149,6 +149,7 @@ def test_search_movies_by_imdb_id_returns_search_hit_shape(mock_get, mock_settin
             'imdb': 'tt0120338',
             'title': 'Titanic',
             'year': '1997',
+            'release_date': '1997-11-18',
             'poster_url': 'https://image.tmdb.org/t/p/w500/t.jpg',
             'type': 'movie',
             'popularity': 91.2,
@@ -210,6 +211,9 @@ def test_search_movies_title_query_uses_search_endpoint(mock_get, mock_settings)
     # Title search carries no IMDb id — that's why tmdb is the join key.
     assert results[0]['imdb'] is None
     assert results[0]['popularity'] == 91.2
+    # Full release_date (not just year) so the frontend can tell unreleased
+    # titles apart and show a date instead of a rank affordance (web#180).
+    assert results[0]['release_date'] == '1997-11-18'
     args, kwargs = mock_get.call_args
     assert args[0].endswith('/search/movie')
     assert kwargs['params']['query'] == 'Titanic'


### PR DESCRIPTION
## Summary
- web#180 (unreleased movies show a release date instead of a rank affordance) was applied to the watchlist card but not search results, because search only ever returned a truncated year
- Threads TMDB's `release_date` through search-hit normalization (`_normalize_hit`) and the `MovieSearchResult` schema so the web client can tell an unreleased title apart in search too

## Test plan
- [x] `pytest tests/unit/movie_search_test.py tests/integration/router_movies_test.py` — 39/39 passing, including new release_date assertions
- [x] `black` / `pylint` clean via pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)