### PR TITLE
fix: onboarding should only fire for accounts with zero items

### DIFF
--- a/app/schemas/model_schemas.py
+++ b/app/schemas/model_schemas.py
@@ -319,3 +319,4 @@ class OutSummary(BaseModel):
     shelves: list[OutSummaryShelf]
     total_ranked: int
     onboarding_completed: bool
+    needs_onboarding: bool

--- a/app/services/summary.py
+++ b/app/services/summary.py
@@ -96,6 +96,8 @@ def build_summary(db: Session, user: DbUser, top_n: int = TOP_N) -> dict:
             }
         )
 
+    total_items = sum(s['ranked_count'] + s['queued_count'] for s in shelves)
+
     return {
         'handle': user.handle,
         'display_name': user.display_name,
@@ -109,6 +111,12 @@ def build_summary(db: Session, user: DbUser, top_n: int = TOP_N) -> dict:
         'shelves': shelves,
         'total_ranked': sum(s['ranked_count'] for s in shelves),
         'onboarding_completed': user.onboarding_completed,
+        # The wizard is for empty accounts, not a one-shot flag: a user
+        # migrated or seeded with items already has something to show and
+        # must never be routed to onboarding just because the flag defaults
+        # false. Once ``onboarding_completed`` is set (finished or skipped),
+        # it stays honored even at zero items, so skipping doesn't loop.
+        'needs_onboarding': not user.onboarding_completed and total_items == 0,
     }
 
 

--- a/tests/integration/router_summary_test.py
+++ b/tests/integration/router_summary_test.py
@@ -115,6 +115,44 @@ def test_summary_is_per_user(test_client: TestClient):
     assert body['total_ranked'] == 0
 
 
+def test_needs_onboarding_true_for_empty_unfinished_account(test_client: TestClient):
+    body = test_client.get(
+        '/v1/users/me/summary', headers=_auth(test_client.first_user.token)
+    ).json()
+    assert body['onboarding_completed'] is False
+    assert body['needs_onboarding'] is True
+
+
+def test_needs_onboarding_false_once_an_item_exists(test_client: TestClient):
+    # An account with items but a still-false flag (e.g. migrated/seeded data,
+    # or pre-existing users who never ran the wizard) must not be routed into
+    # onboarding just because the flag defaults false.
+    token = test_client.first_user.token
+    _queue(test_client, token, _add_movie(test_client, 'Heat', 'tt0113277'))
+
+    body = test_client.get('/v1/users/me/summary', headers=_auth(token)).json()
+    assert body['onboarding_completed'] is False
+    assert body['needs_onboarding'] is False
+
+
+def test_needs_onboarding_false_once_flag_set_even_at_zero_items(
+    test_client: TestClient,
+):
+    # A user who skips the wizard without adding anything still flips the
+    # flag; needs_onboarding must honor that so the home <-> onboarding
+    # redirect doesn't loop.
+    token = test_client.first_user.token
+    test_client.put(
+        '/v1/users/me/preferences',
+        headers=_auth(token),
+        json={'onboarding_completed': True},
+    )
+
+    body = test_client.get('/v1/users/me/summary', headers=_auth(token)).json()
+    assert body['onboarding_completed'] is True
+    assert body['needs_onboarding'] is False
+
+
 def test_profile_public_tracks_handle_and_flags(test_client: TestClient):
     token = test_client.first_user.token
     _rank(test_client, token, _add_movie(test_client, 'Heat', 'tt0113277'), 1)


### PR DESCRIPTION
## Summary
- \`onboarding_completed\` is a one-shot flag that defaults false for every account, including pre-existing ones swept up by the migration that added it — gating the redirect on that flag alone routed any account with items but a still-false flag into onboarding.
- Add \`needs_onboarding\` to \`GET /v1/users/me/summary\`, computed from the four shelves' actual item counts (not the flag), while keeping the flag in the condition so an explicit skip at zero items doesn't loop.

## Test plan
- [x] \`pytest\` — 798 passed, including 3 new cases in \`router_summary_test.py\` (empty+unfinished, items-but-flag-false, flag-true-at-zero-items)
- [x] Verified live against local dev stack: fresh user → onboarding; user with an item added but flag false → home, not onboarding; explicit skip at zero items → no redirect loop