### PR TITLE
feat: expose total_items on the home summary

### DIFF
--- a/app/schemas/model_schemas.py
+++ b/app/schemas/model_schemas.py
@@ -318,5 +318,6 @@ class OutSummary(BaseModel):
     profile_public: bool = False
     shelves: list[OutSummaryShelf]
     total_ranked: int
+    total_items: int
     onboarding_completed: bool
     needs_onboarding: bool

--- a/app/services/summary.py
+++ b/app/services/summary.py
@@ -110,6 +110,10 @@ def build_summary(db: Session, user: DbUser, top_n: int = TOP_N) -> dict:
         and any(s['public'] for s in shelves),
         'shelves': shelves,
         'total_ranked': sum(s['ranked_count'] for s in shelves),
+        # Ranked + queued across every shelf — "has this account added
+        # anything at all," for first-run UI (onboarding, the tutorial) that
+        # should only show to genuinely empty accounts.
+        'total_items': total_items,
         'onboarding_completed': user.onboarding_completed,
         # The wizard is for empty accounts, not a one-shot flag: a user
         # migrated or seeded with items already has something to show and

--- a/tests/integration/router_summary_test.py
+++ b/tests/integration/router_summary_test.py
@@ -115,6 +115,26 @@ def test_summary_is_per_user(test_client: TestClient):
     assert body['total_ranked'] == 0
 
 
+def test_total_items_counts_ranked_and_queued_across_shelves(test_client: TestClient):
+    token = test_client.first_user.token
+    assert (
+        test_client.get('/v1/users/me/summary', headers=_auth(token)).json()[
+            'total_items'
+        ]
+        == 0
+    )
+
+    _rank(test_client, token, _add_movie(test_client, 'Heat', 'tt0113277'), 1)
+    _queue(test_client, token, _add_movie(test_client, 'Ronin', 'tt0113276'))
+
+    assert (
+        test_client.get('/v1/users/me/summary', headers=_auth(token)).json()[
+            'total_items'
+        ]
+        == 2
+    )
+
+
 def test_needs_onboarding_true_for_empty_unfinished_account(test_client: TestClient):
     body = test_client.get(
         '/v1/users/me/summary', headers=_auth(test_client.first_user.token)


### PR DESCRIPTION
## Summary
- PR #318 (merged) added `needs_onboarding` to `GET /v1/users/me/summary`. This adds the underlying `total_items` (ranked + queued across every shelf) as its own field, for other first-run UI — specifically the web tutorial modal — that needs "does this account have anything at all" without re-deriving it from the per-shelf counts.
- No behavior change to `needs_onboarding` itself; this only adds a field.

## Test plan
- [x] `pytest` — 799 passed, including a new case asserting `total_items` sums ranked + queued across shelves