### PR TITLE
Exclude ready-to-rank items from rank totals

### DIFF
--- a/app/services/summary.py
+++ b/app/services/summary.py
@@ -10,7 +10,7 @@ indexed queries per shelf, so page cost stops scaling with library size.
 
 from typing import List, Optional
 
-from sqlalchemy import case, func
+from sqlalchemy import and_, case, func
 from sqlalchemy.orm import Session
 
 from app.db.models import DbUser
@@ -24,14 +24,33 @@ TOP_N = 5
 
 
 def _counts(db: Session, shelf: Shelf, user_pk: int):
-    """Ranked and queued totals for one shelf, in a single aggregate query."""
+    """Placed, ready-to-rank, and watchlist totals in one aggregate query."""
     tracker = shelf.tracker_model
     # count() ignores NULLs, so a CASE with no ELSE counts only the matches.
     return (
         db.query(
             func.count(  # pylint: disable=not-callable
-                case((tracker.on_rankings.is_(True), 1))
+                case(
+                    (
+                        and_(
+                            tracker.on_rankings.is_(True),
+                            tracker.rank.isnot(None),
+                        ),
+                        1,
+                    )
+                )
             ).label('ranked'),
+            func.count(  # pylint: disable=not-callable
+                case(
+                    (
+                        and_(
+                            tracker.on_rankings.is_(True),
+                            tracker.rank.is_(None),
+                        ),
+                        1,
+                    )
+                )
+            ).label('ready_to_rank'),
             func.count(  # pylint: disable=not-callable
                 case((tracker.on_watchlist.is_(True), 1))
             ).label('queued'),
@@ -78,8 +97,10 @@ def build_summary(db: Session, user: DbUser, top_n: int = TOP_N) -> dict:
     """
     limit = max(1, min(top_n, TOP_N))
     shelves = []
+    ready_to_rank_total = 0
     for shelf in SHELVES:
         counts = _counts(db, shelf, user.pk)
+        ready_to_rank_total += counts.ready_to_rank
         shelves.append(
             {
                 'category': shelf.category,
@@ -96,7 +117,13 @@ def build_summary(db: Session, user: DbUser, top_n: int = TOP_N) -> dict:
             }
         )
 
-    total_items = sum(s['ranked_count'] + s['queued_count'] for s in shelves)
+    # Ready-to-rank rows are real account content, but are deliberately not a
+    # rank total until they have a position. Keep them in the zero-item test
+    # without inflating homepage, share-card, or Top-N totals.
+    total_items = (
+        sum(s['ranked_count'] + s['queued_count'] for s in shelves)
+        + ready_to_rank_total
+    )
 
     return {
         'handle': user.handle,
@@ -110,9 +137,9 @@ def build_summary(db: Session, user: DbUser, top_n: int = TOP_N) -> dict:
         and any(s['public'] for s in shelves),
         'shelves': shelves,
         'total_ranked': sum(s['ranked_count'] for s in shelves),
-        # Ranked + queued across every shelf — "has this account added
-        # anything at all," for first-run UI (onboarding, the tutorial) that
-        # should only show to genuinely empty accounts.
+        # Placed + ready-to-rank + queued across every shelf — "has this
+        # account added anything at all," for first-run UI (onboarding, the
+        # tutorial) that should only show to genuinely empty accounts.
         'total_items': total_items,
         'onboarding_completed': user.onboarding_completed,
         # The wizard is for empty accounts, not a one-shot flag: a user
@@ -126,4 +153,4 @@ def build_summary(db: Session, user: DbUser, top_n: int = TOP_N) -> dict:
 
 def profile_path(handle: Optional[str]) -> Optional[str]:
     """Canonical public-profile path for a handle (see DbUser.handle)."""
-    return f'/u/{handle}' if handle else None
+    return f"/u/{handle}" if handle else None

--- a/tests/integration/router_summary_test.py
+++ b/tests/integration/router_summary_test.py
@@ -3,7 +3,7 @@ from fastapi.testclient import TestClient
 
 
 def _auth(token: str) -> dict:
-    return {'Authorization': f'Bearer {token}'}
+    return {'Authorization': f"Bearer {token}"}
 
 
 def _add_movie(test_client: TestClient, title: str, imdb: str, year: int = 1999) -> str:
@@ -16,12 +16,12 @@ def _add_movie(test_client: TestClient, title: str, imdb: str, year: int = 1999)
 
 def _rank(test_client: TestClient, token: str, movie_id: str, position: int):
     test_client.post(
-        f'/v1/users/me/movies/{movie_id}',
+        f"/v1/users/me/movies/{movie_id}",
         headers=_auth(token),
         json={'on_rankings': True},
     )
     test_client.put(
-        f'/v1/users/me/movies/{movie_id}/rank',
+        f"/v1/users/me/movies/{movie_id}/rank",
         headers=_auth(token),
         json={'position': position},
     )
@@ -29,9 +29,17 @@ def _rank(test_client: TestClient, token: str, movie_id: str, position: int):
 
 def _queue(test_client: TestClient, token: str, movie_id: str):
     test_client.post(
-        f'/v1/users/me/movies/{movie_id}',
+        f"/v1/users/me/movies/{movie_id}",
         headers=_auth(token),
         json={'on_watchlist': True},
+    )
+
+
+def _ready_to_rank(test_client: TestClient, token: str, movie_id: str):
+    test_client.post(
+        f"/v1/users/me/movies/{movie_id}",
+        headers=_auth(token),
+        json={'on_rankings': True},
     )
 
 
@@ -62,9 +70,9 @@ def test_top_is_ranked_order_and_counts_are_separate(test_client: TestClient):
     token = test_client.first_user.token
     # Rank three, queue two.
     for i, title in enumerate(['Heat', 'Ronin', 'Sneakers'], start=1):
-        _rank(test_client, token, _add_movie(test_client, title, f'tt000{i}'), i)
+        _rank(test_client, token, _add_movie(test_client, title, f"tt000{i}"), i)
     for i, title in enumerate(['Alien', 'Aliens'], start=4):
-        _queue(test_client, token, _add_movie(test_client, title, f'tt000{i}'))
+        _queue(test_client, token, _add_movie(test_client, title, f"tt000{i}"))
 
     movies = _shelf(
         test_client.get('/v1/users/me/summary', headers=_auth(token)).json(),
@@ -76,10 +84,30 @@ def test_top_is_ranked_order_and_counts_are_separate(test_client: TestClient):
     assert movies['queued_count'] == 2
 
 
+def test_ready_to_rank_items_do_not_inflate_rank_totals(test_client: TestClient):
+    token = test_client.first_user.token
+    _rank(test_client, token, _add_movie(test_client, 'Heat', 'tt0113277'), 1)
+    _rank(test_client, token, _add_movie(test_client, 'Ronin', 'tt0122690'), 2)
+    _ready_to_rank(
+        test_client,
+        token,
+        _add_movie(test_client, 'Sneakers', 'tt0105435'),
+    )
+
+    body = test_client.get('/v1/users/me/summary', headers=_auth(token)).json()
+    movies = _shelf(body, 'movies')
+
+    assert [entry['title'] for entry in movies['top']] == ['Heat', 'Ronin']
+    assert movies['ranked_count'] == 2
+    assert body['total_ranked'] == 2
+    assert body['total_items'] == 3
+    assert body['needs_onboarding'] is False
+
+
 def test_top_is_capped_at_five(test_client: TestClient):
     token = test_client.first_user.token
     for i in range(1, 8):
-        _rank(test_client, token, _add_movie(test_client, f'Film {i}', f'tt10{i}'), i)
+        _rank(test_client, token, _add_movie(test_client, f"Film {i}", f"tt10{i}"), i)
 
     body = test_client.get('/v1/users/me/summary', headers=_auth(token)).json()
     assert len(_shelf(body, 'movies')['top']) == 5


### PR DESCRIPTION
## Summary\n\n- count only placed entries in shelf and aggregate ranked totals\n- keep ready-to-rank entries in total account content for onboarding decisions\n- add integration coverage for two placed items plus one ready-to-rank item\n\n## Verification\n\n- 800 API tests passed\n- Black, Pylint, OpenAPI validation, and security hooks passed\n- local browser verification confirmed 43 ranked remained 43 after adding one unplaced item\n\nCloses #323