### PR TITLE
feat: seed a fixed dev cast covering friend/follow/visibility positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,29 @@ what changed (`pytest-testmon`) — CI runs the full suite as the merge gate.
 pip install pre-commit && pre-commit install && pre-commit install --hook-type pre-push
 ```
 
+### Seeding local data (fixed dev cast)
+
+`task seed:dev` populates local Postgres with real catalog data plus randomized
+tracker state, and seeds a fixed cast of users covering the relationship and
+visibility positions the social features need (#313). All cast accounts share
+the dev password `change-me`:
+
+| Position | Handle | Email | Relationship to you |
+|---|---|---|---|
+| You (seed target) | `you` | `you@example.com` | public everywhere; ranks the 8-movie canon |
+| Friend | `friend` | `friend@example.com` | accepted friend; shares all 8 canon movies (`ready`) |
+| Follower | `follower` | `follower@example.com` | follows you, not followed back; shares 2 |
+| Followee | `followee` | `followee@example.com` | you follow them; books shelf friends-only (`hidden`); shares 1 |
+| Public user | `public-user` | `public@example.com` | no relationship; shares 3 |
+| Private user | `private-user` | `private@example.com` | invisible; 404s like an unknown handle |
+| Stranger | `stranger` | `stranger@example.com` | no relationship; shares 0 (`not_enough_overlap`) |
+
+The cast is additive and idempotent — re-running never duplicates a user,
+friendship, follow, or tracker row. `task seed:dev -- --wipe` clears every
+seeded tracker row (the target's randomized rows and the cast's canon rows
+alike) while leaving catalog rows, the cast users, and their relationships in
+place. See the `seed_dev.py` docstring for the full matrix.
+
 ## API reference
 
 All endpoints are prefixed with `/v1`; protected routes require `Authorization: Bearer <token>`.

--- a/app/migration/seed_dev.py
+++ b/app/migration/seed_dev.py
@@ -1,6 +1,6 @@
 """
-Populate the LOCAL dev Postgres with a realistic volume of real catalog data
-and randomized tracker state (#228).
+Populate the LOCAL dev Postgres with a realistic volume of real catalog data,
+randomized tracker state (#228), and the fixed dev cast (#313).
 
 Titles, ids, and metadata come from the checked-in fixtures
 ``app/migration/fixtures/seed_*.json`` -- real movies/shows/books/games
@@ -32,6 +32,37 @@ Usage::
     task seed:dev -- --email you@example.com       # target a non-admin local user, e.g.
                                                     # whichever account Google Sign-In
                                                     # actually created when you signed in
+
+Every run also seeds the **fixed dev cast** (#313): six accounts covering the
+relationship/visibility positions the social features (compare, sharing,
+friends' activity) need, anchored to the *target* user -- the ``--email``
+user, default the seed admin -- who becomes "you":
+
+    handle         email                 tier       relationship to you
+    ------         -----                 ----       ------------------
+    you            ADMIN_EMAIL           public     the seed target
+    friend         friend@example.com    friends    accepted friend
+    follower       follower@example.com  public     follows you, not followed back
+    followee       followee@example.com  public     you follow them; books are friends-only
+    public-user    public@example.com    public     stranger, shares 3 titles
+    private-user   private@example.com   private    invisible to everyone but themselves
+    stranger       stranger@example.com  public     no relationship, no shared titles
+
+All cast accounts share the dev password ``change-me``, so any position can
+be signed into to demo from that seat. The seeder makes the target user
+public with the handle ``you`` (required for a follower to exist), ranks eight
+real movies from ``seed_movies.json`` for them, and ranks a fixed subset of
+those same movies for each cast member -- which pins the compare states to
+known values: the friend shares all eight (``ready``), public-user three,
+follower two, followee one and stranger none (``not_enough_overlap``), and
+the followee's friends-only books shelf compares as ``hidden``. The private
+cast member 404s identically to an unknown handle.
+
+The cast is additive and idempotent: re-running never duplicates a user, a
+friendship, a follow, or a tracker row. ``--wipe`` clears every seeded tracker
+row -- the target user's randomized rows and the cast's canon rows alike --
+while leaving catalog rows, the cast users themselves, and their
+relationships in place.
 """
 
 import argparse
@@ -46,8 +77,11 @@ from urllib.parse import urlsplit
 from sqlalchemy.orm import Session
 
 from app.config import get_settings
+from app.db import db_follow
+from app.db import db_friendship
 from app.db.database import SessionLocal
-from app.db.models import DbUser
+from app.db.hash import Hash
+from app.db.models import DbFollow, DbFriendship, DbUser
 from app.db.models_sandbox import (
     DbBook,
     DbMovie,
@@ -62,6 +96,7 @@ from app.db.models_sandbox import (
 )
 from app.log.logging_config import logger
 from app.services.book_search import apply_detail_to_book
+from app.services.friendships import FriendshipStatus, canonical_pair
 from app.services.game_search import apply_detail_to_game
 from app.services.movie_search import apply_detail_to_movie
 from app.services.tv_search import apply_detail_to_show
@@ -80,6 +115,99 @@ _FIVE_YEARS_DAYS = 5 * 365
 # (ids themselves were fake, so there was no marker column to use instead).
 # Kept here only so a dev DB seeded the old way can be cleaned up once.
 _LEGACY_FAKE_ID_BASE = 900_000
+
+# --- Fixed dev cast (#313) ---------------------------------------------------
+# Six accounts covering the relationship/visibility positions the social
+# features need, anchored to the seed target ("you"). All share one password
+# so any position can be signed into. Documented in the module docstring and
+# the README; ``_seed_cast`` is what brings them to life.
+
+_CAST_PASSWORD = 'change-me'
+_TARGET_HANDLE = 'you'
+
+# The nine per-user visibility columns on ``users`` (see ``DbUser``).
+_TIER_FIELDS = (
+    'visibility_profile',
+    'visibility_movies',
+    'visibility_tv',
+    'visibility_books',
+    'visibility_games',
+    'visibility_watchlist_movies',
+    'visibility_watchlist_tv',
+    'visibility_watchlist_books',
+    'visibility_watchlist_games',
+)
+
+
+def _cast_tiers(style: str, **overrides) -> dict:
+    """All nine tier columns at ``style``, with ``overrides`` applied."""
+    return {field: overrides.get(field, style) for field in _TIER_FIELDS}
+
+
+# Eight real movies from seed_movies.json, selected by TMDB id. They form the
+# deterministic overlap canon: the target user ranks all of them and each cast
+# member ranks a fixed prefix, so shared-rank counts (and therefore the
+# comparison alignment states) are pinned to known values on every run.
+_CAST_CANON_TMDB = (157336, 603, 27205, 155, 680, 438631, 496243, 244786)
+
+_CAST_USERS = (
+    {
+        'email': 'friend@example.com',
+        'display_name': 'Friend',
+        'handle': 'friend',
+        'position': 'friend',
+        # Friends-only everywhere: from a friend's seat every shelf is visible
+        # and compares ``ready``; from anyone else the profile 404s.
+        'tiers': _cast_tiers('friends'),
+        'canon_movies': 8,
+    },
+    {
+        'email': 'follower@example.com',
+        'display_name': 'Follower',
+        'handle': 'follower',
+        'position': 'follower',
+        'tiers': _cast_tiers('public'),
+        'canon_movies': 2,
+    },
+    {
+        'email': 'followee@example.com',
+        'display_name': 'Followee',
+        'handle': 'followee',
+        'position': 'followee',
+        # Public profile with a friends-only books shelf: the one cast member
+        # whose comparison shows ``hidden`` under a visible profile.
+        'tiers': _cast_tiers('public', visibility_books='friends'),
+        'canon_movies': 1,
+    },
+    {
+        'email': 'public@example.com',
+        'display_name': 'Public User',
+        'handle': 'public-user',
+        'position': 'public',
+        'tiers': _cast_tiers('public'),
+        'canon_movies': 3,
+    },
+    {
+        'email': 'private@example.com',
+        'display_name': 'Private User',
+        'handle': 'private-user',
+        'position': 'private',
+        'tiers': _cast_tiers('private'),
+        'canon_movies': 0,
+    },
+    {
+        'email': 'stranger@example.com',
+        'display_name': 'Stranger',
+        'handle': 'stranger',
+        'position': 'stranger',
+        'tiers': _cast_tiers('public'),
+        'canon_movies': 0,
+        # Non-canon ranked movies so the profile is not empty; none of them
+        # affect the (zero) canon overlap, so the state stays
+        # ``not_enough_overlap``.
+        'extra_movies': 2,
+    },
+)
 
 
 def _assert_local_dev() -> None:
@@ -572,8 +700,193 @@ def _seed_books(session: Session, user: DbUser, rows: list) -> None:
         )
 
 
+def _claim_target_user(user: DbUser) -> None:
+    """
+    Make the seed target the anchor of the cast: public everywhere with a
+    handle, so a follower can exist and others can compare against them.
+
+    An existing handle is never clobbered -- only a ``None`` handle is
+    claimed. The tiers are re-applied every run: the cast positions are this
+    script's job to hold.
+    """
+    if user.handle is None:
+        user.handle = _TARGET_HANDLE
+    for field in _TIER_FIELDS:
+        setattr(user, field, 'public')
+
+
+def _get_or_create_cast_user(session: Session, spec: dict) -> DbUser:
+    """
+    The cast account for ``spec``, created on first sight and reused after.
+
+    Idempotent by email. The fixed handle is claimed only when the account
+    has none, and the nine tiers are re-applied every run.
+    """
+    user = session.query(DbUser).filter_by(email=spec['email']).one_or_none()
+    if user is None:
+        user = DbUser(
+            display_name=spec['display_name'],
+            email=spec['email'],
+            password=Hash.hash_password(_CAST_PASSWORD),
+            handle=spec['handle'],
+        )
+        session.add(user)
+        session.flush()
+    elif user.handle is None:
+        user.handle = spec['handle']
+    for field, tier in spec['tiers'].items():
+        setattr(user, field, tier)
+    return user
+
+
+def _cast_canon_movies() -> list:
+    """
+    The overlap canon as real fixture rows, selected by TMDB id.
+
+    A canon movie missing from a regenerated fixture is skipped with a warning
+    rather than fabricated -- the cast never invents catalog data.
+    """
+    fixture = {row['tmdb']: row for row in _load_fixture('seed_movies.json')}
+    canon = []
+    for tmdb in _CAST_CANON_TMDB:
+        row = fixture.get(tmdb)
+        if row is None:
+            logger.warning(
+                'seed_dev cast: canon movie tmdb=%d missing from fixture', tmdb
+            )
+            continue
+        canon.append(row)
+    return canon
+
+
+def _extra_cast_movies(canon: list, count: int) -> list:
+    """
+    ``count`` non-canon fixture movies, picked deterministically.
+
+    Gives a cast member a non-empty ranked shelf without shifting their canon
+    overlap count: extra movies are never added to the target user by the
+    seeder, so they cannot push a <5-canon user to ``ready`` on their own.
+    """
+    canon_tmdb = {row['tmdb'] for row in canon}
+    return [
+        row
+        for row in _load_fixture('seed_movies.json')
+        if row['tmdb'] not in canon_tmdb
+    ][:count]
+
+
+def _rank_movies(session: Session, user: DbUser, rows: list) -> int:
+    """
+    Rank each of ``rows`` for ``user`` from the first free rank onward.
+
+    Skips anything the user already tracks so seeding never overwrites an
+    existing rank. Returns how many new tracker rows were created.
+    """
+    created = 0
+    rank = _next_rank(session, DbUserMovie, user)
+    for data in rows:
+        movie = _get_or_create_movie(session, data)
+        if _already_tracked(
+            session, DbUserMovie, user.pk, DbUserMovie.movie_id, movie.pk
+        ):
+            continue
+        session.add(
+            DbUserMovie(
+                movie_id=movie.pk,
+                user_id=user.pk,
+                on_rankings=True,
+                rank=rank,
+                ranked_at=_random_past_datetime(),
+                completed=1,
+                completed_at=_random_past_date(),
+                is_seed_data=True,
+            )
+        )
+        created += 1
+        rank += 1
+    return created
+
+
+def _ensure_friendship(session: Session, requester: DbUser, other: DbUser) -> None:
+    """
+    The accepted friendship the cast matrix calls for, created once.
+
+    ``requester`` sent the request. Idempotent: an existing row -- pending or
+    accepted -- is left exactly where it is, since a row that already exists
+    was not written by this seeder run.
+    """
+    if db_friendship.friendship_between(session, requester.pk, other.pk) is not None:
+        return
+    low, high = canonical_pair(requester.pk, other.pk)
+    now = datetime.now(timezone.utc)
+    session.add(
+        DbFriendship(
+            user_low_id=low,
+            user_high_id=high,
+            requested_by_id=requester.pk,
+            status=FriendshipStatus.ACCEPTED,
+            requested_at=now,
+            responded_at=now,
+        )
+    )
+
+
+def _ensure_follow(session: Session, follower: DbUser, followee: DbUser) -> None:
+    """One asymmetric follow, created once; never duplicated."""
+    if db_follow.find(session, follower.pk, followee.pk) is None:
+        session.add(DbFollow(follower_id=follower.pk, followee_id=followee.pk))
+
+
+def _seed_cast(session: Session, target: DbUser) -> dict:
+    """
+    Create the fixed dev cast and wire their relationships (#313).
+
+    Anchored to ``target`` -- the seed's ``--email`` user, default the seed
+    admin -- who is made public with the handle ``you``, becomes the friend of
+    ``friend``, the followee of ``follower``, and follows ``followee``. The
+    eight-movie canon is ranked for the target and a fixed prefix of it for
+    each cast member, pinning the compare states; see the module docstring for
+    the full matrix.
+    """
+    _claim_target_user(target)
+    users = {
+        spec['email']: _get_or_create_cast_user(session, spec) for spec in _CAST_USERS
+    }
+
+    _ensure_friendship(session, target, users['friend@example.com'])
+    _ensure_follow(session, users['follower@example.com'], target)
+    _ensure_follow(session, target, users['followee@example.com'])
+
+    canon = _cast_canon_movies()
+    ranked = {target.pk: _rank_movies(session, target, canon)}
+    for spec in _CAST_USERS:
+        user = users[spec['email']]
+        count = _rank_movies(session, user, canon[: spec.get('canon_movies', 0)])
+        count += _rank_movies(
+            session, user, _extra_cast_movies(canon, spec.get('extra_movies', 0))
+        )
+        ranked[user.pk] = count
+    return {'cast_users': len(users), 'ranked_rows': sum(ranked.values())}
+
+
+def _existing_cast_users(session: Session) -> list:
+    """
+    The cast accounts that already exist, by their fixed emails.
+
+    ``--wipe`` wipes what is there without creating anything, so wipe looks up
+    rather than upserts.
+    """
+    emails = [spec['email'] for spec in _CAST_USERS]
+    return session.query(DbUser).filter(DbUser.email.in_(emails)).all()
+
+
 def run_seed(count: int, wipe_only: bool, email: str = None) -> dict:
-    """Wipe this script's previously-seeded tracker rows, then optionally reseed."""
+    """
+    Wipe this script's previously-seeded tracker rows, then optionally reseed.
+
+    Wipe covers the target user and the fixed dev cast alike; the cast users
+    themselves, their relationships, and catalog rows are all left in place.
+    """
     session = SessionLocal()
     try:
         purged = _purge_legacy_fake_rows(session)
@@ -583,6 +896,9 @@ def run_seed(count: int, wipe_only: bool, email: str = None) -> dict:
 
         user = _target_user(session, email)
         wiped = _wipe(session, user)
+        for cast_user in _existing_cast_users(session):
+            for key, value in _wipe(session, cast_user).items():
+                wiped[key] = wiped.get(key, 0) + value
         session.commit()
         logger.info('seed_dev: wiped previously-seeded tracker rows: %s', wiped)
         if wipe_only:
@@ -614,10 +930,15 @@ def run_seed(count: int, wipe_only: bool, email: str = None) -> dict:
                 _load_fixture('seed_books.json'), max(10, count // _BOOK_RATIO), 'books'
             ),
         )
+        cast = _seed_cast(session, user)
 
         session.commit()
         logger.info(
-            'seed_dev: populated from real-catalog fixtures (target count=%d)', count
+            'seed_dev: populated from real-catalog fixtures (target count=%d) '
+            'and cast (%d users, %d ranked rows)',
+            count,
+            cast['cast_users'],
+            cast['ranked_rows'],
         )
         return wiped
     except Exception:

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -89,7 +89,7 @@ tasks:
       - python -m app.migration.orion_import {{.CLI_ARGS}}
 
   seed:dev:
-    desc: "Populate local dev Postgres with real catalog data + randomized tracker state. Usage: task seed:dev -- --count 500 | --wipe"
+    desc: "Populate local dev Postgres with real catalog data + randomized tracker state + the fixed dev cast (#313). Usage: task seed:dev -- --count 500 | --wipe"
     cmds:
       - python -m app.migration.seed_dev {{.CLI_ARGS}}
 

--- a/tests/unit/seed_dev_test.py
+++ b/tests/unit/seed_dev_test.py
@@ -333,7 +333,8 @@ def test_seed_cast_is_idempotent(test_client):
         session.query(DbUserMovie).filter(DbUserMovie.is_seed_data.is_(True)).count()
         == 24
     )
-    assert session.query(DbMovie).count() == 8
+    # 8 canon titles plus the 2 non-canon ones stranger's shelf pulls in.
+    assert session.query(DbMovie).count() == 10
 
 
 def test_wipe_removes_cast_trackers_but_keeps_relationships(test_client):
@@ -352,8 +353,9 @@ def test_wipe_removes_cast_trackers_but_keeps_relationships(test_client):
     assert (
         session.query(DbUserMovie).filter(DbUserMovie.user_id == friend_pk).count() == 0
     )
-    # Catalog rows survive a wipe -- they are real either way.
-    assert session.query(DbMovie).count() == 8
+    # Catalog rows survive a wipe -- they are real either way. 8 canon plus
+    # the 2 non-canon titles stranger's shelf pulls in.
+    assert session.query(DbMovie).count() == 10
     # The user and the friendship row are not wiped; the relationship outlives
     # the tracker rows.
     assert session.query(DbUser).filter(DbUser.pk == friend_pk).count() == 1

--- a/tests/unit/seed_dev_test.py
+++ b/tests/unit/seed_dev_test.py
@@ -2,8 +2,12 @@
 import pytest
 
 from app.config import Settings
+from app.db import db_follow, db_friendship
+from app.db.hash import Hash
+from app.db.models import DbFollow, DbFriendship, DbUser
 from app.db.models_sandbox import DbMovie, DbTVShow, DbUserMovie, DbUserTVShow
 from app.migration import seed_dev
+from app.services.friendships import FriendshipStatus
 
 _MOVIE_A = {
     'title': 'Interstellar',
@@ -211,6 +215,214 @@ def test_run_seed_wipe_only_does_not_reseed(test_client, monkeypatch):
     assert (
         session.query(DbUserMovie).filter(DbUserMovie.user_id == user.pk).count() == 0
     )
+
+
+def _cast_user(session, email):
+    return session.query(DbUser).filter_by(email=email).one()
+
+
+def test_seed_cast_creates_fixed_users_and_relationships(test_client):
+    session = test_client.test_db_session
+    target = test_client.first_user
+
+    result = seed_dev._seed_cast(session, target)
+    session.commit()
+
+    assert result['cast_users'] == 6
+    assert result['ranked_rows'] == 24
+
+    friend = _cast_user(session, 'friend@example.com')
+    assert friend.handle == 'friend'
+    assert friend.visibility_profile == 'friends'
+    assert Hash.verify(friend.password, seed_dev._CAST_PASSWORD)
+
+    follower = _cast_user(session, 'follower@example.com')
+    followee = _cast_user(session, 'followee@example.com')
+    public_user = _cast_user(session, 'public@example.com')
+    private_user = _cast_user(session, 'private@example.com')
+    stranger = _cast_user(session, 'stranger@example.com')
+
+    # The target is the anchor: public everywhere with the fixed handle.
+    assert target.handle == seed_dev._TARGET_HANDLE
+    assert target.visibility_profile == 'public'
+
+    # target and friend are accepted friends, requested by the target.
+    friendship = db_friendship.friendship_between(session, target.pk, friend.pk)
+    assert friendship is not None
+    assert friendship.requested_by_id == target.pk
+    assert friendship.status == FriendshipStatus.ACCEPTED
+
+    # Exactly the two matrix follows: follower -> target and target -> followee.
+    assert db_follow.find(session, follower.pk, target.pk) is not None
+    assert db_follow.find(session, target.pk, follower.pk) is None
+    assert db_follow.find(session, target.pk, followee.pk) is not None
+    assert db_follow.find(session, followee.pk, target.pk) is None
+    assert session.query(DbFollow).count() == 2
+
+    # Per-member visibility tiers.
+    assert followee.visibility_profile == 'public'
+    assert followee.visibility_books == 'friends'
+    assert public_user.visibility_profile == 'public'
+    assert private_user.visibility_profile == 'private'
+    assert stranger.visibility_profile == 'public'
+
+
+def test_seed_cast_ranks_the_canon_movies(test_client):
+    session = test_client.test_db_session
+    target = test_client.first_user
+
+    seed_dev._seed_cast(session, target)
+    session.commit()
+
+    assert (
+        session.query(DbMovie)
+        .filter(DbMovie.tmdb.in_(seed_dev._CAST_CANON_TMDB))
+        .count()
+        == 8
+    )
+
+    def ranked(user):
+        return {
+            t.movie_id
+            for t in session.query(DbUserMovie).filter(
+                DbUserMovie.user_id == user.pk,
+                DbUserMovie.on_rankings.is_(True),
+                DbUserMovie.is_seed_data.is_(True),
+            )
+        }
+
+    target_canon = ranked(target)
+    assert len(target_canon) == 8
+    assert ranked(_cast_user(session, 'friend@example.com')) == target_canon
+    assert len(ranked(_cast_user(session, 'follower@example.com'))) == 2
+    assert len(ranked(_cast_user(session, 'public@example.com'))) == 3
+    assert len(ranked(_cast_user(session, 'followee@example.com'))) == 1
+    # stranger: zero canon overlap, but a couple of non-canon ranks so the
+    # profile is not empty -- that keeps the compare state not_enough_overlap.
+    stranger = _cast_user(session, 'stranger@example.com')
+    stranger_ranked = ranked(stranger)
+    assert len(stranger_ranked) == 2
+    assert not stranger_ranked & target_canon
+    assert (
+        session.query(DbUserMovie)
+        .filter(DbUserMovie.user_id == stranger.pk, DbUserMovie.is_seed_data.is_(True))
+        .count()
+        == 2
+    )
+
+
+def test_seed_cast_is_idempotent(test_client):
+    session = test_client.test_db_session
+    target = test_client.first_user
+
+    seed_dev._seed_cast(session, target)
+    session.commit()
+    second = seed_dev._seed_cast(session, target)
+    session.commit()
+
+    assert second == {'cast_users': 6, 'ranked_rows': 0}
+    assert (
+        session.query(DbUser)
+        .filter(DbUser.email.in_([s['email'] for s in seed_dev._CAST_USERS]))
+        .count()
+        == 6
+    )
+    assert session.query(DbFriendship).count() == 1
+    assert session.query(DbFollow).count() == 2
+    assert (
+        session.query(DbUserMovie).filter(DbUserMovie.is_seed_data.is_(True)).count()
+        == 24
+    )
+    assert session.query(DbMovie).count() == 8
+
+
+def test_wipe_removes_cast_trackers_but_keeps_relationships(test_client):
+    session = test_client.test_db_session
+    target = test_client.first_user
+
+    seed_dev._seed_cast(session, target)
+    session.commit()
+
+    friend = _cast_user(session, 'friend@example.com')
+    friend_pk = friend.pk
+    wiped = seed_dev._wipe(session, friend)
+    session.commit()
+
+    assert wiped['movies'] == 8
+    assert (
+        session.query(DbUserMovie).filter(DbUserMovie.user_id == friend_pk).count() == 0
+    )
+    # Catalog rows survive a wipe -- they are real either way.
+    assert session.query(DbMovie).count() == 8
+    # The user and the friendship row are not wiped; the relationship outlives
+    # the tracker rows.
+    assert session.query(DbUser).filter(DbUser.pk == friend_pk).count() == 1
+    assert (
+        session.query(DbFriendship)
+        .filter(
+            (DbFriendship.user_low_id == friend_pk)
+            | (DbFriendship.user_high_id == friend_pk)
+        )
+        .count()
+        == 1
+    )
+
+
+def test_run_seed_seeds_cast_alongside_target(test_client, monkeypatch):
+    session = test_client.test_db_session
+    user = test_client.first_user
+
+    monkeypatch.setattr(seed_dev, 'SessionLocal', lambda: session)
+    monkeypatch.setattr(session, 'close', lambda: None)
+
+    seed_dev.run_seed(count=5, wipe_only=False, email=user.email)
+
+    assert user.handle == seed_dev._TARGET_HANDLE
+    assert user.visibility_profile == 'public'
+    friend = _cast_user(session, 'friend@example.com')
+    friendship = db_friendship.friendship_between(session, user.pk, friend.pk)
+    assert friendship is not None
+    assert friendship.status == FriendshipStatus.ACCEPTED
+    # The full 8-movie canon landed on the target regardless of the randomized
+    # sample run_seed drew for the ordinary seed path.
+    assert (
+        session.query(DbUserMovie)
+        .join(DbMovie, DbUserMovie.movie_id == DbMovie.pk)
+        .filter(
+            DbUserMovie.user_id == user.pk,
+            DbMovie.tmdb.in_(seed_dev._CAST_CANON_TMDB),
+            DbUserMovie.is_seed_data.is_(True),
+        )
+        .count()
+        == 8
+    )
+    assert (
+        session.query(DbUserMovie).filter(DbUserMovie.user_id == friend.pk).count() == 8
+    )
+
+
+def test_run_seed_wipe_only_clears_cast_trackers_too(test_client, monkeypatch):
+    session = test_client.test_db_session
+    user = test_client.first_user
+    seed_dev._seed_cast(session, user)
+    session.commit()
+
+    monkeypatch.setattr(seed_dev, 'SessionLocal', lambda: session)
+    monkeypatch.setattr(session, 'close', lambda: None)
+
+    seed_dev.run_seed(count=5, wipe_only=True, email=user.email)
+
+    assert (
+        session.query(DbUserMovie).filter(DbUserMovie.user_id == user.pk).count() == 0
+    )
+    friend = _cast_user(session, 'friend@example.com')
+    assert (
+        session.query(DbUserMovie).filter(DbUserMovie.user_id == friend.pk).count() == 0
+    )
+    # The cast users and their relationships are left in place.
+    assert session.query(DbUser).filter(DbUser.email == friend.email).count() == 1
+    assert session.query(DbFriendship).count() == 1
+    assert session.query(DbFollow).count() == 2
 
 
 def test_assert_local_dev_refuses_when_database_url_overrides_safe_postgres_host(


### PR DESCRIPTION
## Summary

- Demoing a social rule meant hand-building accounts every time, so most
  demos were driven from the admin seat — which is public, friendly with
  everyone, and holds the whole catalog. That is exactly the seat where a
  broken visibility or comparison rule still renders correctly.
- Seeds six fixed accounts covering the relationship and visibility
  positions the social features have: `friend`, `follower`, `followee`,
  `public-user`, `private-user`, `stranger`, anchored to the seed target
  (`you`). All share the password `change-me`.
- Shelf sizes pin the comparison states rather than being arbitrary: the
  friend shares all eight canon titles (`ready`), and the rest sit under the
  five shared titles alignment needs (`not_enough_overlap`). The followee's
  friends-only books shelf is the one case of `hidden` under a *visible*
  profile.
- Additive and idempotent: re-running never duplicates a user, a friendship,
  a follow or a tracker row. `--wipe` clears tracker rows but leaves the
  accounts and their relationships, so the seats survive a data reset.
- Refuses to run against anything but the local dev Postgres, so the fixed
  password can never reach an environment where it matters.

## Test plan

- [x] `pytest` — 806 passed on this branch.
- [x] `tests/unit/seed_dev_test.py` covers user/relationship creation, the
      canon rank distribution, idempotency across two runs, and that `--wipe`
      removes tracker rows while keeping relationships.
- [x] **Fixed two assertions that shipped red**: both said the catalog holds
      8 movies (the canon), but `stranger`'s shelf ranks two non-canon titles
      on top, so it holds 10. The tests were written alongside the seeder and
      never executed.
- [x] Verified against the local dev stack: `/friends` → `friend`,
      `/followers` → `follower`, `/following` → `followee`; comparison
      returns 200 for public/stranger/friend and 404
      `"No visible profile here"` for `private-user`.

Closes #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbKoJGaf4JNae57XqdtHfu
