### PR TITLE
chore: document 5-tier priority scale (P1-P5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,4 @@
+<!-- BEGIN:druthers-workflow -->
 ## Development workflow
 
 New functionality gets demoed locally and approved by Adam **before** anything
@@ -9,10 +10,47 @@ is committed. Applies to all the druthers repos (`druthers-api`,
    (TMDB, TVMaze, Open Library, IGDB), not just mocks and unit tests.
 2. **Test in browser & demo with local URL + visuals.**
    Use the browser subagent to interactively test new web functionality on the
-   local dev stack. Present a local URL (e.g. `http://localhost:3000/u/dadam` or
-   `http://localhost:3000/movies/<id>`), a list of what to look for, embedded
-   screenshots for visual review, and session recording videos (`.webp`) for
-   complex/important UX flows. Stop and wait for Adam's approval.
+   local dev stack, then embed screenshots for visual review and session
+   recording videos (`.webp`) for complex/important UX flows. Stop and wait for
+   Adam's approval.
+
+   **Write the demo as steps Adam can follow, not as a report of what you
+   saw.** One block per delivered item — per issue, per PR, per distinct
+   change — never one merged narrative for the batch. A batch of three gets
+   three blocks. Each block gives, in this order:
+
+   1. **Sign in as** — the exact account *and* password, e.g.
+      `follower@example.com` / `change-me`. Every item states its own, even
+      when three in a row use the same seat; "as above" costs a scroll and
+      breaks if the blocks get reordered. If the item is only reachable from
+      the admin seat, say so and say why. For `$ADMIN_EMAIL` /
+      `$ADMIN_PASSWORD`, name the variables and point at `env/dev.env` rather
+      than pasting the values.
+   2. **Go to** — a full clickable URL, not a route fragment.
+      `http://localhost:3000/tv/schedule`, not "the schedule page".
+   3. **Do this** — the numbered clicks, in order, including any setup the
+      screen does not imply (which env the bundle was built for, a preference
+      that has to be set first, a reload needed because the value is
+      server-rendered).
+   4. **You should see** — the specific observable, with the value that makes
+      it checkable. "Day heading reads `Today — Sunday, 08/09`", not "dates
+      look right". If a number is the proof, quote the number.
+   5. **What it looked like before** — one line, when the change is a fix.
+      A corrected greeting is indistinguishable from a working one in a
+      screenshot; the reviewer needs to know what they are no longer seeing.
+
+   Anything a reviewer would have to discover by trial and error belongs in
+   the steps: a rate limit that bites on repeated sign-ins, a seat that
+   renders nothing in `dev`, data that had to be inserted by hand and will not
+   survive a reseed. State it in the block, not in a footnote.
+
+   **Demo from the seat the change applies to.** `druthers-api/docs/dev-cast.md`
+   lists the seeded local accounts — friend, follower, followee, public,
+   private, stranger — with their credentials, what each one is for, and which
+   to reach for per kind of change. Driving everything as the admin user is the
+   single most common way a broken visibility or comparison rule still demos
+   green: that seat is public, friendly with everyone, and holds the whole
+   catalog.
 3. **Only after Adam approves:** spin the local environment down
    (`task dd -- dev` in `druthers-api`), then commit, push, and open the PR.
 4. **Hand back the PR link.** Merging, releasing, and deploying stay separate
@@ -22,13 +60,42 @@ is committed. Applies to all the druthers repos (`druthers-api`,
    branch is silently inherited by the next session, which either builds new
    work on top of dead history or has to spend a turn untangling it first.
 
-Do not commit or open a PR ahead of the demo, even when tests and CI would
+Do not push or open a PR ahead of the demo, even when tests and CI would
 pass. The approval gate is the demo, not the green build.
+
+**Exception, and it is not really one:** a fleet worker commits to its own
+isolated branch in its own worktree (see below). That branch reaches nobody
+until the orchestrator pushes it after Adam approves, so committing there is
+not shipping — it is how the work is handed over. The rule above governs
+`push` and `gh pr create`, which only the orchestrator runs.
 
 Before starting new work in any of these repos, check `git branch --show-current`
 and `git status` first — don't assume the checkout is `main` or clean.
 
-### Issue vs. PR numbers
+### Working as a fleet worker
+
+When dispatched by `druthers-infra/fleet`, you are one of several agents
+working in parallel, each in its own git worktree. Additional rules apply:
+
+- **Never start the local dev stack.** Ports 5432/8000/3000 and the Docker
+  compose project belong to the orchestrator, which runs the batched demo.
+  Starting them collides with other workers and with the demo.
+- **Write tests, do not run them.** Author the test files your change
+  requires (see Testing below), but leave `pytest`/`vitest`/`lint` to the
+  orchestrator's post-approval sweep. A worker that runs the suite burns
+  budget re-proving what the sweep will prove anyway.
+- **Stay in your worktree.** Do not touch other branches, other repos, or
+  anything outside the issue you were dispatched for. Out-of-scope problems
+  you notice go in `WORKER_REPORT.md`, not in the diff.
+- **Commit on your branch** in the house format, then stop. This is required,
+  not optional: uncommitted work in a worktree is invisible to the fleet and
+  gets discarded. The demo-approval rule above governs pushing and opening
+  PRs, both of which are the orchestrator's job — not your commit.
+- **Leave a `WORKER_REPORT.md`** at the worktree root: what you changed, what
+  you could not verify, what the demo should look at, and any decision you
+  made that the issue did not settle.
+
+## Issue vs. PR numbers
 
 GitHub issue numbers and PR numbers share one repo-wide counter, so a bare
 number is ambiguous — `289` could be either, and groomed backlog stories from
@@ -56,6 +123,32 @@ actually in the code:
   PR that was supposed to deliver it actually merged — don't assume "closed"
   means "done," and don't assume a dependency is real work remaining without
   checking whether it already shipped under a different PR.
+
+## Issue and PR format
+
+Issues follow the forms in `.github/ISSUE_TEMPLATE/` — Story, Problem,
+Acceptance Criteria, Context, Channel Impact, and an Estimate block carrying
+**Recommended model** and **Human effort**. The fleet dispatcher routes work
+off that Estimate block, so it is not decoration.
+
+Every issue also carries exactly one `priority:p1`–`priority:p5` label
+(applied via labels/project board, not the template body):
+
+- **P1** — immediate build; prod or the build is broken.
+- **P2** — high value, time-sensitive.
+- **P3** — chores, done as time permits (default when urgency is unstated).
+- **P4** — backlog / nice-to-have; low urgency and low value.
+- **P5** — roadmap: big, high-value, long-term, not an immediate need.
+
+PRs follow `.github/PULL_REQUEST_TEMPLATE.md`:
+
+- **`## Summary`** — bullets that lead with the cause, then the fix. Not a
+  changelog of files touched. Call out what does *not* change when that is
+  load-bearing.
+- **`## Test plan`** — checked boxes with real evidence: actual pass counts,
+  the specific cases added, and what was verified against the local dev stack.
+- Closing keywords repeated per issue (`Closes #a. Closes #b.`), never the
+  comma form.
 
 ## Testing
 
@@ -90,6 +183,7 @@ and were never revisited.
   not just won't get reviewed. Until then, treat a red `test`/`lint` run as
   a hard blocker anyway; the check not being enforced yet isn't permission
   to ignore it.
+<!-- END:druthers-workflow -->
 
 ## Python formatting
 
@@ -102,8 +196,11 @@ and force an extra fix-and-recommit round trip.
 
 ## graphify
 
-This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+This project has a knowledge graph at graphify-out/ with god nodes, community
+structure, and cross-file relationships.
 
 Rules:
-- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
-- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when
+  query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current
+  (AST-only, no API cost).


### PR DESCRIPTION
## Summary
- Priority labels are moving from p1-p3 to a 5-tier scale: P3 stays chores,
  P4 is backlog/nice-to-have, P5 is long-term roadmap. Labels and the
  project board's Priority field were already updated live.
- AGENTS.md's shared workflow block was also behind the canonical template
  in druthers-infra (fleet/templates/agents-workflow.md), so this sync
  picks up the demo-steps rewrite from that template too, not just the
  priority section.

## Test plan
- [x] Docs-only change; no tests apply.
- [x] Verified `priority:p4`/`priority:p5` labels and Project board options
      exist via `gh api` before opening this PR.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0184A7gvLuYd1sX8Z5yxNcRn