### PR TITLE
Add a users search endpoint for public profiles and friends

### DIFF
--- a/app/db/db_user.py
+++ b/app/db/db_user.py
@@ -8,6 +8,7 @@ from email_validator import EmailNotValidError, validate_email
 from fastapi import HTTPException, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
+from sqlalchemy import or_
 
 from app.db.hash import Hash
 from app.db.models import DbUser
@@ -238,3 +239,37 @@ def delete_user(db: Session, user_id: str) -> list[DbUser]:
     response = []
     response.append(user)
     return response
+
+
+def search_users(
+    db: Session, current_user_pk: int, query: str, limit: int = 20
+) -> list[DbUser]:
+    """
+    Search users by handle or display name, case-insensitive.
+    Returns only public profiles and accepted friends.
+    """
+    if not query:
+        return []
+
+    # pylint: disable=import-outside-toplevel
+    from app.db.db_friendship import friend_pks
+    from app.services.visibility import VisibilityTier
+
+    f_pks = friend_pks(db, current_user_pk)
+    q_str = f"%{query}%"
+
+    return (
+        db.query(DbUser)
+        .filter(
+            or_(
+                DbUser.display_name.ilike(q_str),
+                DbUser.handle.ilike(q_str),
+            ),
+            or_(
+                DbUser.visibility_profile == VisibilityTier.PUBLIC.value,
+                DbUser.pk.in_(f_pks),
+            ),
+        )
+        .limit(limit)
+        .all()
+    )

--- a/app/router/v1/router_search.py
+++ b/app/router/v1/router_search.py
@@ -16,6 +16,8 @@ from sqlalchemy.orm import Session
 
 from app.auth.oauth2 import get_current_user
 from app.db.database import get_db
+from app.db.db_user import search_users
+from app.schemas.model_schemas import OutUserSearchResponse
 from app.schemas.schemas_sandbox import GlobalSearchResponse
 from app.services.rate_limit import search_rate_limit
 from app.services.book_search import search_books
@@ -95,3 +97,22 @@ def global_search(
     for domain, hits in results.items():
         attach_tracked_status(db, user_pk, hits, domain)
     return GlobalSearchResponse(query=q, corrected=corrected, **results)
+
+
+@router.get(
+    '/search/users',
+    response_model=OutUserSearchResponse,
+    dependencies=[Depends(search_rate_limit)],
+)
+def search_users_route(
+    q: str,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    if not q or not q.strip():
+        return OutUserSearchResponse(query=q, corrected=None, users=[])
+
+    user_pk = current_user[0].pk
+    hits = search_users(db, user_pk, q.strip(), limit=20)
+
+    return OutUserSearchResponse(query=q, corrected=None, users=hits)

--- a/app/schemas/model_schemas.py
+++ b/app/schemas/model_schemas.py
@@ -271,6 +271,24 @@ class OutFollow(BaseModel):
     followed_at: datetime
 
 
+class OutUserSearchResult(BaseModel):
+    """One user returned from search."""
+
+    id: str
+    display_name: str
+    handle: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class OutUserSearchResponse(BaseModel):
+    """Response shape for user search, mirroring GlobalSearchResponse."""
+
+    query: str
+    corrected: Optional[str] = None
+    users: list[OutUserSearchResult]
+
+
 class InPreferencesUpdate(BaseModel):
     """Request body for display preferences (#122). Only sent fields change."""
 

--- a/tests/integration/router_search_users_test.py
+++ b/tests/integration/router_search_users_test.py
@@ -1,0 +1,96 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+from fastapi.testclient import TestClient
+from app.db.models import DbFriendship
+from app.services.friendships import FriendshipStatus
+from app.services.visibility import VisibilityTier
+
+
+def test_user_search_requires_auth(test_client: TestClient):
+    assert test_client.get('/v1/search/users?q=bob').status_code == 401
+
+
+def test_user_search_empty_query(test_client: TestClient):
+    headers = {'Authorization': f'Bearer {test_client.first_user.token}'}
+    resp = test_client.get('/v1/search/users?q=', headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['query'] == ''
+    assert data['users'] == []
+
+
+def test_user_search_visibility(test_client: TestClient, test_create_user):
+    headers = {'Authorization': f'Bearer {test_client.first_user.token}'}
+    db = test_client.test_db_session
+
+    users = test_create_user(test_client, user_count=4)
+    public_user = users[0]
+    friend_user = users[1]
+    private_user = users[2]
+    stranger_public = users[3]
+
+    # set public_user to public
+    public_user.visibility_profile = VisibilityTier.PUBLIC.value
+    public_user.display_name = 'Charlie Public'
+    public_user.handle = 'charlie'
+
+    # friend_user is private, but friends with first_user
+    friend_user.visibility_profile = VisibilityTier.PRIVATE.value
+    friend_user.display_name = 'Charlie Friend'
+
+    db.add(
+        DbFriendship(
+            user_low_id=min(test_client.first_user.pk, friend_user.pk),
+            user_high_id=max(test_client.first_user.pk, friend_user.pk),
+            requested_by_id=friend_user.pk,
+            status=FriendshipStatus.ACCEPTED,
+        )
+    )
+
+    # private_user is private, not friends
+    private_user.visibility_profile = VisibilityTier.PRIVATE.value
+    private_user.display_name = 'Charlie Private'
+
+    # stranger_public is public, not friends
+    stranger_public.visibility_profile = VisibilityTier.PUBLIC.value
+    stranger_public.display_name = 'Bob Public'
+
+    db.commit()
+
+    # search for 'Charlie'
+    resp = test_client.get('/v1/search/users?q=Charlie', headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['query'] == 'Charlie'
+    users_returned = data['users']
+
+    ids = [u['id'] for u in users_returned]
+    # Should find Charlie Public and Charlie Friend, NOT Charlie Private.
+    assert public_user.id in ids
+    assert friend_user.id in ids
+    assert private_user.id not in ids
+
+    # Should not find Bob Public (doesn't match query)
+    assert stranger_public.id not in ids
+
+    # search for 'Bob'
+    resp2 = test_client.get('/v1/search/users?q=Bob', headers=headers)
+    assert resp2.status_code == 200
+    assert len(resp2.json()['users']) == 1
+    assert resp2.json()['users'][0]['id'] == stranger_public.id
+
+
+def test_user_search_anti_enumeration(test_client: TestClient, test_create_user):
+    headers = {'Authorization': f'Bearer {test_client.first_user.token}'}
+    db = test_client.test_db_session
+
+    users = test_create_user(test_client, user_count=1)
+    secret_user = users[0]
+    secret_user.visibility_profile = VisibilityTier.PRIVATE.value
+    secret_user.display_name = 'TopSecretName'
+    db.commit()
+
+    # Search specifically for the secret user
+    resp = test_client.get('/v1/search/users?q=TopSecretName', headers=headers)
+    assert resp.status_code == 200
+    # Should be empty, meaning existence is not revealed
+    assert resp.json()['users'] == []


### PR DESCRIPTION
## Summary

- The web app's People search (ALeonard9/druthers-web#191) had no endpoint to call. Adds `GET /v1/search/users`, returning users whose `display_name` or `handle` matches a case-insensitive query.
- **Visibility is enforced in SQL, not filtered after the fact:** the query returns public profiles plus the caller's accepted friends and nothing else, so a private profile or a stranger is never loaded, let alone serialised.
- **Anti-enumeration is the point, not a side effect.** A query naming a private user returns the same empty list as a query naming nobody at all, so the endpoint cannot be used to discover which handles exist — the property epic #272 built the rest of the sharing surface around.
- Response mirrors `GlobalSearchResponse` as `{query, corrected, users}` so the web companion parses People results the same way it parses catalog results. Capped at 20, matching the 4 domains × 5 the existing global search returns.
- Authentication is required: there is no anonymous user search.

## Test plan

- [x] `pytest -q` — 842 tests pass.
- [x] `pre-commit run --all-files` — black, pylint, openapi-spec-validator, and the rest all pass.
- [x] Added `tests/integration/router_search_users_test.py`, 4 tests: visibility filtering (a matching public profile and a matching private friend are returned; a matching private stranger and non-matching public profiles are not); anti-enumeration (querying a private profile's exact handle yields `[]`); empty `q=` short-circuits to `[]` without a lookup; unauthenticated requests get 401.
- [x] Verified against the local dev stack using the seeded cast from #313, which has exactly one accepted friendship (`you` ↔ `friend`) and `friend` set to `visibility_profile='friends'` — so this distinguishes the tier check firing from a fixture coincidence:

  | caller | query | result |
  |---|---|---|
  | admin (friends with `friend`) | `friend` | `[{"display_name":"Friend","handle":"friend"}]` |
  | `stranger@example.com` (not friends) | `friend` | `[]` |
  | either | `private` | `[]` |
  | admin | `public` | `[{"display_name":"Public User","handle":"public-user"}]` |
  | unauthenticated | `public` | `401` |
  | admin | *(empty)* | `[]` |

Closes #315.
