### PR TITLE
Add an authorization/IDOR test pass on sharing and visibility

### DIFF
--- a/tests/integration/router_follows_test.py
+++ b/tests/integration/router_follows_test.py
@@ -124,6 +124,49 @@ def test_following_is_asymmetric(test_client: TestClient):
     )
 
 
+def test_follow_lists_and_deletion_are_scoped_to_the_caller(test_client: TestClient):
+    """
+    Knowing another user's follow id or followee handle must not expose the
+    row through an outsider's lists or let the outsider delete it.
+    """
+    _claim_public_handle(test_client, test_client.second_user.token, 'blake')
+    created = test_client.put(
+        '/v1/users/me/following/blake', headers=_auth(test_client.first_user.token)
+    )
+    assert created.status_code == 200
+    follow_id = created.json()['id']
+    outsider = test_client.admin_user.token
+
+    assert (
+        test_client.get('/v1/users/me/following', headers=_auth(outsider)).json() == []
+    )
+    assert (
+        test_client.get('/v1/users/me/followers', headers=_auth(outsider)).json() == []
+    )
+    assert (
+        test_client.delete(
+            '/v1/users/me/following/blake', headers=_auth(outsider)
+        ).status_code
+        == 404
+    )
+    assert (
+        test_client.delete(
+            f'/v1/users/me/following/{follow_id}', headers=_auth(outsider)
+        ).status_code
+        == 404
+    )
+
+    following = test_client.get(
+        '/v1/users/me/following', headers=_auth(test_client.first_user.token)
+    ).json()
+    assert [row['id'] for row in following] == [follow_id]
+    assert is_following(
+        test_client.test_db_session,
+        test_client.first_user.pk,
+        test_client.second_user.pk,
+    )
+
+
 def test_following_requires_no_approval(test_client: TestClient):
     """Unlike a friend request, the row exists immediately — no accept step."""
     _claim_public_handle(test_client, test_client.second_user.token, 'blake')

--- a/tests/integration/router_friends_test.py
+++ b/tests/integration/router_friends_test.py
@@ -306,6 +306,81 @@ def test_each_side_gets_only_its_own_verb(test_client: TestClient):
     )
 
 
+def test_an_outsider_cannot_read_or_mutate_another_pairs_request(
+    test_client: TestClient,
+):
+    """
+    A leaked or guessed request id gives an uninvolved user no pending data
+    and no accept, decline, cancel, or unfriend path into the pair's row.
+    """
+    _claim_handle(test_client, test_client.second_user.token, 'blake')
+    sender = test_client.first_user.token
+    recipient = test_client.second_user.token
+    outsider = test_client.admin_user.token
+    assert _send(test_client, sender, 'blake').status_code == 202
+    request_id = test_client.get(
+        '/v1/users/me/friends/requests', headers=_auth(sender)
+    ).json()['outgoing'][0]['id']
+
+    assert test_client.get(
+        '/v1/users/me/friends/requests', headers=_auth(outsider)
+    ).json() == {'incoming': [], 'outgoing': []}
+
+    for suffix in ('accept', 'decline'):
+        guessed = test_client.put(
+            f'/v1/users/me/friends/requests/{request_id}/{suffix}',
+            headers=_auth(outsider),
+        )
+        nonexistent = test_client.put(
+            f'/v1/users/me/friends/requests/not-a-real-id/{suffix}',
+            headers=_auth(outsider),
+        )
+        assert guessed.status_code == nonexistent.status_code == 404
+        assert guessed.json() == nonexistent.json()
+
+    guessed_cancel = test_client.delete(
+        f'/v1/users/me/friends/requests/{request_id}', headers=_auth(outsider)
+    )
+    nonexistent_cancel = test_client.delete(
+        '/v1/users/me/friends/requests/not-a-real-id', headers=_auth(outsider)
+    )
+    assert guessed_cancel.status_code == nonexistent_cancel.status_code == 404
+    assert guessed_cancel.json() == nonexistent_cancel.json()
+
+    assert (
+        test_client.delete(
+            f'/v1/users/me/friends/{request_id}', headers=_auth(outsider)
+        ).status_code
+        == 404
+    )
+    pending = test_client.get(
+        '/v1/users/me/friends/requests', headers=_auth(recipient)
+    ).json()
+    assert [row['id'] for row in pending['incoming']] == [request_id]
+
+
+def test_an_outsider_cannot_unfriend_another_pair_by_id(test_client: TestClient):
+    friendship_id = _become_friends(test_client)
+    outsider = test_client.admin_user.token
+
+    guessed = test_client.delete(
+        f'/v1/users/me/friends/{friendship_id}', headers=_auth(outsider)
+    )
+    nonexistent = test_client.delete(
+        '/v1/users/me/friends/not-a-real-id', headers=_auth(outsider)
+    )
+    assert guessed.status_code == nonexistent.status_code == 404
+    assert guessed.json() == nonexistent.json()
+    assert test_client.get('/v1/users/me/friends', headers=_auth(outsider)).json() == []
+    for token in (test_client.first_user.token, test_client.second_user.token):
+        assert [
+            row['id']
+            for row in test_client.get(
+                '/v1/users/me/friends', headers=_auth(token)
+            ).json()
+        ] == [friendship_id]
+
+
 def test_either_side_can_unfriend(test_client: TestClient):
     friendship_id = _become_friends(test_client)
     # The recipient of the original request ends it.

--- a/tests/integration/router_visibility_test.py
+++ b/tests/integration/router_visibility_test.py
@@ -271,6 +271,43 @@ def test_partial_updates_only_touch_sent_fields(test_client: TestClient):
     assert body['visibility_games'] == 'friends'
 
 
+def test_visibility_update_cannot_be_redirected_to_another_user(
+    test_client: TestClient,
+):
+    """
+    Guessed account identifiers in the body must not turn the ``me`` route
+    into a mass-assignment path for somebody else's visibility row.
+    """
+    victim_token = test_client.first_user.token
+    attacker_token = test_client.second_user.token
+    victim_before = test_client.get(
+        '/v1/users/me/visibility', headers=_auth(victim_token)
+    ).json()
+
+    attempted = test_client.put(
+        '/v1/users/me/visibility',
+        headers=_auth(attacker_token),
+        json={
+            'id': test_client.first_user.id,
+            'user_id': test_client.first_user.id,
+            'user_pk': test_client.first_user.pk,
+            'handle': 'attacker',
+            'visibility_profile': 'public',
+        },
+    )
+
+    # Ignoring unknown selectors and rejecting them are both safe. The
+    # authorization property is that neither outcome targets the victim.
+    assert attempted.status_code in (200, 422), attempted.text
+    if attempted.status_code == 200:
+        assert attempted.json()['handle'] == 'attacker'
+        assert attempted.json()['visibility_profile'] == 'public'
+    assert (
+        test_client.get('/v1/users/me/visibility', headers=_auth(victim_token)).json()
+        == victim_before
+    )
+
+
 def test_public_profile_exposes_only_public_ranked_lists(test_client: TestClient):
     token = test_client.first_user.token
     _rank_a_movie(test_client, token)

--- a/tests/integration/router_visibility_viewer_test.py
+++ b/tests/integration/router_visibility_viewer_test.py
@@ -248,6 +248,46 @@ def test_a_public_watchlist_cannot_outrun_its_private_shelf(profile: TestClient)
     ]
 
 
+# --- Direct shelf references ------------------------------------------------
+
+
+def test_a_named_shelf_does_not_bypass_the_viewers_tier(
+    profile: TestClient, stranger_token
+):
+    """
+    Guessing a valid handle and shelf slug must go through the same ceiling
+    as the profile hub: strangers cannot fetch friends shelves, and friends
+    cannot fetch private ones.
+    """
+    attempts = (
+        (stranger_token, 'tv', 'Ranked tv-shows'),
+        (profile.second_user.token, 'games', 'Ranked games'),
+    )
+    for token, shelf, secret_title in attempts:
+        denied = profile.get(f'/v1/public/{HANDLE}?shelf={shelf}', headers=_auth(token))
+        nonexistent = profile.get(
+            f'/v1/public/{HANDLE}?shelf=not-a-shelf', headers=_auth(token)
+        )
+        assert _fingerprint(denied) == _fingerprint(nonexistent)
+        assert secret_title not in str(denied.json())
+
+
+def test_a_named_public_shelf_still_redacts_private_tracker_data(
+    profile: TestClient, stranger_token
+):
+    """Public means the ranked item, not the owner's tracker row or notes."""
+    response = profile.get(
+        f'/v1/public/{HANDLE}?shelf=movies', headers=_auth(stranger_token)
+    )
+    assert response.status_code == 200
+    shelf = response.json()['shelves'][0]
+    assert shelf['category'] == 'Movies'
+    assert [item['title'] for item in shelf['items']] == ['Ranked movies']
+    assert set(shelf['items'][0]) == {'rank', 'id', 'title', 'year', 'poster_url'}
+    assert 'private note!' not in str(response.json())
+    assert 'user_id' not in str(response.json())
+
+
 # --- 404 indistinguishability ----------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- The sharing/visibility rework (#272, #283) and friend-request work (#282) added per-user data reachable through relationships and handles — the shape where authorization bugs are easy to introduce, high-impact, and invisible to static scanning, because the code runs correctly, just for the wrong caller. Existing tests covered the happy path; this adds the adversarial half.
- Six negative cases across follows, friends and visibility: an outsider reading or mutating another pair's friend request, unfriending another pair by id, redirecting a visibility update at a different user, and two attempts to reach a shelf directly by handle and slug.
- **No application code changes.** Every case passes against `main` as written — this pins the current behaviour so a future change cannot quietly relax it.

## Test plan

- [x] `pytest -q` → **848 passed**.
- [x] The four touched files on their own → **75 passed**.
- [x] The denial cases compare a denied response's fingerprint against a nonexistent one, so "you may not" and "does not exist" stay indistinguishable — the anti-enumeration property of #272 rather than just a status code.
- [x] The public-shelf case asserts an exact field allowlist (`rank`, `id`, `title`, `year`, `poster_url`) and that neither the owner's private note nor `user_id` appears anywhere in the payload.

Closes #293.
