### PR TITLE
Register the dev and qa MCP servers for this repo

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "druthers-dev": {
+      "type": "stdio",
+      "command": "/Users/adam/dev/druthers-mcp/bin/druthers-mcp",
+      "env": { "MCP_ENV": "dev" }
+    },
+    "druthers-qa": {
+      "type": "stdio",
+      "command": "/Users/adam/dev/druthers-mcp/bin/druthers-mcp",
+      "env": { "MCP_ENV": "qa" }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- The MCP server picks its target environment from the server registration rather than runtime state (ALeonard9/druthers-mcp#33), because MCP reads its env once at process start — a `switch_environment` tool would either need a restart anyway or leave the process inconsistent with its own setting, and a stale switch means a write lands in the wrong database with nothing at the call site to show it.
- Registering one server per environment makes the target visible in the transcript: a dev call reads `mcp__druthers-dev__add_book`.
- Adds the project-scoped `.mcp.json` so `druthers-dev` and `druthers-qa` load **only** when working in this repo, keeping ~30 extra tool definitions out of unrelated sessions. The global `druthers` server stays prod.
- Servers are named by environment, never after the repo — the same two entries appear in all three druthers repos, differing only by `MCP_ENV`.

## Test plan

- [x] File parses as JSON; both entries resolve to the same launcher with `MCP_ENV` set to `dev` and `qa` respectively.
- [x] Byte-identical to the `.mcp.json` in ALeonard9/druthers-mcp and the sibling repo.
- [x] Launcher behaviour verified in ALeonard9/druthers-mcp#47: unknown `MCP_ENV` exits 1, unset resolves prod, `MCP_ENV=qa` logs the resolved environment and base URL at startup.

## Merge order

**Merge ALeonard9/druthers-mcp#47 first.** The `command` path here is `bin/druthers-mcp`, which only exists after the rename in that PR — merging this first ships a config pointing at a missing binary, and the failure mode is a server that silently does not start.

Part of ALeonard9/druthers-mcp#33.
