### PR TITLE
Run seed:dev and fixtures:build inside the compose network

### DIFF
--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -134,15 +134,24 @@ tasks:
     cmds:
       - python -m app.migration.orion_import {{.CLI_ARGS}}
 
+  # Both of these run inside the compose network, for the same reason `migrate`
+  # does. On the host, `python` is not on PATH at all unless .venv happens to be
+  # activated, and even once it is, nothing exports ENV -- so Settings.env falls
+  # back to 'local' and sqlalchemy_database_url quietly returns SQLite. The
+  # seeder would then populate a stray .db file and report success while dev
+  # Postgres stayed empty. The container has the interpreter, the env file, and
+  # the right hostname for Postgres (env/dev.env points at the compose service
+  # name, which does not resolve from the host anyway).
   seed:dev:
     desc: "Populate local dev Postgres with real catalog data + randomized tracker state + the fixed dev cast (#313). Usage: task seed:dev -- --count 500 | --wipe"
     cmds:
-      - python -m app.migration.seed_dev {{.CLI_ARGS}}
+      - docker compose -f dc-dev.yml --env-file env/dev.env run --rm api-dev python -m app.migration.seed_dev {{.CLI_ARGS}}
 
   fixtures:build:
     desc: "Refresh app/migration/fixtures/seed_*.json from TMDB/TVMaze/Open Library/IGDB (needs API keys)"
     cmds:
-      - python -m app.migration.build_seed_fixtures
+      # Writes land on the host because api-dev bind-mounts the repo at /app.
+      - docker compose -f dc-dev.yml --env-file env/dev.env run --rm api-dev python -m app.migration.build_seed_fixtures
 
   gh:
     desc: "Open project repository in GitHub"


### PR DESCRIPTION
## Summary

- `task seed:dev` and `task fixtures:build` shelled out to a bare `python`, which is not on the host PATH at all — the task failed with `"python": executable file not found in $PATH`.
- The failure that would have followed is worse than the one you see. `Settings` has no `env_file`, so it reads only the process environment; on the host nothing exports `ENV`, so `Settings.env` falls back to `'local'` and `sqlalchemy_database_url` returns `sqlite:///./aleonard-api-local.db`. With a venv activated, the seeder runs happily and populates a stray SQLite file while dev Postgres stays empty — and reports success.
- Run both through the `api-dev` service instead, the same way `migrate` already does after the identical bug was fixed there. The container has the interpreter, the env file, and a hostname that resolves: `env/dev.env` sets `POSTGRES_HOST` to the compose service name, which never resolves from the host, and Postgres is published on 5430 rather than 5432.
- `fixtures:build` output still lands on the host — `api-dev` bind-mounts the repo at `/app`.

## Test plan

- [x] `taskfile.yaml` parses.
- [x] This exact command seeded the dev cast against the running local stack — 7 users (`you`, `friend`, `follower`, `followee`, `public-user`, `private-user`, `stranger`) with the documented per-seat movie counts (270/8/2/1/3/6/4). It was run by hand during a demo when `task seed:dev` failed; this change is that command moved into the task.
- [x] `task migrate`, whose fix this mirrors, is unchanged.

No linked issue — found while bringing the stack up for a fleet demo, alongside the `migrate` fix that shipped in #331.
