### PR TITLE
feat: friends and follows activity feed, default privacy resolution, and follower counts

### DIFF
--- a/alembic/versions/ab29c4e81f70_default_privacy_overrides.py
+++ b/alembic/versions/ab29c4e81f70_default_privacy_overrides.py
@@ -1,0 +1,80 @@
+"""default privacy and nullable shelf overrides
+
+Adds the account-wide default privacy tier introduced by api#298. Existing
+concrete shelf tiers are retained as overrides so profiles do not change when
+upgraded; only new or explicitly-cleared shelf settings inherit the default.
+
+Revision ID: ab29c4e81f70
+Revises: a7d40c9b1e52
+Create Date: 2026-08-11 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'ab29c4e81f70'
+down_revision: Union[str, Sequence[str], None] = 'a7d40c9b1e52'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SHELF_TIER_COLUMNS: Sequence[str] = (
+    'visibility_movies',
+    'visibility_tv',
+    'visibility_books',
+    'visibility_games',
+    'visibility_watchlist_movies',
+    'visibility_watchlist_tv',
+    'visibility_watchlist_books',
+    'visibility_watchlist_games',
+)
+
+
+def upgrade() -> None:
+    """Add the default and let shelf values be absent overrides."""
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                'default_privacy',
+                sa.Enum(
+                    'private',
+                    'friends',
+                    'public',
+                    name='ck_users_default_privacy',
+                    native_enum=False,
+                    create_constraint=True,
+                    length=16,
+                ),
+                nullable=False,
+                server_default='friends',
+            )
+        )
+        for column in SHELF_TIER_COLUMNS:
+            batch_op.alter_column(
+                column,
+                existing_type=sa.String(length=16),
+                existing_nullable=False,
+                nullable=True,
+                server_default=None,
+            )
+
+
+def downgrade() -> None:
+    """Restore concrete friends-tier shelf values before dropping the default."""
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        for column in SHELF_TIER_COLUMNS:
+            batch_op.execute(
+                sa.text(
+                    f'UPDATE users SET {column} = default_privacy WHERE {column} IS NULL'
+                )
+            )
+            batch_op.alter_column(
+                column,
+                existing_type=sa.String(length=16),
+                existing_nullable=True,
+                nullable=False,
+                server_default='friends',
+            )
+        batch_op.drop_column('default_privacy')

--- a/alembic/versions/e2c7a94f1b30_activity_sharing_opt_out.py
+++ b/alembic/versions/e2c7a94f1b30_activity_sharing_opt_out.py
@@ -1,0 +1,40 @@
+"""Add activity sharing opt-out
+
+The social feed (#280) evaluates shelf tiers against their current values on
+every read. This independent owner-level switch removes all of a user's
+otherwise-visible events without rewriting tracker rows.
+
+Revision ID: e2c7a94f1b30
+Revises: a7d40c9b1e52
+Create Date: 2026-08-11 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'e2c7a94f1b30'
+down_revision: Union[str, Sequence[str], None] = 'a7d40c9b1e52'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add the owner-level social activity sharing switch."""
+    op.add_column(
+        'users',
+        sa.Column(
+            'share_activity',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text('true'),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Remove the activity sharing switch."""
+    op.drop_column('users', 'share_activity')

--- a/app/db/db_follow.py
+++ b/app/db/db_follow.py
@@ -50,6 +50,11 @@ def is_following(db: Session, follower_pk: int, followee_pk: int) -> bool:
     )
 
 
+def count_followers(db: Session, followee_pk: int) -> int:
+    """Return the number of follow rows directed at ``followee_pk``."""
+    return db.query(DbFollow).filter(DbFollow.followee_id == followee_pk).count()
+
+
 def list_following(db: Session, user_pk: int) -> List[Tuple[DbFollow, DbUser]]:
     """Everyone this user follows, each paired with the followee's row."""
     return (

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -105,6 +105,17 @@ class DbUser(DBBaseModel):
     visibility_watchlist_books = tier_column('visibility_watchlist_books')
     visibility_watchlist_games = tier_column('visibility_watchlist_games')
 
+    # Sharing control for the friends/follows activity feed (#280). This is
+    # independent of shelf tiers: those still authorize every event at read
+    # time, while this switch lets the owner withdraw all contributions at
+    # once. Existing users participate until they explicitly opt out.
+    share_activity = Column(
+        Boolean,
+        nullable=False,
+        default=True,
+        server_default=text('true'),
+    )
+
     # --- Display preferences (#122). Viewer-controlled, not visibility —
     # how much of a ranked list to read, remembered across sessions and
     # devices. NULL means "unset", read as the default (25) everywhere.

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -51,6 +51,22 @@ def tier_column(name: str) -> Column:
     )
 
 
+def tier_override_column(name: str) -> Column:
+    """One optional per-shelf override, falling back to ``default_privacy``."""
+    return Column(
+        name,
+        Enum(
+            VisibilityTier,
+            name=f'ck_users_{name}',
+            native_enum=False,
+            create_constraint=True,
+            length=16,
+            values_callable=lambda members: [member.value for member in members],
+        ),
+        nullable=True,
+    )
+
+
 class DBBaseModel(Base):
     """
     Base model that includes common fields for all tables.
@@ -92,18 +108,21 @@ class DbUser(DBBaseModel):
     # more closed than the shelf.
     visibility_profile = tier_column('visibility_profile')
 
-    visibility_movies = tier_column('visibility_movies')
-    visibility_tv = tier_column('visibility_tv')
-    visibility_books = tier_column('visibility_books')
-    visibility_games = tier_column('visibility_games')
+    # A shelf with no explicit override inherits this account-wide tier.
+    default_privacy = tier_column('default_privacy')
+
+    visibility_movies = tier_override_column('visibility_movies')
+    visibility_tv = tier_override_column('visibility_tv')
+    visibility_books = tier_override_column('visibility_books')
+    visibility_games = tier_override_column('visibility_games')
 
     # Watchlist visibility (#236): independent of the ranked-list tiers
     # above. A category's watchlist is only served when this tier AND the
     # matching ranked-list tier both admit the viewer.
-    visibility_watchlist_movies = tier_column('visibility_watchlist_movies')
-    visibility_watchlist_tv = tier_column('visibility_watchlist_tv')
-    visibility_watchlist_books = tier_column('visibility_watchlist_books')
-    visibility_watchlist_games = tier_column('visibility_watchlist_games')
+    visibility_watchlist_movies = tier_override_column('visibility_watchlist_movies')
+    visibility_watchlist_tv = tier_override_column('visibility_watchlist_tv')
+    visibility_watchlist_books = tier_override_column('visibility_watchlist_books')
+    visibility_watchlist_games = tier_override_column('visibility_watchlist_games')
 
     # --- Display preferences (#122). Viewer-controlled, not visibility —
     # how much of a ranked list to read, remembered across sessions and

--- a/app/router/v1/router_activity.py
+++ b/app/router/v1/router_activity.py
@@ -165,33 +165,29 @@ def _social_shelf_rows(  # pylint: disable=too-many-arguments, too-many-position
     )
 
     friend = relationships.c.is_friend == 1
-    profile_visible = or_(
-        DbUser.visibility_profile == VisibilityTier.PUBLIC,
-        and_(
-            friend,
-            DbUser.visibility_profile == VisibilityTier.FRIENDS,
-        ),
-    )
+
+    # The SQL mirror of ``visibility.resolve_tier``: since api#298 a shelf tier
+    # is nullable, and null means "inherit ``default_privacy``" rather than
+    # "private". Comparing the raw column would make every inherited shelf
+    # vanish from the feed, because ``NULL = 'friends'`` is null, not false.
+    def _resolved(field: str):
+        return func.coalesce(getattr(DbUser, field), DbUser.default_privacy)
+
+    def _admits(tier):
+        return or_(
+            tier == VisibilityTier.PUBLIC,
+            and_(friend, tier == VisibilityTier.FRIENDS),
+        )
+
+    # The profile tier stays explicit and non-null, so it is compared directly.
+    profile_visible = _admits(DbUser.visibility_profile)
     ranked_visible = and_(
         profile_visible,
-        or_(
-            getattr(DbUser, shelf.visibility_tier) == VisibilityTier.PUBLIC,
-            and_(
-                friend,
-                getattr(DbUser, shelf.visibility_tier) == VisibilityTier.FRIENDS,
-            ),
-        ),
+        _admits(_resolved(shelf.visibility_tier)),
     )
     watchlist_visible = and_(
         ranked_visible,
-        or_(
-            getattr(DbUser, shelf.watchlist_visibility_tier) == VisibilityTier.PUBLIC,
-            and_(
-                friend,
-                getattr(DbUser, shelf.watchlist_visibility_tier)
-                == VisibilityTier.FRIENDS,
-            ),
-        ),
+        _admits(_resolved(shelf.watchlist_visibility_tier)),
     )
     event_visible = or_(
         and_(ranked, ranked_visible),

--- a/app/router/v1/router_activity.py
+++ b/app/router/v1/router_activity.py
@@ -7,14 +7,20 @@ lives in router_tv.py because it's purely TV data), this is its own router
 that reads across Movies/TV/Games/Books.
 """
 
+import base64
+import binascii
+import json
 import random
-from typing import List, Optional
+from datetime import datetime
+from typing import List, NamedTuple, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import case, func
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import and_, case, func, literal, or_, select, union_all
 from sqlalchemy.orm import Session, joinedload
 
+from app.auth.oauth2 import get_current_user
 from app.db.database import get_db
+from app.db.models import DbFollow, DbFriendship, DbUser
 from app.db.models_sandbox import (
     DbTVEpisode,
     DbUserBook,
@@ -23,13 +29,237 @@ from app.db.models_sandbox import (
     DbUserTVShow,
     DbUserVideoGame,
 )
-from app.auth.oauth2 import get_current_user
-from app.schemas.schemas_sandbox import ActivityItem, BoredItem, BoredResponse
+from app.schemas.schemas_sandbox import (
+    ActivityActor,
+    ActivityItem,
+    BoredItem,
+    BoredResponse,
+    SocialActivityItem,
+    SocialActivityPage,
+)
+from app.services.friendships import FriendshipStatus
+from app.services.shelves import SHELVES, Shelf
+from app.services.visibility import VisibilityTier
 
 router = APIRouter(prefix='/v1', tags=['Activity'])
 
 # Hard ceiling on the returned feed; also bounds per-domain SQL fetches.
 MAX_FEED = 200
+
+# A social page runs one query per shelf and merges those bounded result sets.
+# Keeping this below MAX_FEED limits both the response and every SQL fetch.
+MAX_SOCIAL_FEED = 100
+
+_ACTIVITY_CATEGORIES = {
+    'movies': 'movie',
+    'tv': 'tv_show',
+    'books': 'book',
+    'games': 'game',
+}
+
+
+class _SocialCursor(NamedTuple):
+    """Stable global sort key for one social-feed row."""
+
+    occurred_at: datetime
+    shelf_order: int
+    tracker_pk: int
+
+
+class _SocialRow(NamedTuple):
+    """Response item plus the private fields keyset paging needs."""
+
+    cursor: _SocialCursor
+    item: SocialActivityItem
+
+
+def _encode_cursor(cursor: _SocialCursor) -> str:
+    payload = json.dumps(
+        [cursor.occurred_at.isoformat(), cursor.shelf_order, cursor.tracker_pk],
+        separators=(',', ':'),
+    ).encode()
+    return base64.urlsafe_b64encode(payload).decode().rstrip('=')
+
+
+def _decode_cursor(raw: str) -> _SocialCursor:
+    try:
+        padding = '=' * (-len(raw) % 4)
+        occurred_at, shelf_order, tracker_pk = json.loads(
+            base64.urlsafe_b64decode(raw + padding)
+        )
+        cursor = _SocialCursor(
+            datetime.fromisoformat(occurred_at), int(shelf_order), int(tracker_pk)
+        )
+        if not 0 <= cursor.shelf_order < len(SHELVES) or cursor.tracker_pk < 1:
+            raise ValueError
+        return cursor
+    except (
+        TypeError,
+        ValueError,
+        UnicodeDecodeError,
+        binascii.Error,
+        json.JSONDecodeError,
+    ) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail='Invalid activity feed cursor',
+        ) from exc
+
+
+def _feed_relationships(viewer_pk: int):
+    """
+    Owners this viewer may receive activity from, deduplicated in SQL.
+
+    Each branch starts from an indexed viewer-side relationship column. The
+    grouped result is at most the viewer's own graph size, and an accepted
+    friendship wins over a duplicate follow so friends-tier shelves remain
+    visible without widening follow-only access.
+    """
+    friend_from_low = select(
+        DbFriendship.user_high_id.label('owner_id'),
+        literal(1).label('is_friend'),
+    ).where(
+        DbFriendship.user_low_id == viewer_pk,
+        DbFriendship.status == FriendshipStatus.ACCEPTED,
+    )
+    friend_from_high = select(
+        DbFriendship.user_low_id.label('owner_id'),
+        literal(1).label('is_friend'),
+    ).where(
+        DbFriendship.user_high_id == viewer_pk,
+        DbFriendship.status == FriendshipStatus.ACCEPTED,
+    )
+    followed = select(
+        DbFollow.followee_id.label('owner_id'), literal(0).label('is_friend')
+    ).where(DbFollow.follower_id == viewer_pk)
+    edges = union_all(friend_from_low, friend_from_high, followed).subquery()
+    return (
+        select(
+            edges.c.owner_id,
+            func.max(edges.c.is_friend).label('is_friend'),
+        )
+        .group_by(edges.c.owner_id)
+        .subquery()
+    )
+
+
+def _social_shelf_rows(  # pylint: disable=too-many-arguments, too-many-positional-arguments, too-many-locals
+    db: Session,
+    relationships,
+    shelf: Shelf,
+    shelf_order: int,
+    cursor: Optional[_SocialCursor],
+    limit: int,
+) -> List[_SocialRow]:
+    """One shelf's currently authorized candidates, bounded in SQL."""
+    tracker_model = shelf.tracker_model
+    catalog_model = shelf.catalog_model
+    ranked = and_(tracker_model.on_rankings.is_(True), tracker_model.rank.isnot(None))
+    watchlisted = and_(tracker_model.on_watchlist.is_(True), ~ranked)
+    occurred_at = case(
+        (
+            ranked,
+            func.coalesce(tracker_model.ranked_at, tracker_model.updated_at),
+        ),
+        else_=func.coalesce(tracker_model.created_at, tracker_model.updated_at),
+    )
+
+    friend = relationships.c.is_friend == 1
+    profile_visible = or_(
+        DbUser.visibility_profile == VisibilityTier.PUBLIC,
+        and_(
+            friend,
+            DbUser.visibility_profile == VisibilityTier.FRIENDS,
+        ),
+    )
+    ranked_visible = and_(
+        profile_visible,
+        or_(
+            getattr(DbUser, shelf.visibility_tier) == VisibilityTier.PUBLIC,
+            and_(
+                friend,
+                getattr(DbUser, shelf.visibility_tier) == VisibilityTier.FRIENDS,
+            ),
+        ),
+    )
+    watchlist_visible = and_(
+        ranked_visible,
+        or_(
+            getattr(DbUser, shelf.watchlist_visibility_tier) == VisibilityTier.PUBLIC,
+            and_(
+                friend,
+                getattr(DbUser, shelf.watchlist_visibility_tier)
+                == VisibilityTier.FRIENDS,
+            ),
+        ),
+    )
+    event_visible = or_(
+        and_(ranked, ranked_visible),
+        and_(watchlisted, watchlist_visible),
+    )
+
+    query = (
+        db.query(tracker_model, catalog_model, DbUser, occurred_at.label('occurred_at'))
+        .join(relationships, relationships.c.owner_id == tracker_model.user_id)
+        .join(DbUser, DbUser.pk == tracker_model.user_id)
+        .join(
+            catalog_model,
+            getattr(tracker_model, shelf.join_col) == catalog_model.pk,
+        )
+        .filter(DbUser.share_activity.is_(True), event_visible)
+    )
+    if cursor is not None:
+        query = query.filter(
+            or_(
+                occurred_at < cursor.occurred_at,
+                and_(
+                    occurred_at == cursor.occurred_at,
+                    literal(shelf_order) < cursor.shelf_order,
+                ),
+                and_(
+                    occurred_at == cursor.occurred_at,
+                    literal(shelf_order) == cursor.shelf_order,
+                    tracker_model.pk < cursor.tracker_pk,
+                ),
+            )
+        )
+
+    rows = (
+        query.order_by(occurred_at.desc(), tracker_model.pk.desc()).limit(limit).all()
+    )
+    category = _ACTIVITY_CATEGORIES[shelf.category]
+    result = []
+    for tracker, catalog, actor, timestamp in rows:
+        action = (
+            'ranked'
+            if tracker.on_rankings and tracker.rank is not None
+            else 'watchlist_added'
+        )
+        result.append(
+            _SocialRow(
+                cursor=_SocialCursor(timestamp, shelf_order, tracker.pk),
+                item=SocialActivityItem(
+                    category=category,
+                    action=action,
+                    title=catalog.title,
+                    subtitle=(
+                        '100%'
+                        if category == 'game' and tracker.is_100_percent
+                        else None
+                    ),
+                    entity_id=catalog.id,
+                    poster_url=catalog.poster_url,
+                    rank=tracker.rank if action == 'ranked' else None,
+                    occurred_at=timestamp,
+                    actor=ActivityActor(
+                        id=actor.id,
+                        handle=actor.handle,
+                        display_name=actor.display_name,
+                    ),
+                ),
+            )
+        )
+    return result
 
 
 def _tracker_occurred_at(tracker, action):
@@ -247,6 +477,47 @@ def get_activity(
         items = [i for i in items if i.category == category]
     items.sort(key=lambda i: i.occurred_at, reverse=True)
     return items[: max(1, min(limit, MAX_FEED))]
+
+
+@router.get('/users/me/feed', response_model=SocialActivityPage)
+def get_social_activity(
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+    limit: int = Query(default=50, ge=1, le=MAX_SOCIAL_FEED),
+    cursor: Optional[str] = Query(default=None, max_length=256),
+):
+    """
+    Recent ranking and watchlist activity from friends and followed users.
+
+    Relationships and the owner's current sharing tiers are joined into each
+    shelf query. Nothing about visibility is copied onto a tracker row, so an
+    unfriend, unfollow, opt-out, or tier reduction takes effect on old entries
+    immediately. Keyset paging avoids an increasingly expensive offset scan
+    as a caller moves deeper into the feed.
+    """
+    decoded_cursor = _decode_cursor(cursor) if cursor else None
+    relationships = _feed_relationships(current_user[0].pk)
+    fetch_limit = limit + 1
+    rows = [
+        row
+        for shelf_order, shelf in enumerate(SHELVES)
+        for row in _social_shelf_rows(
+            db,
+            relationships,
+            shelf,
+            shelf_order,
+            decoded_cursor,
+            fetch_limit,
+        )
+    ]
+    rows.sort(key=lambda row: row.cursor, reverse=True)
+    page = rows[:limit]
+    return SocialActivityPage(
+        items=[row.item for row in page],
+        next_cursor=(
+            _encode_cursor(page[-1].cursor) if len(rows) > limit and page else None
+        ),
+    )
 
 
 # --- "I'm bored" recommendation ---

--- a/app/router/v1/router_comparison.py
+++ b/app/router/v1/router_comparison.py
@@ -13,7 +13,7 @@ from app.services.comparison import compare_shelf
 from app.services.profile_access import viewer_relationship
 from app.services.shelves import SHELVES, Shelf
 from app.services.tracker_rules import default_completed_at
-from app.services.visibility import admits, ceiling_for
+from app.services.visibility import admits, ceiling_for, resolve_tier
 
 router = APIRouter(prefix='/v1', tags=['Comparison'])
 
@@ -43,7 +43,12 @@ def _target_access(db: Session, viewer: DbUser, handle: str):
     visible = [
         shelf
         for shelf in SHELVES
-        if admits(ceiling, getattr(target, shelf.visibility_tier))
+        if admits(
+            ceiling,
+            resolve_tier(
+                target.default_privacy, getattr(target, shelf.visibility_tier)
+            ),
+        )
     ]
     if not visible:
         raise _not_found()
@@ -92,7 +97,10 @@ def save_recommendation(  # pylint: disable=too-many-arguments,too-many-position
     viewer = current_user[0]
     target, _, ceiling = _target_access(db, viewer, handle)
     shelf = _shelf(category)
-    if not admits(ceiling, getattr(target, shelf.visibility_tier)):
+    if not admits(
+        ceiling,
+        resolve_tier(target.default_privacy, getattr(target, shelf.visibility_tier)),
+    ):
         raise _not_found()
 
     tracker_model, catalog_model = shelf.tracker_model, shelf.catalog_model

--- a/app/router/v1/router_search.py
+++ b/app/router/v1/router_search.py
@@ -16,8 +16,9 @@ from sqlalchemy.orm import Session
 
 from app.auth.oauth2 import get_current_user
 from app.db.database import get_db
+from app.db import db_follow
 from app.db.db_user import search_users
-from app.schemas.model_schemas import OutUserSearchResponse
+from app.schemas.model_schemas import OutUserSearchResponse, OutUserSearchResult
 from app.schemas.schemas_sandbox import GlobalSearchResponse
 from app.services.rate_limit import search_rate_limit
 from app.services.book_search import search_books
@@ -27,6 +28,7 @@ from app.services.search_correction import correct_query
 from app.services.search_ranking import rank_and_cap
 from app.services.tracked_status import attach_tracked_status
 from app.services.tv_search import search_tv_shows
+from app.services.visibility import is_public
 
 router = APIRouter(prefix='/v1', tags=['Search'])
 
@@ -115,4 +117,20 @@ def search_users_route(
     user_pk = current_user[0].pk
     hits = search_users(db, user_pk, q.strip(), limit=20)
 
-    return OutUserSearchResponse(query=q, corrected=None, users=hits)
+    return OutUserSearchResponse(
+        query=q,
+        corrected=None,
+        users=[
+            OutUserSearchResult(
+                id=user.id,
+                display_name=user.display_name,
+                handle=user.handle,
+                follower_count=(
+                    db_follow.count_followers(db, user.pk)
+                    if is_public(user.visibility_profile)
+                    else None
+                ),
+            )
+            for user in hits
+        ],
+    )

--- a/app/router/v1/router_visibility.py
+++ b/app/router/v1/router_visibility.py
@@ -30,7 +30,7 @@ from sqlalchemy.orm import Session
 from app.auth.oauth2 import get_current_user, get_optional_current_user
 from app.config import get_settings
 from app.db.database import get_db
-from app.db.db_follow import is_following
+from app.db.db_follow import count_followers, is_following
 from app.db.models import DbUser
 from app.schemas.model_schemas import InVisibilityUpdate, OutVisibility
 from app.services import handles
@@ -45,6 +45,7 @@ from app.services.visibility import (
     coerce,
     covers,
     most_open,
+    is_public,
 )
 
 router = APIRouter(prefix='/v1', tags=['Visibility'])
@@ -451,10 +452,16 @@ def public_profile(  # pylint: disable=too-many-arguments, too-many-positional-a
         or relationship is ViewerRelationship.FRIEND
     ) and is_following(db, viewer.pk, user.pk)
 
-    return {
+    payload = {
         'handle': user.handle,
         'display_name': user.display_name,
         'viewer': {'relationship': relationship.value, 'following': following},
         'shelves': shelves,
         'total_ranked': sum(s['ranked_count'] for s in shelves),
     }
+    # Follow rows survive a profile becoming non-public so the follower can
+    # later unfollow, but the row count is only public while the profile is.
+    # Do not return a zero or null here: the field itself is the disclosure.
+    if is_public(user.visibility_profile):
+        payload['follower_count'] = count_followers(db, user.pk)
+    return payload

--- a/app/router/v1/router_visibility.py
+++ b/app/router/v1/router_visibility.py
@@ -45,6 +45,7 @@ from app.services.visibility import (
     coerce,
     covers,
     most_open,
+    resolve_tier,
 )
 
 router = APIRouter(prefix='/v1', tags=['Visibility'])
@@ -84,6 +85,7 @@ VARY_ON_AUTH = {'Vary': 'Authorization'}
 # Every tier column a client may set, profile first. Shelf columns come from
 # the registry, so a new domain arrives here without a code change.
 TIER_FIELDS = (PROFILE_TIER_FIELD,) + tuple(field for field, _ in shelf_tier_fields())
+SHELF_TIER_FIELDS = frozenset(TIER_FIELDS[1:])
 
 
 def _validate_handle(db: Session, user: DbUser, raw: Optional[str]) -> Optional[str]:
@@ -125,7 +127,7 @@ def _validate_handle(db: Session, user: DbUser, raw: Optional[str]) -> Optional[
     return handle
 
 
-def _proposed_tiers(user: DbUser, data: dict) -> dict:
+def _proposed_tiers(user: DbUser, data: dict, default_privacy: VisibilityTier) -> dict:
     """
     The nine tiers as they would stand after this request.
 
@@ -135,9 +137,16 @@ def _proposed_tiers(user: DbUser, data: dict) -> dict:
     """
     return {
         field: (
-            VisibilityTier(data[field])
-            if data.get(field) is not None
-            else coerce(getattr(user, field))
+            resolve_tier(
+                default_privacy,
+                data[field] if field in data else getattr(user, field),
+            )
+            if field in SHELF_TIER_FIELDS
+            else (
+                VisibilityTier(data[field])
+                if data.get(field) is not None
+                else coerce(getattr(user, field))
+            )
         )
         for field in TIER_FIELDS
     }
@@ -253,7 +262,12 @@ def _shelf_payload(  # pylint: disable=too-many-arguments, too-many-positional-a
         ],
     }
 
-    if not admits(ceiling, getattr(user, shelf.watchlist_visibility_tier)):
+    if not admits(
+        ceiling,
+        resolve_tier(
+            user.default_privacy, getattr(user, shelf.watchlist_visibility_tier)
+        ),
+    ):
         return payload
 
     watchlist_filter = (
@@ -318,14 +332,23 @@ def update_visibility(
     handle = (
         _validate_handle(db, user, data['handle']) if 'handle' in data else user.handle
     )
-    tiers = _proposed_tiers(user, data)
+    default_privacy = (
+        VisibilityTier(data['default_privacy'])
+        if data.get('default_privacy') is not None
+        else coerce(user.default_privacy)
+    )
+    tiers = _proposed_tiers(user, data, default_privacy)
 
     _assert_handle_present(handle, tiers)
     _assert_profile_covers_shelves(tiers)
 
     user.handle = handle
-    for field, tier in tiers.items():
-        setattr(user, field, tier)
+    user.default_privacy = default_privacy
+    for field in TIER_FIELDS:
+        if field == PROFILE_TIER_FIELD and data.get(field) is None:
+            continue
+        if field in data:
+            setattr(user, field, data[field])
 
     db.commit()
     db.refresh(user)
@@ -432,7 +455,10 @@ def public_profile(  # pylint: disable=too-many-arguments, too-many-positional-a
     shelves = [
         _shelf_payload(db, user, s, ceiling, *ranked_depth, *watchlist_depth)
         for s in candidates
-        if admits(ceiling, getattr(user, s.visibility_tier))
+        if admits(
+            ceiling,
+            resolve_tier(user.default_privacy, getattr(user, s.visibility_tier)),
+        )
     ]
 
     # A named shelf query (`?shelf=...`) that doesn't exist or isn't admitted

--- a/app/router/v1/router_visibility.py
+++ b/app/router/v1/router_visibility.py
@@ -304,7 +304,7 @@ def update_visibility(
     current_user: list = Depends(get_current_user),
 ):
     """
-    Update the handle and/or any of the nine visibility tiers.
+    Update the handle, activity sharing, and/or any of the nine visibility tiers.
 
     Only fields present in the body change. The result has to satisfy both
     invariants — a handle for anything non-private, and a profile at least as
@@ -314,18 +314,23 @@ def update_visibility(
     """
     user = current_user[0]
     data = request.model_dump(exclude_unset=True)
+    changes_visibility = 'handle' in data or any(field in data for field in TIER_FIELDS)
+    if changes_visibility:
+        handle = (
+            _validate_handle(db, user, data['handle'])
+            if 'handle' in data
+            else user.handle
+        )
+        tiers = _proposed_tiers(user, data)
 
-    handle = (
-        _validate_handle(db, user, data['handle']) if 'handle' in data else user.handle
-    )
-    tiers = _proposed_tiers(user, data)
+        _assert_handle_present(handle, tiers)
+        _assert_profile_covers_shelves(tiers)
 
-    _assert_handle_present(handle, tiers)
-    _assert_profile_covers_shelves(tiers)
-
-    user.handle = handle
-    for field, tier in tiers.items():
-        setattr(user, field, tier)
+        user.handle = handle
+        for field, tier in tiers.items():
+            setattr(user, field, tier)
+    if 'share_activity' in data and data['share_activity'] is not None:
+        user.share_activity = data['share_activity']
 
     db.commit()
     db.refresh(user)

--- a/app/schemas/model_schemas.py
+++ b/app/schemas/model_schemas.py
@@ -277,6 +277,10 @@ class OutUserSearchResult(BaseModel):
     id: str
     display_name: str
     handle: Optional[str] = None
+    # Public profiles alone disclose their audience size. Friends-only
+    # results carry null, matching the existing optional-handle convention
+    # without turning a friend search into a follower-enumeration side channel.
+    follower_count: Optional[int] = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/app/schemas/model_schemas.py
+++ b/app/schemas/model_schemas.py
@@ -137,12 +137,12 @@ class InVisibilityUpdate(BaseModel):
     ``private``, ``friends`` or ``public`` — not a boolean.
 
     Only sent fields change; a null handle clears it (allowed only while
-    everything is private). An unsent field and an explicit null are both
-    left alone, so a client can PUT one radio button without echoing the
-    other eight.
+    everything is private). A null shelf tier clears its override and resumes
+    using ``default_privacy``; an omitted field is left alone.
     """
 
     handle: Optional[str] = None
+    default_privacy: Optional[VisibilityTier] = None
     visibility_profile: Optional[VisibilityTier] = None
     visibility_movies: Optional[VisibilityTier] = None
     visibility_tv: Optional[VisibilityTier] = None
@@ -160,15 +160,16 @@ class OutVisibility(BaseModel):
     """
 
     handle: Optional[str] = None
+    default_privacy: VisibilityTier = VisibilityTier.FRIENDS
     visibility_profile: VisibilityTier = VisibilityTier.PRIVATE
-    visibility_movies: VisibilityTier = VisibilityTier.PRIVATE
-    visibility_tv: VisibilityTier = VisibilityTier.PRIVATE
-    visibility_books: VisibilityTier = VisibilityTier.PRIVATE
-    visibility_games: VisibilityTier = VisibilityTier.PRIVATE
-    visibility_watchlist_movies: VisibilityTier = VisibilityTier.PRIVATE
-    visibility_watchlist_tv: VisibilityTier = VisibilityTier.PRIVATE
-    visibility_watchlist_books: VisibilityTier = VisibilityTier.PRIVATE
-    visibility_watchlist_games: VisibilityTier = VisibilityTier.PRIVATE
+    visibility_movies: Optional[VisibilityTier] = None
+    visibility_tv: Optional[VisibilityTier] = None
+    visibility_books: Optional[VisibilityTier] = None
+    visibility_games: Optional[VisibilityTier] = None
+    visibility_watchlist_movies: Optional[VisibilityTier] = None
+    visibility_watchlist_tv: Optional[VisibilityTier] = None
+    visibility_watchlist_books: Optional[VisibilityTier] = None
+    visibility_watchlist_games: Optional[VisibilityTier] = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/app/schemas/model_schemas.py
+++ b/app/schemas/model_schemas.py
@@ -133,8 +133,9 @@ class OutToken(BaseModel):
 
 class InVisibilityUpdate(BaseModel):
     """
-    Request body for visibility settings (#274). Every setting is a tier —
-    ``private``, ``friends`` or ``public`` — not a boolean.
+    Request body for visibility settings (#274) and activity sharing (#280).
+    Every shelf setting is a ``private``, ``friends`` or ``public`` tier;
+    ``share_activity`` is the independent whole-feed opt-out.
 
     Only sent fields change; a null handle clears it (allowed only while
     everything is private). An unsent field and an explicit null are both
@@ -152,11 +153,12 @@ class InVisibilityUpdate(BaseModel):
     visibility_watchlist_tv: Optional[VisibilityTier] = None
     visibility_watchlist_books: Optional[VisibilityTier] = None
     visibility_watchlist_games: Optional[VisibilityTier] = None
+    share_activity: Optional[bool] = None
 
 
 class OutVisibility(BaseModel):
     """
-    The caller's visibility settings, one tier per setting.
+    The caller's shelf tiers and activity-sharing setting.
     """
 
     handle: Optional[str] = None
@@ -169,6 +171,7 @@ class OutVisibility(BaseModel):
     visibility_watchlist_tv: VisibilityTier = VisibilityTier.PRIVATE
     visibility_watchlist_books: VisibilityTier = VisibilityTier.PRIVATE
     visibility_watchlist_games: VisibilityTier = VisibilityTier.PRIVATE
+    share_activity: bool = True
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/app/schemas/schemas_sandbox.py
+++ b/app/schemas/schemas_sandbox.py
@@ -618,6 +618,27 @@ class ActivityItem(BaseModel):
     occurred_at: datetime
 
 
+class ActivityActor(BaseModel):
+    """The person whose tracker change produced a social-feed event."""
+
+    id: str
+    handle: Optional[str] = None
+    display_name: Optional[str] = None
+
+
+class SocialActivityItem(ActivityItem):
+    """One authorized activity event from a friend or followed user."""
+
+    actor: ActivityActor
+
+
+class SocialActivityPage(BaseModel):
+    """One bounded keyset page of the caller's social activity feed."""
+
+    items: List[SocialActivityItem]
+    next_cursor: Optional[str] = None
+
+
 class BoredItem(BaseModel):
     """One candidate pulled from a to-be-consumed (watchlist/bucket) list."""
 

--- a/app/services/comparison.py
+++ b/app/services/comparison.py
@@ -3,7 +3,7 @@
 from sqlalchemy.orm import Session
 
 from app.services.shelves import Shelf
-from app.services.visibility import VisibilityTier, admits
+from app.services.visibility import VisibilityTier, admits, resolve_tier
 
 MIN_SHARED_FOR_SCORE = 5
 RESULT_LIMIT = 5
@@ -43,9 +43,15 @@ def compare_shelf(  # pylint: disable=too-many-locals
     ceiling: VisibilityTier,
 ) -> dict:
     """Compare one shelf without ever reading target data above the ceiling."""
-    ranked_visible = admits(ceiling, getattr(target, shelf.visibility_tier))
+    ranked_visible = admits(
+        ceiling,
+        resolve_tier(target.default_privacy, getattr(target, shelf.visibility_tier)),
+    )
     watchlist_visible = ranked_visible and admits(
-        ceiling, getattr(target, shelf.watchlist_visibility_tier)
+        ceiling,
+        resolve_tier(
+            target.default_privacy, getattr(target, shelf.watchlist_visibility_tier)
+        ),
     )
     base = {
         'category': shelf.category,

--- a/app/services/summary.py
+++ b/app/services/summary.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session
 
 from app.db.models import DbUser
 from app.services.shelves import SHELVES, Shelf
-from app.services.visibility import is_public
+from app.services.visibility import is_public, resolve_tier
 
 # Ranked entries returned per shelf. Five is the product ("your Top 5"), not
 # an arbitrary page size — callers may ask for fewer but not more, so this
@@ -112,7 +112,11 @@ def build_summary(db: Session, user: DbUser, top_n: int = TOP_N) -> dict:
                 # question about ``public`` alone now that the profile itself
                 # is viewer-aware (#277). A friends-only shelf is false here
                 # and still reaches friends on the profile.
-                'public': is_public(getattr(user, shelf.visibility_tier)),
+                'public': is_public(
+                    resolve_tier(
+                        user.default_privacy, getattr(user, shelf.visibility_tier)
+                    )
+                ),
                 'top': _top(db, shelf, user.pk, limit),
             }
         )

--- a/app/services/visibility.py
+++ b/app/services/visibility.py
@@ -75,6 +75,11 @@ def coerce(value) -> VisibilityTier:
         return VisibilityTier.PRIVATE
 
 
+def resolve_tier(default_privacy, override) -> VisibilityTier:
+    """Return a shelf override or, when absent, its global default tier."""
+    return coerce(default_privacy if override is None else override)
+
+
 def openness(value) -> int:
     """Comparable rank of a tier: private 0, friends 1, public 2."""
     return _OPENNESS[coerce(value)]

--- a/tests/integration/router_activity_test.py
+++ b/tests/integration/router_activity_test.py
@@ -297,6 +297,53 @@ def test_lowering_current_shelf_tier_retroactively_removes_activity(
     }
 
 
+def test_feed_resolves_a_shelf_with_no_override_against_the_default(
+    test_client: TestClient,
+):
+    """
+    A shelf with no override inherits ``default_privacy`` (api#298), so the
+    feed has to resolve inheritance the way the profile reads do. Comparing
+    the raw column instead drops every inherited shelf out of every feed,
+    because ``NULL = 'friends'`` is null rather than false.
+    """
+    _friend_users(test_client)
+    owner_token = test_client.second_user.token
+    _claim_handle(test_client, owner_token)
+    movie_id = _make_movie(test_client)
+    _track(test_client, owner_token, 'movies', movie_id, 'ranked')
+    viewer_headers = _auth(test_client.first_user.token)
+
+    inherited = test_client.put(
+        '/v1/users/me/visibility',
+        headers=_auth(owner_token),
+        json={
+            'default_privacy': 'friends',
+            'visibility_profile': 'friends',
+            'visibility_movies': None,
+        },
+    )
+    assert inherited.status_code == 200, inherited.text
+    assert inherited.json()['visibility_movies'] is None
+    assert [
+        item['title']
+        for item in test_client.get('/v1/users/me/feed', headers=viewer_headers).json()[
+            'items'
+        ]
+    ] == ['Inception']
+
+    # Closing the global default has to close the inherited shelf with it.
+    closed = test_client.put(
+        '/v1/users/me/visibility',
+        headers=_auth(owner_token),
+        json={'default_privacy': 'private'},
+    )
+    assert closed.status_code == 200, closed.text
+    assert test_client.get('/v1/users/me/feed', headers=viewer_headers).json() == {
+        'items': [],
+        'next_cursor': None,
+    }
+
+
 def test_watchlist_event_requires_current_ranked_and_watchlist_tiers(
     test_client: TestClient,
 ):

--- a/tests/integration/router_activity_test.py
+++ b/tests/integration/router_activity_test.py
@@ -1,5 +1,12 @@
 # pylint: disable=missing-module-docstring, missing-function-docstring
+from datetime import datetime, timezone
+
 from fastapi.testclient import TestClient
+from sqlalchemy import event
+
+from app.db.models import DbFollow, DbFriendship
+from app.db.models_sandbox import DbUserMovie
+from app.services.friendships import FriendshipStatus, canonical_pair
 
 
 def _make_movie(test_client: TestClient, imdb='tt1375666', title='Inception') -> str:
@@ -47,6 +54,68 @@ def _make_book(test_client: TestClient, title='Dune', **extra) -> str:
     )
     assert resp.status_code == 201
     return resp.json()['id']
+
+
+def _auth(token: str) -> dict:
+    return {'Authorization': f'Bearer {token}'}
+
+
+def _friend_users(test_client: TestClient, accepted=True) -> None:
+    viewer_pk = test_client.first_user.pk
+    owner_pk = test_client.second_user.pk
+    low, high = canonical_pair(viewer_pk, owner_pk)
+    test_client.test_db_session.add(
+        DbFriendship(
+            user_low_id=low,
+            user_high_id=high,
+            requested_by_id=viewer_pk,
+            status=(
+                FriendshipStatus.ACCEPTED if accepted else FriendshipStatus.PENDING
+            ),
+            requested_at=datetime.now(timezone.utc),
+            responded_at=datetime.now(timezone.utc) if accepted else None,
+        )
+    )
+    test_client.test_db_session.commit()
+
+
+def _follow_user(test_client: TestClient) -> None:
+    test_client.test_db_session.add(
+        DbFollow(
+            follower_id=test_client.first_user.pk,
+            followee_id=test_client.second_user.pk,
+            followed_at=datetime.now(timezone.utc),
+        )
+    )
+    test_client.test_db_session.commit()
+
+
+def _claim_handle(test_client: TestClient, token: str) -> None:
+    response = test_client.put(
+        '/v1/users/me/visibility', headers=_auth(token), json={'handle': 'blake'}
+    )
+    assert response.status_code == 200, response.text
+
+
+def _track(
+    test_client: TestClient,
+    token: str,
+    path: str,
+    entity_id: str,
+    action: str,
+) -> None:
+    payload = {'on_rankings': True} if action == 'ranked' else {'on_watchlist': True}
+    response = test_client.post(
+        f'/v1/users/me/{path}/{entity_id}', headers=_auth(token), json=payload
+    )
+    assert response.status_code in (200, 201), response.text
+    if action == 'ranked' and response.json()['rank'] is None:
+        ranked = test_client.put(
+            f'/v1/users/me/{path}/{entity_id}/rank',
+            headers=_auth(token),
+            json={'position': 1},
+        )
+        assert ranked.status_code == 200, ranked.text
 
 
 # --- Activity Log ---
@@ -131,6 +200,309 @@ def test_activity_untracked_items_excluded(test_client: TestClient):
 def test_activity_requires_auth(test_client: TestClient):
     resp = test_client.get('/v1/users/me/activity')
     assert resp.status_code == 401
+
+
+# --- Friends and follows feed ---
+def test_social_feed_includes_friend_rankings_and_watchlist_adds(
+    test_client: TestClient,
+):
+    _friend_users(test_client)
+    owner_token = test_client.second_user.token
+    movie_id = _make_movie(test_client, title='Heat', imdb='tt0113277')
+    book_id = _make_book(test_client, title='Dune')
+    _track(test_client, owner_token, 'movies', movie_id, 'ranked')
+    _track(test_client, owner_token, 'books', book_id, 'watchlist_added')
+
+    response = test_client.get(
+        '/v1/users/me/feed', headers=_auth(test_client.first_user.token)
+    )
+    assert response.status_code == 200, response.text
+    items = response.json()['items']
+    assert {(item['title'], item['action']) for item in items} == {
+        ('Heat', 'ranked'),
+        ('Dune', 'watchlist_added'),
+    }
+    assert {item['actor']['id'] for item in items} == {test_client.second_user.id}
+    assert next(item for item in items if item['title'] == 'Heat')['rank'] == 1
+
+
+def test_follow_only_receives_public_shelf_activity(test_client: TestClient):
+    _follow_user(test_client)
+    owner_token = test_client.second_user.token
+    visibility = test_client.put(
+        '/v1/users/me/visibility',
+        headers=_auth(owner_token),
+        json={
+            'handle': 'blake',
+            'visibility_profile': 'public',
+            'visibility_movies': 'public',
+        },
+    )
+    assert visibility.status_code == 200, visibility.text
+    movie_id = _make_movie(test_client, title='Arrival', imdb='tt2543164')
+    book_id = _make_book(test_client, title='The Dispossessed')
+    _track(test_client, owner_token, 'movies', movie_id, 'ranked')
+    _track(test_client, owner_token, 'books', book_id, 'watchlist_added')
+
+    items = test_client.get(
+        '/v1/users/me/feed', headers=_auth(test_client.first_user.token)
+    ).json()['items']
+    assert [(item['title'], item['category']) for item in items] == [
+        ('Arrival', 'movie')
+    ]
+
+
+def test_pending_friendship_does_not_contribute_activity(test_client: TestClient):
+    _friend_users(test_client, accepted=False)
+    movie_id = _make_movie(test_client)
+    _track(
+        test_client,
+        test_client.second_user.token,
+        'movies',
+        movie_id,
+        'ranked',
+    )
+
+    response = test_client.get(
+        '/v1/users/me/feed', headers=_auth(test_client.first_user.token)
+    )
+    assert response.json() == {'items': [], 'next_cursor': None}
+
+
+def test_lowering_current_shelf_tier_retroactively_removes_activity(
+    test_client: TestClient,
+):
+    _friend_users(test_client)
+    owner_token = test_client.second_user.token
+    _claim_handle(test_client, owner_token)
+    movie_id = _make_movie(test_client)
+    _track(test_client, owner_token, 'movies', movie_id, 'ranked')
+    viewer_headers = _auth(test_client.first_user.token)
+    assert [
+        item['title']
+        for item in test_client.get('/v1/users/me/feed', headers=viewer_headers).json()[
+            'items'
+        ]
+    ] == ['Inception']
+
+    lowered = test_client.put(
+        '/v1/users/me/visibility',
+        headers=_auth(owner_token),
+        json={'visibility_movies': 'private'},
+    )
+    assert lowered.status_code == 200, lowered.text
+    assert test_client.get('/v1/users/me/feed', headers=viewer_headers).json() == {
+        'items': [],
+        'next_cursor': None,
+    }
+
+
+def test_watchlist_event_requires_current_ranked_and_watchlist_tiers(
+    test_client: TestClient,
+):
+    _friend_users(test_client)
+    owner_token = test_client.second_user.token
+    _claim_handle(test_client, owner_token)
+    movie_id = _make_movie(test_client)
+    _track(test_client, owner_token, 'movies', movie_id, 'watchlist_added')
+    viewer_headers = _auth(test_client.first_user.token)
+    assert (
+        len(
+            test_client.get('/v1/users/me/feed', headers=viewer_headers).json()['items']
+        )
+        == 1
+    )
+
+    lowered = test_client.put(
+        '/v1/users/me/visibility',
+        headers=_auth(owner_token),
+        json={'visibility_watchlist_movies': 'private'},
+    )
+    assert lowered.status_code == 200, lowered.text
+    assert (
+        test_client.get('/v1/users/me/feed', headers=viewer_headers).json()['items']
+        == []
+    )
+
+
+def test_owner_can_opt_out_and_back_in_of_activity_sharing(
+    test_client: TestClient,
+):
+    _friend_users(test_client)
+    owner_token = test_client.second_user.token
+    movie_id = _make_movie(test_client)
+    _track(test_client, owner_token, 'movies', movie_id, 'ranked')
+    viewer_headers = _auth(test_client.first_user.token)
+    defaults = test_client.get(
+        '/v1/users/me/visibility', headers=_auth(owner_token)
+    ).json()
+    assert defaults['share_activity'] is True
+
+    opted_out = test_client.put(
+        '/v1/users/me/visibility',
+        headers=_auth(owner_token),
+        json={'share_activity': False},
+    )
+    assert opted_out.status_code == 200, opted_out.text
+    assert opted_out.json()['share_activity'] is False
+    assert (
+        test_client.get('/v1/users/me/feed', headers=viewer_headers).json()['items']
+        == []
+    )
+
+    opted_in = test_client.put(
+        '/v1/users/me/visibility',
+        headers=_auth(owner_token),
+        json={'share_activity': True},
+    )
+    assert opted_in.json()['share_activity'] is True
+    assert [
+        item['title']
+        for item in test_client.get('/v1/users/me/feed', headers=viewer_headers).json()[
+            'items'
+        ]
+    ] == ['Inception']
+
+
+def test_social_feed_uses_all_four_domain_shelves(test_client: TestClient):
+    _friend_users(test_client)
+    owner_token = test_client.second_user.token
+    entities = (
+        ('movies', _make_movie(test_client), 'ranked'),
+        ('tv-shows', _make_show(test_client), 'watchlist_added'),
+        ('games', _make_game(test_client), 'ranked'),
+        ('books', _make_book(test_client), 'watchlist_added'),
+    )
+    for path, entity_id, action in entities:
+        _track(test_client, owner_token, path, entity_id, action)
+
+    items = test_client.get(
+        '/v1/users/me/feed', headers=_auth(test_client.first_user.token)
+    ).json()['items']
+    assert {(item['category'], item['action']) for item in items} == {
+        ('movie', 'ranked'),
+        ('tv_show', 'watchlist_added'),
+        ('game', 'ranked'),
+        ('book', 'watchlist_added'),
+    }
+
+
+def test_friendship_wins_when_the_same_owner_is_also_followed(
+    test_client: TestClient,
+):
+    _friend_users(test_client)
+    _follow_user(test_client)
+    movie_id = _make_movie(test_client)
+    _track(
+        test_client,
+        test_client.second_user.token,
+        'movies',
+        movie_id,
+        'ranked',
+    )
+
+    items = test_client.get(
+        '/v1/users/me/feed', headers=_auth(test_client.first_user.token)
+    ).json()['items']
+    assert [(item['title'], item['action']) for item in items] == [
+        ('Inception', 'ranked')
+    ]
+
+
+def test_social_feed_keyset_pages_without_duplicates(test_client: TestClient):
+    _friend_users(test_client)
+    owner_token = test_client.second_user.token
+    for index in range(3):
+        movie_id = _make_movie(
+            test_client,
+            title=f'Movie {index}',
+            imdb=f'tt900000{index}',
+        )
+        _track(test_client, owner_token, 'movies', movie_id, 'watchlist_added')
+
+    # Exercise the complete keyset, not just its timestamp: simultaneous
+    # events in one shelf must page by tracker pk without skipping or repeats.
+    tied_at = datetime(2026, 8, 11, 12, 0, 0)
+    trackers = (
+        test_client.test_db_session.query(DbUserMovie)
+        .filter(DbUserMovie.user_id == test_client.second_user.pk)
+        .all()
+    )
+    for tracker in trackers:
+        tracker.created_at = tied_at
+        tracker.updated_at = tied_at
+    test_client.test_db_session.commit()
+
+    first = test_client.get(
+        '/v1/users/me/feed',
+        headers=_auth(test_client.first_user.token),
+        params={'limit': 2},
+    )
+    assert first.status_code == 200, first.text
+    assert len(first.json()['items']) == 2
+    assert first.json()['next_cursor']
+
+    second = test_client.get(
+        '/v1/users/me/feed',
+        headers=_auth(test_client.first_user.token),
+        params={'limit': 2, 'cursor': first.json()['next_cursor']},
+    )
+    assert second.status_code == 200, second.text
+    assert len(second.json()['items']) == 1
+    assert second.json()['next_cursor'] is None
+    titles = [item['title'] for item in first.json()['items'] + second.json()['items']]
+    assert len(titles) == len(set(titles)) == 3
+
+
+def test_social_feed_is_sql_bounded_without_relationship_n_plus_one(
+    test_client: TestClient,
+):
+    _friend_users(test_client)
+    movie_id = _make_movie(test_client)
+    _track(
+        test_client,
+        test_client.second_user.token,
+        'movies',
+        movie_id,
+        'ranked',
+    )
+    statements = []
+
+    def record_statement(_conn, _cursor, statement, _parameters, _context, _many):
+        statements.append(statement)
+
+    engine = test_client.test_db_session.get_bind()
+    event.listen(engine, 'before_cursor_execute', record_statement)
+    try:
+        response = test_client.get(
+            '/v1/users/me/feed', headers=_auth(test_client.first_user.token)
+        )
+    finally:
+        event.remove(engine, 'before_cursor_execute', record_statement)
+
+    assert response.status_code == 200, response.text
+    feed_queries = [statement for statement in statements if 'UNION ALL' in statement]
+    assert len(feed_queries) == 4
+    assert all(' LIMIT ' in statement for statement in feed_queries)
+
+
+def test_social_feed_rejects_invalid_or_unbounded_pages(test_client: TestClient):
+    headers = _auth(test_client.first_user.token)
+    invalid_cursor = test_client.get(
+        '/v1/users/me/feed', headers=headers, params={'cursor': 'not-a-cursor'}
+    )
+    assert invalid_cursor.status_code == 422
+    assert 'Invalid activity feed cursor' in invalid_cursor.text
+    assert (
+        test_client.get(
+            '/v1/users/me/feed', headers=headers, params={'limit': 101}
+        ).status_code
+        == 422
+    )
+
+
+def test_social_feed_requires_auth(test_client: TestClient):
+    assert test_client.get('/v1/users/me/feed').status_code == 401
 
 
 # --- Bored ---

--- a/tests/integration/router_follows_test.py
+++ b/tests/integration/router_follows_test.py
@@ -84,6 +84,24 @@ def test_following_a_public_profile_succeeds(test_client: TestClient):
     )
 
 
+def test_public_profile_exposes_an_accurate_follower_count(test_client: TestClient):
+    _claim_public_handle(test_client, test_client.second_user.token, 'blake')
+    profile = '/v1/public/blake'
+    assert test_client.get(profile).json()['follower_count'] == 0
+
+    followed = test_client.put(
+        '/v1/users/me/following/blake', headers=_auth(test_client.first_user.token)
+    )
+    assert followed.status_code == 200
+    assert test_client.get(profile).json()['follower_count'] == 1
+
+    unfollowed = test_client.delete(
+        '/v1/users/me/following/blake', headers=_auth(test_client.first_user.token)
+    )
+    assert unfollowed.status_code == 204
+    assert test_client.get(profile).json()['follower_count'] == 0
+
+
 def test_follow_and_unfollow_show_up_on_both_sides(test_client: TestClient):
     _claim_public_handle(test_client, test_client.second_user.token, 'blake')
     follow = test_client.put(
@@ -488,6 +506,12 @@ def test_a_follow_survives_the_followee_going_private(test_client: TestClient):
         == 404
     )
     assert test_client.get('/v1/public/blake').status_code == 404
+
+    # The owner may still render their private profile, but its retained
+    # follow row is hidden rather than converted into an audience count.
+    owner_view = test_client.get('/v1/public/blake', headers=_auth(owner_token))
+    assert owner_view.status_code == 200
+    assert 'follower_count' not in owner_view.json()
 
     # The follower can still unfollow afterwards.
     unfollow = test_client.delete(

--- a/tests/integration/router_search_users_test.py
+++ b/tests/integration/router_search_users_test.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-module-docstring, missing-function-docstring
 from fastapi.testclient import TestClient
 from app.db.models import DbFriendship
+from app.db.models import DbFollow
 from app.services.friendships import FriendshipStatus
 from app.services.visibility import VisibilityTier
 
@@ -94,3 +95,39 @@ def test_user_search_anti_enumeration(test_client: TestClient, test_create_user)
     assert resp.status_code == 200
     # Should be empty, meaning existence is not revealed
     assert resp.json()['users'] == []
+
+
+def test_user_search_exposes_counts_for_public_profiles_only(
+    test_client: TestClient, test_create_user
+):
+    headers = {'Authorization': f'Bearer {test_client.first_user.token}'}
+    db = test_client.test_db_session
+    public_user, friend_user = test_create_user(test_client, user_count=2)
+    public_user.display_name = 'Counted Public'
+    public_user.handle = 'counted-public'
+    public_user.visibility_profile = VisibilityTier.PUBLIC.value
+    friend_user.display_name = 'Counted Friend'
+    friend_user.handle = 'counted-friend'
+    friend_user.visibility_profile = VisibilityTier.FRIENDS.value
+    db.add_all(
+        [
+            DbFriendship(
+                user_low_id=min(test_client.first_user.pk, friend_user.pk),
+                user_high_id=max(test_client.first_user.pk, friend_user.pk),
+                requested_by_id=friend_user.pk,
+                status=FriendshipStatus.ACCEPTED,
+            ),
+            DbFollow(follower_id=test_client.first_user.pk, followee_id=public_user.pk),
+            DbFollow(
+                follower_id=test_client.second_user.pk, followee_id=public_user.pk
+            ),
+            DbFollow(follower_id=test_client.first_user.pk, followee_id=friend_user.pk),
+        ]
+    )
+    db.commit()
+
+    response = test_client.get('/v1/search/users?q=Counted', headers=headers)
+    assert response.status_code == 200
+    results = {user['id']: user for user in response.json()['users']}
+    assert results[public_user.id]['follower_count'] == 2
+    assert results[friend_user.id]['follower_count'] is None

--- a/tests/integration/router_visibility_test.py
+++ b/tests/integration/router_visibility_test.py
@@ -51,12 +51,54 @@ def _watchlist_a_movie(
     )
 
 
-def test_defaults_are_fully_friends(test_client: TestClient):
+def test_default_privacy_is_friends_and_shelves_start_without_overrides(
+    test_client: TestClient,
+):
     body = test_client.get(
         '/v1/users/me/visibility', headers=_auth(test_client.first_user.token)
     ).json()
     assert body['handle'] is None
-    assert [body[field] for field in TIER_FIELDS] == ['friends'] * len(TIER_FIELDS)
+    assert body['default_privacy'] == 'friends'
+    assert body['visibility_profile'] == 'friends'
+    assert [body[field] for field in TIER_FIELDS[1:]] == [None] * (len(TIER_FIELDS) - 1)
+
+
+def test_shelves_inherit_default_privacy_until_an_override_is_set(
+    test_client: TestClient,
+):
+    token = test_client.first_user.token
+    _rank_a_movie(test_client, token)
+    response = test_client.put(
+        '/v1/users/me/visibility',
+        headers=_auth(token),
+        json={
+            'handle': 'avery',
+            'visibility_profile': 'public',
+            'default_privacy': 'public',
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()['visibility_movies'] is None
+    assert test_client.get('/v1/public/avery?shelf=movies').status_code == 200
+
+    assert (
+        test_client.put(
+            '/v1/users/me/visibility',
+            headers=_auth(token),
+            json={'visibility_movies': 'private'},
+        ).status_code
+        == 200
+    )
+    assert test_client.get('/v1/public/avery?shelf=movies').status_code == 404
+
+    restored = test_client.put(
+        '/v1/users/me/visibility',
+        headers=_auth(token),
+        json={'visibility_movies': None},
+    )
+    assert restored.status_code == 200
+    assert restored.json()['visibility_movies'] is None
+    assert test_client.get('/v1/public/avery?shelf=movies').status_code == 200
 
 
 def test_leaving_private_requires_a_handle(test_client: TestClient):
@@ -268,7 +310,7 @@ def test_partial_updates_only_touch_sent_fields(test_client: TestClient):
     assert body['visibility_movies'] == 'public'
     assert body['visibility_books'] == 'friends'
     assert body['visibility_tv'] == 'friends'
-    assert body['visibility_games'] == 'friends'
+    assert body['visibility_games'] is None
 
 
 def test_visibility_update_cannot_be_redirected_to_another_user(

--- a/tests/unit/activity_sharing_migration_test.py
+++ b/tests/unit/activity_sharing_migration_test.py
@@ -1,0 +1,47 @@
+"""The activity-sharing migration adds a default-on, reversible switch."""
+
+import importlib.util
+from pathlib import Path
+
+from sqlalchemy import create_engine, inspect, text
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+
+def _migration_module():
+    path = (
+        Path(__file__).parents[2]
+        / 'alembic/versions/e2c7a94f1b30_activity_sharing_opt_out.py'
+    )
+    spec = importlib.util.spec_from_file_location('activity_sharing_migration', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_upgrade_defaults_existing_users_in_and_downgrade_is_reversible():
+    """Upgrade existing data safely, then restore the original schema."""
+    migration = _migration_module()
+    engine = create_engine('sqlite://')
+    with engine.begin() as connection:
+        connection.execute(text('CREATE TABLE users (pk INTEGER PRIMARY KEY)'))
+        connection.execute(text('INSERT INTO users (pk) VALUES (1)'))
+        migration.op = Operations(MigrationContext.configure(connection))
+
+        migration.upgrade()
+        columns = {
+            column['name']: column
+            for column in inspect(connection).get_columns('users')
+        }
+        assert columns['share_activity']['nullable'] is False
+        assert (
+            connection.execute(
+                text('SELECT share_activity FROM users WHERE pk = 1')
+            ).scalar_one()
+            == 1
+        )
+
+        migration.downgrade()
+        assert {
+            column['name'] for column in inspect(connection).get_columns('users')
+        } == {'pk'}

--- a/tests/unit/visibility_test.py
+++ b/tests/unit/visibility_test.py
@@ -11,6 +11,7 @@ from app.services.visibility import (
     is_public,
     most_open,
     openness,
+    resolve_tier,
 )
 
 
@@ -32,6 +33,13 @@ def test_only_public_is_public():
     assert is_public(VisibilityTier.PRIVATE) is False
     # Strings off the wire resolve the same way as enum members.
     assert is_public('public') is True
+
+
+def test_shelf_override_resolution_uses_default_only_when_absent():
+    assert resolve_tier('friends', None) is VisibilityTier.FRIENDS
+    assert resolve_tier('private', 'public') is VisibilityTier.PUBLIC
+    # A malformed override must still resolve closed, never to the default.
+    assert resolve_tier('public', 'everyone') is VisibilityTier.PRIVATE
 
 
 def test_most_open_picks_the_widest_tier():


### PR DESCRIPTION
## Summary

Three parallel sharing stories that turned out to be one change. Each was
correct alone and their own suites passed; merged together they broke, so they
ship as one PR rather than three that are only right in a particular order.

- **Feed (#280).** There was no viewer feed — activity existed only for the
  caller. Adds `GET /v1/users/me/feed`, returning actor-attributed ranking and
  watchlist events from accepted friends and followed users. Relationships and
  the owner's *current* tiers are joined at read time, so an unfriend, unfollow,
  or tier reduction takes effect on old entries immediately rather than needing
  a fan-out rewrite. Four bounded shelf queries, an opaque
  `(occurred_at, shelf, tracker pk)` keyset cursor, default page 50, hard max
  100. Adds a default-on `share_activity` opt-out so an owner can withdraw every
  otherwise-authorized contribution without touching tracker rows.
  `/v1/users/me/activity` keeps its existing contract.

- **Default privacy (#298).** A shelf always stored a concrete tier, so an
  account-wide setting could not reach a shelf the user had never configured.
  Adds `default_privacy` (default `friends`), makes the eight shelf and
  watchlist tiers nullable, and resolves `null` against the default through one
  shared resolver used by profile, summary, and comparison reads. `null` on a
  shelf means "clear this override"; an omitted field is still a no-op. The
  profile tier stays explicit and non-null — it remains the outer access
  boundary and keeps the profile-covers-shelves invariant.

- **Follower counts (#320).** The public-only follow relation had no way to show
  its audience. Adds an exact `follower_count`, exposed only while
  `visibility_profile` is `public`: friends-only search results report `null`,
  and non-public profile responses omit the field entirely. Existing follow rows
  are deliberately retained when a followee stops being public — matching the
  policy established in #276 — so a follower can still unfollow; they just stop
  being counted.

- **The integration bug, which is why these are one PR.** #280's feed compared
  the stored shelf column directly against the tier constants. #298 made that
  column nullable, where `null` means "inherit `default_privacy`". `NULL =
  'friends'` evaluates to null rather than false, so **every inherited shelf
  silently dropped out of every viewer's feed** — no error, just missing events.
  The feed query now coalesces the override against `default_privacy` in SQL,
  mirroring `visibility.resolve_tier`. Landing #280 and #298 as separate PRs
  would reintroduce this the moment the second one merged.

- **Migrations are linearized.** Both stories added a revision off
  `a7d40c9b1e52`; `ab29c4e81f70` (default privacy) is now parented on
  `e2c7a94f1b30` (activity sharing), so the branch has a single head. #298's
  migration preserves existing concrete shelf tiers as overrides — **no user's
  visibility changes on upgrade**, only new or explicitly-cleared shelves
  inherit.

- **No web changes here.** The Default Sharing control in the web settings page
  still bulk-writes concrete tiers and cannot reach the new field; that gap is
  filed as ALeonard9/druthers-web#223.

## Test plan

- [x] `pytest -q` — **866 passed**, 17 pre-existing warnings. The merged state
      initially failed 7 tests in `router_activity_test.py`; all pass now.
- [x] New case `test_feed_resolves_a_shelf_with_no_override_against_the_default`
      pins the regression both ways: a shelf with no override is visible to a
      friend while the default admits them, and disappears when the default
      closes. Verified it is actually collected (24 in that file), not silently
      skipped.
- [x] Also added: 12 social-feed cases (friend/follow dedup, pending-request
      exclusion, retroactive tier changes, all four domains, same-timestamp
      keyset paging, oversized page rejection), migration upgrade/downgrade,
      follower-count progression, and search-result count gating.
- [x] Verified against the local dev stack (Postgres + seeded dev cast), not
      just SQLite:
  - Feed as `you`: **8 items from `friend` + 1 from `followee`**, nothing from
    `follower`, `stranger`, `public-user`, or `private-user`.
  - `friend` sets `share_activity: false` → all 8 vanish; back to `true` → all 8 return.
  - Paging `?limit=5`: **5 then 4, zero overlap, 9 distinct** actor/category/id keys.
  - #298: clearing `visibility_movies` keeps the shelf at 200 for a friend
    (inheriting `friends`), then `default_privacy: private` turns it **404**.
  - #320: `follower_count` on `/v1/public/you` moves **1 → 2 → 1** across a
    follow and unfollow; `/v1/search/users` reports `null` for a friends-only
    profile and exact counts for public ones; `/v1/public/private-user` stays
    **404**.
  - `task migrate` applies both revisions in one chain against real Postgres.

## Checklist

- [x] Branch named `feat/…`
- [x] New module has a test file in this PR (see CLAUDE.md → Testing)
- [x] Per-domain change checked against the other three domains (movies/TV/books/games) — the feed and the resolver both run through the shared shelf registry; the feed test covers all four
- [x] CI green (lint + tests) — pre-commit black/pylint clean, suite green
- [x] No secrets committed
- [ ] Docs/README updated if behavior changed — not updated; flagging rather than claiming it

Closes #280. Closes #298. Closes #320.
