### PR TITLE
Add sort, search, and a total to the tracker list endpoints

### DIFF
--- a/app/router/v1/router_books.py
+++ b/app/router/v1/router_books.py
@@ -7,7 +7,7 @@ search proxy, lazy enrichment on detail view (keyed on isbn), and per-user
 trackers with independent Watchlist (to-read) / Rankings (read) lists.
 """
 
-from typing import List
+from typing import List, Union
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func
@@ -16,9 +16,9 @@ from sqlalchemy.orm import Session, joinedload
 from app.db.database import get_db
 from app.services.rate_limit import catalog_add_cap, search_rate_limit
 from app.services.tracker_query import (
-    apply_list_params,
-    guard_truncation,
+    list_tracker_items,
     list_params,
+    tracker_list_response,
 )
 from app.services.tracker_rules import (
     default_completed_at,
@@ -35,6 +35,7 @@ from app.schemas.schemas_sandbox import (
     BookSummary,
     BookUpdate,
     RankPlacement,
+    TrackerListPage,
     UserBookCreate,
     UserBookResponse,
     UserBookUpdate,
@@ -212,7 +213,10 @@ def _close_rank_gap(db: Session, user_pk: int, vacated_rank) -> None:
     ).update({DbUserBook.rank: DbUserBook.rank - 1}, synchronize_session=False)
 
 
-@router.get('/users/me/books', response_model=List[UserBookResponse])
+@router.get(
+    '/users/me/books',
+    response_model=Union[List[UserBookResponse], TrackerListPage[UserBookResponse]],
+)
 def get_user_books(
     db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
@@ -223,8 +227,8 @@ def get_user_books(
         .options(joinedload(DbUserBook.book))
         .filter(DbUserBook.user_id == current_user[0].pk)
     )
-    rows = apply_list_params(query, DbUserBook, params).all()
-    return guard_truncation(rows, params, 'Book')
+    rows, total = list_tracker_items(query, DbUserBook, DbBook, params)
+    return tracker_list_response(rows, total, params, 'Book')
 
 
 @router.put('/users/me/books/rankings/order', response_model=List[UserBookResponse])

--- a/app/router/v1/router_games.py
+++ b/app/router/v1/router_games.py
@@ -8,7 +8,7 @@ and per-user trackers with independent Watchlist (backlog) / Rankings
 (played) lists plus a 100%-completion flag.
 """
 
-from typing import List
+from typing import List, Union
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func
@@ -17,9 +17,9 @@ from sqlalchemy.orm import Session, joinedload
 from app.db.database import get_db
 from app.services.rate_limit import catalog_add_cap, search_rate_limit
 from app.services.tracker_query import (
-    apply_list_params,
-    guard_truncation,
+    list_tracker_items,
     list_params,
+    tracker_list_response,
 )
 from app.services.tracker_rules import (
     default_completed_at,
@@ -32,6 +32,7 @@ from app.schemas.schemas_sandbox import (
     GameRankingReorder,
     GameSearchResult,
     RankPlacement,
+    TrackerListPage,
     UserVideoGameCreate,
     UserVideoGameResponse,
     UserVideoGameUpdate,
@@ -207,7 +208,12 @@ def _close_rank_gap(db: Session, user_pk: int, vacated_rank) -> None:
     )
 
 
-@router.get('/users/me/games', response_model=List[UserVideoGameResponse])
+@router.get(
+    '/users/me/games',
+    response_model=Union[
+        List[UserVideoGameResponse], TrackerListPage[UserVideoGameResponse]
+    ],
+)
 def get_user_games(
     db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
@@ -218,8 +224,8 @@ def get_user_games(
         .options(joinedload(DbUserVideoGame.game))
         .filter(DbUserVideoGame.user_id == current_user[0].pk)
     )
-    rows = apply_list_params(query, DbUserVideoGame, params).all()
-    return guard_truncation(rows, params, 'Game')
+    rows, total = list_tracker_items(query, DbUserVideoGame, DbVideoGame, params)
+    return tracker_list_response(rows, total, params, 'Game')
 
 
 @router.put(

--- a/app/router/v1/router_movies.py
+++ b/app/router/v1/router_movies.py
@@ -3,7 +3,7 @@
 This module contains the API routes for Movies.
 """
 
-from typing import List
+from typing import List, Union
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func, or_
@@ -25,6 +25,7 @@ from app.schemas.schemas_sandbox import (
     MovieUpdate,
     RankPlacement,
     RankingReorder,
+    TrackerListPage,
     UserMovieCreate,
     UserMovieResponse,
     UserMovieUpdate,
@@ -40,9 +41,9 @@ from app.services.watch_providers import DEFAULT_REGION, get_movie_providers
 from app.services.search_correction import correct_query
 from app.services.tracked_status import attach_tracked_status
 from app.services.tracker_query import (
-    apply_list_params,
-    guard_truncation,
+    list_tracker_items,
     list_params,
+    tracker_list_response,
 )
 
 router = APIRouter(prefix='/v1', tags=['Movies'])
@@ -254,7 +255,10 @@ def _close_rank_gap(db: Session, user_pk: int, vacated_rank) -> None:
     ).update({DbUserMovie.rank: DbUserMovie.rank - 1}, synchronize_session=False)
 
 
-@router.get('/users/me/movies', response_model=List[UserMovieResponse])
+@router.get(
+    '/users/me/movies',
+    response_model=Union[List[UserMovieResponse], TrackerListPage[UserMovieResponse]],
+)
 def get_user_movies(
     db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
@@ -265,8 +269,8 @@ def get_user_movies(
         .options(joinedload(DbUserMovie.movie))
         .filter(DbUserMovie.user_id == current_user[0].pk)
     )
-    rows = apply_list_params(query, DbUserMovie, params).all()
-    return guard_truncation(rows, params, 'Movie')
+    rows, total = list_tracker_items(query, DbUserMovie, DbMovie, params)
+    return tracker_list_response(rows, total, params, 'Movie')
 
 
 @router.get('/users/me/movies/{movie_id}', response_model=UserMovieResponse)

--- a/app/router/v1/router_tv.py
+++ b/app/router/v1/router_tv.py
@@ -8,7 +8,7 @@ Watchlist/Rankings lists plus episode-level watched marks.
 """
 
 from datetime import datetime, time, timedelta
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func
@@ -18,9 +18,9 @@ from app.db.database import get_db
 from app.services import preferences
 from app.services.rate_limit import catalog_add_cap, search_rate_limit
 from app.services.tracker_query import (
-    apply_list_params,
-    guard_truncation,
+    list_tracker_items,
     list_params,
+    tracker_list_response,
 )
 from app.services.tracker_rules import (
     default_completed_at,
@@ -43,6 +43,7 @@ from app.schemas.schemas_sandbox import (
     TVShowSearchResult,
     TVShowSummary,
     TVShowUpdate,
+    TrackerListPage,
     UserTVEpisodeResponse,
     UserTVShowCreate,
     UserTVShowResponse,
@@ -377,7 +378,12 @@ def _watch_status(aired: int, watched: int, show_status: Optional[str]) -> str:
     return 'complete' if show_status == 'Ended' else 'up_to_date'
 
 
-@router.get('/users/me/tv-shows', response_model=List[UserTVShowWithStatus])
+@router.get(
+    '/users/me/tv-shows',
+    response_model=Union[
+        List[UserTVShowWithStatus], TrackerListPage[UserTVShowWithStatus]
+    ],
+)
 def get_user_tv_shows(
     db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
@@ -389,9 +395,7 @@ def get_user_tv_shows(
         .options(joinedload(DbUserTVShow.tv_show))
         .filter(DbUserTVShow.user_id == user_pk)
     )
-    trackers = guard_truncation(
-        apply_list_params(query, DbUserTVShow, params).all(), params, 'TV'
-    )
+    trackers, total = list_tracker_items(query, DbUserTVShow, DbTVShow, params)
     show_pks = [t.tv_show_id for t in trackers]
     aired_before = _local_day_end(current_user[0])
 
@@ -442,7 +446,7 @@ def get_user_tv_shows(
                 watched_count=watched_count,
             )
         )
-    return results
+    return tracker_list_response(results, total, params, 'TV')
 
 
 @router.get('/users/me/schedule', response_model=ScheduleResponse)

--- a/app/schemas/schemas_sandbox.py
+++ b/app/schemas/schemas_sandbox.py
@@ -5,7 +5,7 @@ This module contains Pydantic schemas for Sandbox entities.
 # pylint: disable=missing-class-docstring
 
 from datetime import date, datetime
-from typing import Annotated, List, Optional
+from typing import Annotated, Generic, List, Optional, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -15,6 +15,16 @@ from pydantic import BaseModel, ConfigDict, Field
 # database will reject — or, before the CHECK existed, a silently stored 0
 # that showed up as "0" at the top of the Top 5 board.
 RankPosition = Annotated[int, Field(ge=1)]
+TrackerItem = TypeVar('TrackerItem')
+
+
+class TrackerListPage(BaseModel, Generic[TrackerItem]):
+    """A page from a user's tracker collection."""
+
+    items: List[TrackerItem]
+    total: int
+    limit: int
+    offset: int
 
 
 # --- Watch providers (shared by Movies and TV) ---

--- a/app/services/tracker_query.py
+++ b/app/services/tracker_query.py
@@ -18,7 +18,7 @@ from fastapi import HTTPException, Query, status
 MAX_PAGE = 5000
 
 
-def list_params(
+def list_params(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     on_rankings: Optional[bool] = Query(
         None, description='Only ranked entries (true) or only unranked (false)'
     ),
@@ -29,6 +29,23 @@ def list_params(
         MAX_PAGE, ge=1, le=MAX_PAGE, description='Maximum entries to return'
     ),
     offset: int = Query(0, ge=0, description='Entries to skip'),
+    sort: Optional[str] = Query(
+        None,
+        pattern=r'^-?(rank|title|completed_at)$',
+        description=(
+            'Order by rank, title, or completed_at; prefix with - for descending'
+        ),
+    ),
+    search: Optional[str] = Query(
+        None, description='Case-insensitive substring match against the title'
+    ),
+    include_total: bool = Query(
+        False,
+        description=(
+            'Return an {items, total, limit, offset} envelope instead of the '
+            'legacy array response'
+        ),
+    ),
 ) -> dict:
     """FastAPI dependency supplying the shared tracker list query params."""
     return {
@@ -36,16 +53,48 @@ def list_params(
         'on_watchlist': on_watchlist,
         'limit': limit,
         'offset': offset,
+        'sort': sort,
+        'search': search,
+        'include_total': include_total,
     }
 
 
-def apply_list_params(query, tracker, params: dict):
-    """Apply the shared filters and paging to a tracker query."""
+def apply_list_params(query, tracker, catalog, params: dict):
+    """Apply the shared filters and ordering to a tracker query."""
+    sort = params['sort']
+    uses_catalog = params['search'] is not None or (
+        sort is not None and sort.lstrip('-') == 'title'
+    )
+    if uses_catalog:
+        query = query.join(catalog)
     if params['on_rankings'] is not None:
         query = query.filter(tracker.on_rankings.is_(params['on_rankings']))
     if params['on_watchlist'] is not None:
         query = query.filter(tracker.on_watchlist.is_(params['on_watchlist']))
-    return query.offset(params['offset']).limit(params['limit'])
+    if params['search'] is not None:
+        search = params['search']
+        query = query.filter(catalog.title.ilike(f'%{search}%'))
+    if sort is None:
+        return query
+
+    descending = sort.startswith('-')
+    column = {
+        'rank': tracker.rank,
+        'title': catalog.title,
+        'completed_at': tracker.completed_at,
+    }[sort.lstrip('-')]
+    order = column.desc() if descending else column.asc()
+    # The leading predicate puts nulls at the end for both ascending and
+    # descending sorts. The primary key makes pagination stable for ties.
+    return query.order_by(column.is_(None), order, tracker.pk)
+
+
+def list_tracker_items(query, tracker, catalog, params: dict):
+    """Return the requested page and, when requested, its pre-page total."""
+    query = apply_list_params(query, tracker, catalog, params)
+    total = query.order_by(None).count() if params['include_total'] else None
+    rows = query.offset(params['offset']).limit(params['limit']).all()
+    return rows, total
 
 
 def guard_truncation(rows, params: dict, label: str):
@@ -66,3 +115,15 @@ def guard_truncation(rows, params: dict, label: str):
             ),
         )
     return rows
+
+
+def tracker_list_response(rows, total, params: dict, label: str):
+    """Preserve legacy arrays until callers opt into the paginated envelope."""
+    if not params['include_total']:
+        return guard_truncation(rows, params, label)
+    return {
+        'items': rows,
+        'total': total,
+        'limit': params['limit'],
+        'offset': params['offset'],
+    }

--- a/tests/integration/router_tracker_paging_test.py
+++ b/tests/integration/router_tracker_paging_test.py
@@ -7,6 +7,11 @@ from app.services.tracker_query import MAX_PAGE
 # (list path, catalog path, catalog payload builder)
 DOMAINS = (
     ('movies', '/v1/movies', lambda i: {'title': f'M{i}', 'imdb': f'tt50{i}'}),
+    (
+        'tv-shows',
+        '/v1/tv-shows',
+        lambda i: {'title': f'T{i}', 'tvmaze': 5000 + i},
+    ),
     ('books', '/v1/books', lambda i: {'title': f'B{i}', 'googleid': f'gid50{i}'}),
     ('games', '/v1/games', lambda i: {'title': f'G{i}', 'igdb': 5000 + i}),
 )
@@ -19,15 +24,18 @@ def _auth(token: str) -> dict:
 def _seed(test_client: TestClient, domain: str, catalog_path: str, payload, count: int):
     """Create ``count`` catalog rows; rank the odd ones, queue the even ones."""
     token = test_client.first_user.token
+    entity_ids = []
     for i in range(count):
         entity_id = test_client.post(
             catalog_path, headers=_auth(test_client.admin_user.token), json=payload(i)
         ).json()['id']
+        entity_ids.append(entity_id)
         test_client.post(
             f'/v1/users/me/{domain}/{entity_id}',
             headers=_auth(token),
             json=({'on_rankings': True} if i % 2 else {'on_watchlist': True}),
         )
+    return entity_ids
 
 
 @pytest.mark.parametrize('domain,catalog_path,payload', DOMAINS)
@@ -47,6 +55,26 @@ def test_limit_and_offset_page_the_list(
 
 
 @pytest.mark.parametrize('domain,catalog_path,payload', DOMAINS)
+def test_include_total_returns_page_metadata(
+    test_client: TestClient, domain, catalog_path, payload
+):
+    token = test_client.first_user.token
+    _seed(test_client, domain, catalog_path, payload, 6)
+    path = f'/v1/users/me/{domain}'
+
+    page = test_client.get(
+        f'{path}?on_rankings=true&limit=2&offset=2&include_total=true',
+        headers=_auth(token),
+    ).json()
+
+    assert page['total'] == 3
+    assert page['limit'] == 2
+    assert page['offset'] == 2
+    assert len(page['items']) == 1
+    assert page['items'][0]['on_rankings'] is True
+
+
+@pytest.mark.parametrize('domain,catalog_path,payload', DOMAINS)
 def test_list_filters(test_client: TestClient, domain, catalog_path, payload):
     token = test_client.first_user.token
     _seed(test_client, domain, catalog_path, payload, 6)
@@ -60,6 +88,86 @@ def test_list_filters(test_client: TestClient, domain, catalog_path, payload):
     assert all(q['on_watchlist'] for q in queued)
 
 
+@pytest.mark.parametrize('domain,catalog_path,payload', DOMAINS)
+def test_list_searches_titles_case_insensitively(
+    test_client: TestClient, domain, catalog_path, payload
+):
+    token = test_client.first_user.token
+    _seed(test_client, domain, catalog_path, payload, 3)
+    path = f'/v1/users/me/{domain}'
+
+    result = test_client.get(
+        f'{path}?search={domain[0].lower()}1&include_total=true',
+        headers=_auth(token),
+    ).json()
+
+    assert result['total'] == 1
+    assert (
+        result['items'][0][
+            {
+                'movies': 'movie',
+                'tv-shows': 'tv_show',
+                'books': 'book',
+                'games': 'game',
+            }[domain]
+        ]['title']
+        == f'{domain[0].upper()}1'
+    )
+
+
+@pytest.mark.parametrize('domain,catalog_path,payload', DOMAINS)
+@pytest.mark.parametrize('sort', ('rank', '-rank'))
+def test_list_sorts_rank_and_keeps_nulls_last(
+    test_client: TestClient, domain, catalog_path, payload, sort
+):
+    token = test_client.first_user.token
+    entity_ids = _seed(test_client, domain, catalog_path, payload, 6)
+    path = f'/v1/users/me/{domain}'
+    for position, entity_id in enumerate(entity_ids[1::2], start=1):
+        response = test_client.put(
+            f'{path}/{entity_id}/rank',
+            headers=_auth(token),
+            json={'position': position},
+        )
+        assert response.status_code == 200
+
+    result = test_client.get(
+        f'{path}?sort={sort}&include_total=true', headers=_auth(token)
+    ).json()
+    ranks = [item['rank'] for item in result['items']]
+
+    assert ranks[:3] == ([1, 2, 3] if sort == 'rank' else [3, 2, 1])
+    assert ranks[3:] == [None, None, None]
+
+
+@pytest.mark.parametrize('domain,catalog_path,payload', DOMAINS)
+@pytest.mark.parametrize('sort', ('title', '-completed_at'))
+def test_list_sorts_title_and_completed_at(
+    test_client: TestClient, domain, catalog_path, payload, sort
+):
+    token = test_client.first_user.token
+    _seed(test_client, domain, catalog_path, payload, 6)
+    path = f'/v1/users/me/{domain}'
+
+    items = test_client.get(
+        f'{path}?sort={sort}&include_total=true', headers=_auth(token)
+    ).json()['items']
+
+    if sort == 'title':
+        title_key = {
+            'movies': 'movie',
+            'tv-shows': 'tv_show',
+            'books': 'book',
+            'games': 'game',
+        }[domain]
+        assert [item[title_key]['title'] for item in items] == [
+            f'{domain[0].upper()}{i}' for i in range(6)
+        ]
+    else:
+        assert all(item['completed_at'] is not None for item in items[:3])
+        assert all(item['completed_at'] is None for item in items[3:])
+
+
 def test_limit_is_capped_at_max_page(test_client: TestClient):
     response = test_client.get(
         f'/v1/users/me/movies?limit={MAX_PAGE + 1}',
@@ -68,30 +176,9 @@ def test_limit_is_capped_at_max_page(test_client: TestClient):
     assert response.status_code == 422
 
 
-def test_tv_list_takes_the_same_params(test_client: TestClient):
-    token = test_client.first_user.token
-    show_id = test_client.post(
-        '/v1/tv-shows',
-        headers=_auth(test_client.admin_user.token),
-        json={'title': 'Show', 'tvmaze': 5001},
-    ).json()['id']
-    test_client.post(
-        f'/v1/users/me/tv-shows/{show_id}',
-        headers=_auth(token),
-        json={'on_watchlist': True},
+def test_list_rejects_an_unknown_sort(test_client: TestClient):
+    response = test_client.get(
+        '/v1/users/me/movies?sort=created_at',
+        headers=_auth(test_client.first_user.token),
     )
-
-    assert (
-        len(
-            test_client.get(
-                '/v1/users/me/tv-shows?on_watchlist=true', headers=_auth(token)
-            ).json()
-        )
-        == 1
-    )
-    assert (
-        test_client.get(
-            '/v1/users/me/tv-shows?on_rankings=true', headers=_auth(token)
-        ).json()
-        == []
-    )
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary

- The tracker list endpoints returned a bare array with no total, no ordering control, and no way to search within a shelf. A client wanting "how many do I have" or "find the one called X" had to fetch the whole collection and do it locally, which is what `ALeonard9/druthers-web#240` exists to stop doing.
- Adds `sort`, `search` and `include_total` to the tracker list endpoints across all four domains — movies, TV shows, books and games — in lockstep.
- **The default response shape is unchanged.** Without `include_total` the endpoints still return a plain array, so every existing caller — web, MCP, iOS — keeps working untouched. `include_total=true` opts into an `{items, total, limit, offset}` envelope instead.
- `sort` takes a field with an optional `-` prefix for descending. `search` filters on the catalog title with a case-insensitive contains, and only joins the catalog table when a search or a title sort actually needs it.
- Shared logic lives in `app/services/tracker_query.py` rather than being repeated per router.

## Test plan

- [x] `pytest -q` — **898 passed**, 17 warnings
- [x] `tests/integration/router_tracker_paging_test.py` extended for sort direction, search matching, the total envelope, and the unchanged default shape
- [x] **Verified against the local dev stack** from the `friend@example.com` seat:
  - default, no params → plain list of 8 (back-compat intact)
  - `?include_total=true&limit=3` → `{"items": [...3], "total": 8, "limit": 3, "offset": 0}`
  - `?sort=title&limit=4` → Dune, Inception, Interstellar, Parasite
  - `?sort=-title&limit=4` → Whiplash, The Matrix, The Dark Knight, Pulp Fiction
  - `?search=the&include_total=true` → `total: 2` — The Dark Knight, The Matrix
- [x] Merges onto current `main` with no conflicts

## Note for sequencing

`ALeonard9/druthers-web#240` consumes these filters. This has to be merged and deployed **before** #240 ships, or the web app calls parameters the API does not yet accept.

Closes #339.
