### PR TITLE
Fix self-service account deletion cascades

### DIFF
--- a/app/auth/oauth2.py
+++ b/app/auth/oauth2.py
@@ -89,6 +89,23 @@ def _user_from_api_key(token: str, db: Session, credentials_exception):
     return [row.user]
 
 
+def _user_from_access_token(token: str, db: Session, credentials_exception):
+    """Resolve a signed, expiring access JWT to its user."""
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        uuid: str = payload.get('sub')
+        if uuid is None:
+            raise credentials_exception
+    except jwt.ExpiredSignatureError as exc:
+        raise credentials_exception from exc
+    except jwt.InvalidTokenError as exc:
+        raise credentials_exception from exc
+    user = db_user.get_user(db, uuid)
+    if user is None:
+        raise credentials_exception
+    return user
+
+
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
     """
     This function creates an access token
@@ -118,19 +135,26 @@ def get_current_user(
     )
     if token.startswith(API_KEY_PREFIX):
         return _user_from_api_key(token, db, credentials_exception)
-    try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        uuid: str = payload.get('sub')
-        if uuid is None:
-            raise credentials_exception
-    except jwt.ExpiredSignatureError as exc:
-        raise credentials_exception from exc
-    except jwt.InvalidTokenError as exc:
-        raise credentials_exception from exc
-    user = db_user.get_user(db, uuid)
-    if user is None:
-        raise credentials_exception
-    return user
+    return _user_from_access_token(token, db, credentials_exception)
+
+
+def get_current_session_user(
+    token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)
+):
+    """
+    Authenticate only an expiring interactive-session access token.
+
+    API keys are intentionally not considered here. Destructive account
+    deletion uses this dependency so a long-lived MCP or script credential
+    cannot delete its owner, while the rest of the API can continue accepting
+    both supported bearer credential types through :func:`get_current_user`.
+    """
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail='Could not validate credentials',
+        headers={'WWW-Authenticate': 'Bearer'},
+    )
+    return _user_from_access_token(token, db, credentials_exception)
 
 
 def get_optional_current_user(

--- a/app/db/db_user.py
+++ b/app/db/db_user.py
@@ -6,7 +6,7 @@ import os
 
 from email_validator import EmailNotValidError, validate_email
 from fastapi import HTTPException, status
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session
 from sqlalchemy import or_
 
@@ -14,6 +14,17 @@ from app.db.hash import Hash
 from app.db.models import DbUser
 from app.log.logging_config import logger
 from app.schemas.model_schemas import InUserBase
+
+
+def _database_error_code(exc: SQLAlchemyError) -> str:
+    """Return a non-sensitive, stable identifier for a database failure."""
+    original = getattr(exc, 'orig', None)
+    return (
+        getattr(original, 'sqlstate', None)
+        or getattr(original, 'pgcode', None)
+        or getattr(exc, 'code', None)
+        or 'unknown'
+    )
 
 
 def create_user(db: Session, request: InUserBase) -> list[DbUser]:
@@ -228,8 +239,21 @@ def delete_user(db: Session, user_id: str) -> list[DbUser]:
             detail=f"User with id {user_id} not found",
         )
 
-    db.delete(user)
-    db.commit()
+    try:
+        db.delete(user)
+        db.commit()
+    except SQLAlchemyError as exc:
+        db.rollback()
+        logger.error(
+            'Failed to delete user account account_id=%s exception=%s database_code=%s',
+            user_id,
+            type(exc).__name__,
+            _database_error_code(exc),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail='Unable to delete user account',
+        ) from exc
     logger.info(
         'User deleted: %s, display_name: %s, email: %s',
         user.id,

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -190,7 +190,10 @@ class DbApiKey(DBBaseModel):
     prefix = Column(String(length=12), nullable=False)
     last_used_at = Column(DateTime, nullable=True)
 
-    user = relationship('DbUser', backref='api_keys')
+    user = relationship(
+        'DbUser',
+        backref=backref('api_keys', cascade='all, delete-orphan'),
+    )
 
 
 class DbRefreshToken(DBBaseModel):
@@ -281,6 +284,16 @@ class DbFriendship(DBBaseModel):
         ForeignKey('users.pk', ondelete='CASCADE'),
         nullable=False,
     )
+    user_low = relationship(
+        'DbUser',
+        foreign_keys=[user_low_id],
+        backref=backref('friendships_as_low', cascade='all, delete-orphan'),
+    )
+    user_high = relationship(
+        'DbUser',
+        foreign_keys=[user_high_id],
+        backref=backref('friendships_as_high', cascade='all, delete-orphan'),
+    )
     status = Column(
         Enum(
             FriendshipStatus,
@@ -343,6 +356,16 @@ class DbFollow(DBBaseModel):
         ForeignKey('users.pk', ondelete='CASCADE'),
         nullable=False,
         index=True,
+    )
+    follower = relationship(
+        'DbUser',
+        foreign_keys=[follower_id],
+        backref=backref('outgoing_follows', cascade='all, delete-orphan'),
+    )
+    followee = relationship(
+        'DbUser',
+        foreign_keys=[followee_id],
+        backref=backref('incoming_follows', cascade='all, delete-orphan'),
     )
     # Explicit rather than created_at/updated_at: those are row bookkeeping
     # and could be rewritten by a future column touch, whereas this is the

--- a/app/db/models_sandbox.py
+++ b/app/db/models_sandbox.py
@@ -19,7 +19,7 @@ from sqlalchemy import (
     UniqueConstraint,
     text,
 )
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import backref, relationship
 
 from app.db.models import DBBaseModel
 
@@ -79,7 +79,10 @@ class DbNotification(DBBaseModel):
     dedupe_key = Column(String(120), nullable=False)
     read = Column(Boolean, nullable=False, default=False)
 
-    user = relationship('DbUser', backref='notifications')
+    user = relationship(
+        'DbUser',
+        backref=backref('notifications', cascade='all, delete-orphan'),
+    )
 
 
 class DbMovie(DBBaseModel):
@@ -143,8 +146,16 @@ class DbUserMovie(DBBaseModel):
     is_seed_data = Column(Boolean, nullable=False, default=False)
 
     movie = relationship('DbMovie', back_populates='user_movies')
-    user = relationship('DbUser', foreign_keys=[user_id], backref='user_movies')
-    source_user = relationship('DbUser', foreign_keys=[source_user_id])
+    user = relationship(
+        'DbUser',
+        foreign_keys=[user_id],
+        backref=backref('user_movies', cascade='all, delete-orphan'),
+    )
+    source_user = relationship(
+        'DbUser',
+        foreign_keys=[source_user_id],
+        backref='sourced_user_movies',
+    )
 
     @property
     def source_handle(self):
@@ -209,8 +220,16 @@ class DbUserTVShow(DBBaseModel):
     is_seed_data = Column(Boolean, nullable=False, default=False)
 
     tv_show = relationship('DbTVShow', back_populates='user_tv_shows')
-    user = relationship('DbUser', foreign_keys=[user_id], backref='user_tv_shows')
-    source_user = relationship('DbUser', foreign_keys=[source_user_id])
+    user = relationship(
+        'DbUser',
+        foreign_keys=[user_id],
+        backref=backref('user_tv_shows', cascade='all, delete-orphan'),
+    )
+    source_user = relationship(
+        'DbUser',
+        foreign_keys=[source_user_id],
+        backref='sourced_user_tv_shows',
+    )
 
     @property
     def source_handle(self):
@@ -259,7 +278,10 @@ class DbUserTVEpisode(DBBaseModel):
     favorited_at = Column(DateTime, nullable=True)
 
     episode = relationship('DbTVEpisode', back_populates='user_episodes')
-    user = relationship('DbUser', backref='user_tv_episodes')
+    user = relationship(
+        'DbUser',
+        backref=backref('user_tv_episodes', cascade='all, delete-orphan'),
+    )
 
 
 class DbVideoGame(DBBaseModel):
@@ -314,8 +336,16 @@ class DbUserVideoGame(DBBaseModel):
     is_seed_data = Column(Boolean, nullable=False, default=False)
 
     game = relationship('DbVideoGame', back_populates='user_games')
-    user = relationship('DbUser', foreign_keys=[user_id], backref='user_video_games')
-    source_user = relationship('DbUser', foreign_keys=[source_user_id])
+    user = relationship(
+        'DbUser',
+        foreign_keys=[user_id],
+        backref=backref('user_video_games', cascade='all, delete-orphan'),
+    )
+    source_user = relationship(
+        'DbUser',
+        foreign_keys=[source_user_id],
+        backref='sourced_user_video_games',
+    )
 
     @property
     def source_handle(self):
@@ -378,8 +408,16 @@ class DbUserBook(DBBaseModel):
     is_seed_data = Column(Boolean, nullable=False, default=False)
 
     book = relationship('DbBook', back_populates='user_books')
-    user = relationship('DbUser', foreign_keys=[user_id], backref='user_books')
-    source_user = relationship('DbUser', foreign_keys=[source_user_id])
+    user = relationship(
+        'DbUser',
+        foreign_keys=[user_id],
+        backref=backref('user_books', cascade='all, delete-orphan'),
+    )
+    source_user = relationship(
+        'DbUser',
+        foreign_keys=[source_user_id],
+        backref='sourced_user_books',
+    )
 
     @property
     def source_handle(self):

--- a/app/router/v1/user.py
+++ b/app/router/v1/user.py
@@ -5,7 +5,7 @@ This module contains the API routes for user-related operations.
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
-from app.auth.oauth2 import get_current_user
+from app.auth.oauth2 import get_current_session_user, get_current_user
 from app.config import get_settings
 from app.db import db_user
 from app.db.database import get_db
@@ -135,7 +135,7 @@ def update_user(
 def delete_user(
     uuid: str,
     db: Session = Depends(get_db),
-    current_user: dict = Depends(get_current_user),
+    current_user: list = Depends(get_current_session_user),
 ):
     """
     Delete a user by ID from the database.

--- a/tests/integration/router_user_test.py
+++ b/tests/integration/router_user_test.py
@@ -7,8 +7,30 @@ from unittest.mock import patch
 
 from faker import Faker
 from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError
 
 from app.config import Settings
+from app.db.models import (
+    DbApiKey,
+    DbFollow,
+    DbFriendship,
+    DbRefreshToken,
+    DbUser,
+)
+from app.db.models_sandbox import (
+    DbBook,
+    DbMovie,
+    DbNotification,
+    DbTVEpisode,
+    DbTVShow,
+    DbUserBook,
+    DbUserMovie,
+    DbUserTVEpisode,
+    DbUserTVShow,
+    DbUserVideoGame,
+    DbVideoGame,
+)
+from app.services.friendships import FriendshipStatus
 
 fake = Faker()
 
@@ -370,6 +392,189 @@ def test_api_user_delete_self(
     )
     assert response_data['data'][0]['user_group'] == 'user'
     test_assert_timestamps(response_data['data'][0])
+
+
+def test_api_key_cannot_delete_owner_but_session_can(test_client: TestClient):
+    """Long-lived script credentials cannot perform irreversible deletion."""
+    user = test_client.first_user
+    session_headers = {'Authorization': f'Bearer {user.token}'}
+    create_response = test_client.post(
+        '/v1/users/me/api-keys',
+        headers=session_headers,
+        json={'name': 'Cannot delete account'},
+    )
+    assert create_response.status_code == 201
+    api_key = create_response.json()['key']
+
+    api_key_response = test_client.delete(
+        f'/v1/users/{user.id}',
+        headers={'Authorization': f'Bearer {api_key}'},
+    )
+
+    assert api_key_response.status_code == 401
+    assert api_key_response.json()['message'] == 'Could not validate credentials'
+    assert test_client.test_db_session.query(DbUser).filter_by(pk=user.pk).count() == 1
+
+    session_response = test_client.delete(
+        f'/v1/users/{user.id}', headers=session_headers
+    )
+    assert session_response.status_code == 200
+    assert test_client.test_db_session.query(DbUser).filter_by(pk=user.pk).count() == 0
+
+
+def test_api_user_delete_self_removes_owned_rows_only(test_client: TestClient):
+    """Account deletion removes every user-owned row, not shared catalog data."""
+    db = test_client.test_db_session
+    deleted_user = test_client.first_user
+    surviving_user = test_client.second_user
+
+    movie = DbMovie(title='Shared movie', tmdb=900_001)
+    show = DbTVShow(title='Shared show', tvmaze=900_002)
+    episode = DbTVEpisode(title='Shared episode', tvmaze=900_003, tv_show=show)
+    book = DbBook(title='Shared book', isbn='delete-test-book')
+    game = DbVideoGame(title='Shared game', igdb=900_004)
+    db.add_all([movie, show, book, game])
+    db.flush()
+
+    deleted_rows = [
+        DbUserMovie(user_id=deleted_user.pk, movie_id=movie.pk, on_watchlist=True),
+        DbUserTVShow(user_id=deleted_user.pk, tv_show_id=show.pk, on_watchlist=True),
+        DbUserTVEpisode(user_id=deleted_user.pk, episode_id=episode.pk, watched=1),
+        DbUserBook(user_id=deleted_user.pk, book_id=book.pk, on_watchlist=True),
+        DbUserVideoGame(user_id=deleted_user.pk, game_id=game.pk, on_watchlist=True),
+        DbNotification(
+            user_id=deleted_user.pk,
+            type='movie_release',
+            title='Owned notification',
+            dedupe_key='account-delete-owned-notification',
+        ),
+        DbApiKey(
+            user_id=deleted_user.pk,
+            name='Owned key',
+            key_hash='a' * 64,
+            prefix='drk_owned',
+        ),
+    ]
+    surviving_rows = [
+        DbUserMovie(
+            user_id=surviving_user.pk,
+            movie_id=movie.pk,
+            source_user_id=deleted_user.pk,
+            on_watchlist=True,
+        ),
+        DbUserTVShow(
+            user_id=surviving_user.pk,
+            tv_show_id=show.pk,
+            source_user_id=deleted_user.pk,
+            on_watchlist=True,
+        ),
+        DbUserTVEpisode(user_id=surviving_user.pk, episode_id=episode.pk, watched=1),
+        DbUserBook(
+            user_id=surviving_user.pk,
+            book_id=book.pk,
+            source_user_id=deleted_user.pk,
+            on_watchlist=True,
+        ),
+        DbUserVideoGame(
+            user_id=surviving_user.pk,
+            game_id=game.pk,
+            source_user_id=deleted_user.pk,
+            on_watchlist=True,
+        ),
+        DbNotification(
+            user_id=surviving_user.pk,
+            type='movie_release',
+            title='Surviving notification',
+            dedupe_key='account-delete-surviving-notification',
+        ),
+        DbApiKey(
+            user_id=surviving_user.pk,
+            name='Surviving key',
+            key_hash='b' * 64,
+            prefix='drk_survive',
+        ),
+    ]
+    db.add_all(deleted_rows + surviving_rows)
+    low, high = sorted((deleted_user.pk, surviving_user.pk))
+    db.add(
+        DbFriendship(
+            user_low_id=low,
+            user_high_id=high,
+            requested_by_id=deleted_user.pk,
+            status=FriendshipStatus.ACCEPTED,
+        )
+    )
+    db.add(DbFollow(follower_id=deleted_user.pk, followee_id=surviving_user.pk))
+    db.commit()
+
+    assert db.query(DbRefreshToken).filter_by(user_id=deleted_user.pk).count() == 1
+    response = test_client.delete(
+        f'/v1/users/{deleted_user.id}',
+        headers={'Authorization': f'Bearer {deleted_user.token}'},
+    )
+
+    assert response.status_code == 200
+    assert db.query(DbUser).filter_by(pk=deleted_user.pk).count() == 0
+    for model in (
+        DbUserMovie,
+        DbUserTVShow,
+        DbUserTVEpisode,
+        DbUserBook,
+        DbUserVideoGame,
+        DbNotification,
+        DbApiKey,
+        DbRefreshToken,
+    ):
+        assert db.query(model).filter_by(user_id=deleted_user.pk).count() == 0
+        assert db.query(model).filter_by(user_id=surviving_user.pk).count() == 1
+    for model in (DbUserMovie, DbUserTVShow, DbUserBook, DbUserVideoGame):
+        assert (
+            db.query(model).filter_by(user_id=surviving_user.pk).one().source_user_id
+            is None
+        )
+    assert db.query(DbFriendship).count() == 0
+    assert db.query(DbFollow).count() == 0
+    assert db.query(DbUser).filter_by(pk=surviving_user.pk).count() == 1
+    assert db.query(DbMovie).filter_by(pk=movie.pk).count() == 1
+    assert db.query(DbTVShow).filter_by(pk=show.pk).count() == 1
+    assert db.query(DbTVEpisode).filter_by(pk=episode.pk).count() == 1
+    assert db.query(DbBook).filter_by(pk=book.pk).count() == 1
+    assert db.query(DbVideoGame).filter_by(pk=game.pk).count() == 1
+
+
+def test_api_user_delete_failure_is_safe_and_rolls_back(
+    test_client: TestClient, caplog
+):
+    """Database failures return a stable message without SQL or row details."""
+    db = test_client.test_db_session
+    user = test_client.first_user
+    database_error = IntegrityError(
+        'UPDATE user_video_games SET user_id=NULL',
+        {'user_id': None},
+        ValueError('failing row contains private data'),
+    )
+
+    with (
+        patch.object(db, 'commit', side_effect=database_error),
+        patch.object(db, 'rollback', wraps=db.rollback) as rollback,
+    ):
+        response = test_client.delete(
+            f'/v1/users/{user.id}',
+            headers={'Authorization': f'Bearer {user.token}'},
+        )
+
+    assert response.status_code == 500
+    assert response.json() == {
+        'success': False,
+        'message': 'Unable to delete user account',
+        'data': [],
+    }
+    rollback.assert_called_once_with()
+    assert 'exception=IntegrityError' in caplog.text
+    assert 'database_code=gkpj' in caplog.text
+    assert 'UPDATE user_video_games' not in caplog.text
+    assert 'failing row contains private data' not in caplog.text
+    assert "'user_id': None" not in caplog.text
 
 
 def test_api_user_cant_delete_other(


### PR DESCRIPTION
## Summary

- Self-service account deletion attempted to set non-null user foreign keys to null, so stocked accounts failed with a database constraint error and exposed SQL details to the browser.
- Cascade deletion through every user-owned movie, TV, episode, book, game, notification, API-key, token, friendship, and follow relationship while preserving shared catalog rows and other users' trackers.
- Require a signed interactive access token for irreversible deletion, rejecting long-lived API keys while preserving owner, admin, and cross-user authorization behavior.
- Roll back database failures and return and log only stable, sanitized error details.

## Test plan

- [x] `pytest`, 897 tests passed at 87% coverage, including 19 user-router tests for all four tracker domains, cross-user preservation, API-key rejection, rollback, and sanitized errors.
- [x] Black, Pylint, and all changed-file pre-commit hooks passed.
- [x] Verified against the local Postgres dev stack at `http://localhost:3000/settings`: the previously failing stocked disposable account deletion returned 200, removed the session, and displayed no SQLAlchemy error.

## Checklist

- [ ] Branch uses the required `codex/` desktop prefix rather than the repository `fix/` convention
- [x] No new module was introduced; integration coverage is in the existing user-router test file
- [x] Per-domain deletion checked across movies, TV, books, and games
- [ ] CI green, pending GitHub checks
- [x] No secrets committed
- [x] Docs/README not required for this corrective behavior
