### PR TITLE
feat(admin): admin console API - directory, audit trail, account disable, and read-only view-as

### DIFF
--- a/alembic/versions/c71d4e83f9a2_impersonation_sessions.py
+++ b/alembic/versions/c71d4e83f9a2_impersonation_sessions.py
@@ -1,0 +1,101 @@
+"""Add impersonation_sessions
+
+Server-side state for the admin view-as feature (#341). The impersonation
+JWT is the capability, but a token alone cannot satisfy two of the issue's
+requirements: ending a session "at any time", and a session dying when the
+acting admin is demoted or disabled. Both need a row to check per request.
+
+Separate migration rather than folded into e584fd92429d: that one is the
+audit-log/disabled_at foundation and has already been applied locally, and
+these are different features that should be revertable independently.
+
+Revision ID: c71d4e83f9a2
+Revises: e584fd92429d
+Create Date: 2026-08-19 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'c71d4e83f9a2'
+down_revision: Union[str, Sequence[str], None] = 'e584fd92429d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'impersonation_sessions',
+        sa.Column('pk', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('id', sa.String(), nullable=True),
+        sa.Column('admin_user_pk', sa.Integer(), nullable=False),
+        sa.Column('target_user_pk', sa.Integer(), nullable=False),
+        sa.Column('reason', sa.String(), nullable=True),
+        sa.Column('expires_at', sa.DateTime(), nullable=False),
+        sa.Column('ended_at', sa.DateTime(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ['admin_user_pk'],
+            ['users.pk'],
+            name='fk_impersonation_sessions_admin_user_pk',
+            ondelete='CASCADE',
+        ),
+        sa.ForeignKeyConstraint(
+            ['target_user_pk'],
+            ['users.pk'],
+            name='fk_impersonation_sessions_target_user_pk',
+            ondelete='CASCADE',
+        ),
+        sa.PrimaryKeyConstraint('pk'),
+    )
+    op.create_index(
+        op.f('ix_impersonation_sessions_pk'),
+        'impersonation_sessions',
+        ['pk'],
+        unique=False,
+    )
+    # Looked up by id on every impersonated request, so it needs the index
+    # even though the base model would give it one anyway.
+    op.create_index(
+        op.f('ix_impersonation_sessions_id'),
+        'impersonation_sessions',
+        ['id'],
+        unique=True,
+    )
+    op.create_index(
+        op.f('ix_impersonation_sessions_admin_user_pk'),
+        'impersonation_sessions',
+        ['admin_user_pk'],
+        unique=False,
+    )
+    op.create_index(
+        op.f('ix_impersonation_sessions_target_user_pk'),
+        'impersonation_sessions',
+        ['target_user_pk'],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        op.f('ix_impersonation_sessions_target_user_pk'),
+        table_name='impersonation_sessions',
+    )
+    op.drop_index(
+        op.f('ix_impersonation_sessions_admin_user_pk'),
+        table_name='impersonation_sessions',
+    )
+    op.drop_index(
+        op.f('ix_impersonation_sessions_id'), table_name='impersonation_sessions'
+    )
+    op.drop_index(
+        op.f('ix_impersonation_sessions_pk'), table_name='impersonation_sessions'
+    )
+    op.drop_table('impersonation_sessions')

--- a/alembic/versions/e584fd92429d_admin_audit_log_and_user_disabled_at.py
+++ b/alembic/versions/e584fd92429d_admin_audit_log_and_user_disabled_at.py
@@ -31,6 +31,8 @@ def upgrade() -> None:
     op.create_table(
         'admin_audit_log',
         sa.Column('actor_user_pk', sa.Integer(), nullable=True),
+        sa.Column('actor_user_id', sa.String(), nullable=True),
+        sa.Column('actor_email', sa.String(), nullable=True),
         sa.Column('target_user_pk', sa.Integer(), nullable=True),
         sa.Column('target_user_id', sa.String(), nullable=True),
         sa.Column('target_email', sa.String(), nullable=True),

--- a/alembic/versions/e584fd92429d_admin_audit_log_and_user_disabled_at.py
+++ b/alembic/versions/e584fd92429d_admin_audit_log_and_user_disabled_at.py
@@ -1,0 +1,95 @@
+"""Add admin_audit_log table and users.disabled_at
+
+Foundations for the admin console (#344): an append-only audit trail for
+admin actions, and the disable/enable status column the directory reads
+from. Nothing writes ``disabled_at`` yet - the toggle and enforcing it on
+the auth path are a later increment - this migration only adds the column
+so the web directory has a real status field from the start.
+
+Revision ID: e584fd92429d
+Revises: 8f2c1a4d9b73
+Create Date: 2026-08-18 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'e584fd92429d'
+down_revision: Union[str, Sequence[str], None] = '8f2c1a4d9b73'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('users', sa.Column('disabled_at', sa.DateTime(), nullable=True))
+
+    op.create_table(
+        'admin_audit_log',
+        sa.Column('actor_user_pk', sa.Integer(), nullable=True),
+        sa.Column('target_user_pk', sa.Integer(), nullable=True),
+        sa.Column('target_user_id', sa.String(), nullable=True),
+        sa.Column('target_email', sa.String(), nullable=True),
+        sa.Column('action', sa.String(), nullable=False),
+        sa.Column('result', sa.String(length=16), nullable=False),
+        sa.Column('detail', sa.JSON(), nullable=True),
+        sa.Column('request_id', sa.String(), nullable=True),
+        sa.Column('method', sa.String(length=10), nullable=True),
+        sa.Column('path', sa.String(), nullable=True),
+        sa.Column('status_code', sa.Integer(), nullable=True),
+        sa.Column('source_ip', sa.String(), nullable=True),
+        sa.Column('user_agent', sa.String(), nullable=True),
+        sa.Column('pk', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('id', sa.String(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ['actor_user_pk'],
+            ['users.pk'],
+            name='fk_admin_audit_log_actor_user_pk_users',
+            ondelete='SET NULL',
+        ),
+        sa.ForeignKeyConstraint(
+            ['target_user_pk'],
+            ['users.pk'],
+            name='fk_admin_audit_log_target_user_pk_users',
+            ondelete='SET NULL',
+        ),
+        sa.PrimaryKeyConstraint('pk'),
+    )
+    with op.batch_alter_table('admin_audit_log', schema=None) as batch_op:
+        batch_op.create_index(batch_op.f('ix_admin_audit_log_id'), ['id'], unique=True)
+        batch_op.create_index(batch_op.f('ix_admin_audit_log_pk'), ['pk'], unique=False)
+        batch_op.create_index(
+            batch_op.f('ix_admin_audit_log_actor_user_pk'),
+            ['actor_user_pk'],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f('ix_admin_audit_log_target_user_pk'),
+            ['target_user_pk'],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f('ix_admin_audit_log_action'), ['action'], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f('ix_admin_audit_log_created_at'), ['created_at'], unique=False
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('admin_audit_log', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_admin_audit_log_created_at'))
+        batch_op.drop_index(batch_op.f('ix_admin_audit_log_action'))
+        batch_op.drop_index(batch_op.f('ix_admin_audit_log_target_user_pk'))
+        batch_op.drop_index(batch_op.f('ix_admin_audit_log_actor_user_pk'))
+        batch_op.drop_index(batch_op.f('ix_admin_audit_log_pk'))
+        batch_op.drop_index(batch_op.f('ix_admin_audit_log_id'))
+    op.drop_table('admin_audit_log')
+    op.drop_column('users', 'disabled_at')

--- a/app/auth/authentication.py
+++ b/app/auth/authentication.py
@@ -3,6 +3,7 @@ This module creates tokens for users.
 """
 
 import secrets
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, status
 from fastapi.param_functions import Depends
@@ -207,5 +208,17 @@ def logout(request: InRefreshToken, db: Session = Depends(get_db)):
     Deliberately 204 whether or not the token was recognised - sign-out must
     not depend on the client still holding a valid credential, and the status
     shouldn't reveal whether a guessed token existed.
+
+    Signing out also ends any view-as session the owner of that refresh token
+    is running (#341). Otherwise an admin could sign out believing they had
+    closed everything down while a live impersonation token kept working
+    until its own expiry.
     """
+    owner_pk = refresh_tokens.owner_pk_for_token(db, request.refresh_token)
     refresh_tokens.revoke_refresh_token(db, request.refresh_token)
+    if owner_pk is not None:
+        db.query(models.DbImpersonationSession).filter(
+            models.DbImpersonationSession.admin_user_pk == owner_pk,
+            models.DbImpersonationSession.ended_at.is_(None),
+        ).update({'ended_at': datetime.now(timezone.utc)}, synchronize_session=False)
+        db.commit()

--- a/app/auth/authentication.py
+++ b/app/auth/authentication.py
@@ -83,6 +83,14 @@ def get_token(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail='Invalid credentials'
         )
+    if user.disabled_at is not None:
+        # Correct credentials, but this account is not allowed to sign in.
+        # The resolver in oauth2.py would reject the token on its very next
+        # use anyway; rejecting here too means the client never sees a
+        # "successful" sign-in that dies on the following request.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail='Account disabled'
+        )
 
     return _sign_in_response(user, db)
 
@@ -153,6 +161,10 @@ def google_login(request: GoogleAuthRequest, db: Session = Depends(get_db)):
         db.add(user)
         db.commit()
         db.refresh(user)
+    elif user.disabled_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail='Account disabled'
+        )
 
     return _sign_in_response(user, db)
 

--- a/app/auth/oauth2.py
+++ b/app/auth/oauth2.py
@@ -2,6 +2,17 @@
 This module creates access tokens and verifys tokens.
 """
 
+# pylint: disable=cyclic-import
+# _audit_impersonation_write_blocked below does a deferred import of
+# app.services.admin_audit, which imports app.services.rate_limit, which
+# imports this module at top level. The edge is real but harmless: it is
+# deferred to call time, well after every module involved has finished
+# importing, so it never executes during import resolution. pylint's
+# cyclic-import check still counts deferred edges when building its graph
+# and has no per-import way to say "this one is fine" (its report also
+# lands on an unrelated third file, not the line with the import), so the
+# only precise place to silence it is here, module-wide.
+
 import hashlib
 import secrets
 from datetime import datetime, timedelta, timezone
@@ -130,6 +141,54 @@ def _impersonation_exception(detail: str) -> HTTPException:
     return HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
 
 
+def _session_expires_at_utc(row) -> datetime:
+    """
+    Read ``DbImpersonationSession.expires_at`` back as UTC-aware.
+
+    The column is a naive ``DateTime`` holding a UTC value, which is the
+    normal case here (SQLite and Postgres both hand back naive values, and
+    everything that writes this column stamps UTC). ``.replace(tzinfo=...)``
+    overwrites rather than converts, though: fed an already-aware,
+    non-UTC value it would silently misread as UTC and shift the session's
+    effective expiry by the offset. ``.astimezone`` converts correctly when
+    tzinfo is already present, so use it instead of assuming the naive case.
+    """
+    return (
+        row.expires_at.astimezone(timezone.utc)
+        if row.expires_at.tzinfo
+        else row.expires_at.replace(tzinfo=timezone.utc)
+    )
+
+
+def _audit_impersonation_write_blocked(request, admin, target) -> None:
+    """
+    Record a refused write attempted from a live impersonation session.
+
+    A denied *start* is already audited by the caller in
+    ``router_admin.start_impersonation``; without this, a denied *write*
+    while a session is already live left no trace at all - the riskier of
+    the two attempts was the one going unrecorded. Local import: this module
+    is imported by ``app.services.rate_limit``, which ``app.services.
+    admin_audit`` also imports, so importing it at module scope here would
+    be circular.
+    """
+    # admin_audit imports app.services.rate_limit, which imports this
+    # module at top level - a module-level import here would be a genuine
+    # circular import, not just a pylint false positive. Deferring it to
+    # call time (this function only runs mid-request, well after both
+    # modules have finished importing) is what makes it safe.
+    from app.services import admin_audit  # pylint: disable=import-outside-toplevel
+
+    admin_audit.record(
+        request,
+        actor=admin,
+        target=target,
+        action='admin.impersonation.write_blocked',
+        result=admin_audit.AdminAuditResult.DENIED,
+        status_code=status.HTTP_403_FORBIDDEN,
+    )
+
+
 def _resolve_impersonation(payload: dict, db: Session, request, credentials_exception):
     """
     Swap the resolved identity to the impersonation target, or raise.
@@ -164,10 +223,7 @@ def _resolve_impersonation(payload: dict, db: Session, request, credentials_exce
     now = datetime.now(timezone.utc)
     if row is None or row.ended_at is not None:
         raise _impersonation_exception('Impersonation session has ended')
-    if (
-        row.expires_at is not None
-        and row.expires_at.replace(tzinfo=timezone.utc) <= now
-    ):
+    if row.expires_at is not None and _session_expires_at_utc(row) <= now:
         raise _impersonation_exception('Impersonation session has expired')
 
     # Re-check the acting admin on every request, not just at mint: they can
@@ -193,6 +249,7 @@ def _resolve_impersonation(payload: dict, db: Session, request, credentials_exce
     # itself, creating exactly the second decode path this function exists to
     # avoid.
     if request is not None and request.method not in _SAFE_METHODS:
+        _audit_impersonation_write_blocked(request, admin, target)
         raise _impersonation_exception(
             'This view-as session is read-only. End it to act as yourself.'
         )
@@ -239,7 +296,9 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
     return encoded_jwt
 
 
-def create_impersonation_token(target_id: str, admin_id: str, session_id: str):
+def create_impersonation_token(
+    target_id: str, admin_id: str, session_id: str, expires_at: datetime
+):
     """
     Mint the credential for one view-as session, and only that.
 
@@ -247,18 +306,42 @@ def create_impersonation_token(target_id: str, admin_id: str, session_id: str):
     :mod:`app.auth.authentication`: both of those mint a refresh token, and an
     impersonation session must never be refreshable. Expiry has to be a hard
     stop, or a diagnostic tool becomes a permanent alternate login.
+
+    ``expires_at`` is passed in rather than computed here: the caller also
+    stamps this same instant onto the ``DbImpersonationSession`` row, and
+    two separate ``datetime.now()`` calls would let the row's ``expires_at``
+    and the token's own ``exp`` drift apart by however long the two calls
+    were apart - small, but pointless when one value serves both.
     """
-    expires = datetime.now(timezone.utc) + timedelta(
-        minutes=IMPERSONATION_TOKEN_MINUTES
-    )
     payload = {
         'sub': target_id,
         'act': admin_id,
         'typ': IMPERSONATION_TOKEN_TYPE,
         'sid': session_id,
-        'exp': expires,
+        'exp': expires_at,
     }
-    return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM), expires
+    return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM), expires_at
+
+
+def decode_token_payload_best_effort(token: str) -> Optional[dict]:
+    """
+    Decode a JWT's payload without raising, or ``None`` for anything that
+    is not a validly-signed token of ours (an API key, garbage, expired,
+    forged).
+
+    For callers that only want to inspect claims - never to authenticate
+    with them - and must not let a raw JWT error escape to their own
+    caller: :func:`is_impersonation_token`'s nesting check, and
+    :func:`app.services.admin_audit.resolve_actor_best_effort`'s need to
+    attribute a denied admin-route request to the acting admin rather than
+    an impersonation token's swapped-in target.
+    """
+    if not token or token.startswith(API_KEY_PREFIX):
+        return None
+    try:
+        return jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    except jwt.InvalidTokenError:
+        return None
 
 
 def is_impersonation_token(token: str) -> bool:
@@ -270,17 +353,12 @@ def is_impersonation_token(token: str) -> bool:
     identity is not an admin), so this is defence in depth for the case where
     an admin target somehow slipped through.
     """
-    if not token or token.startswith(API_KEY_PREFIX):
-        return False
-    try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-    except jwt.InvalidTokenError:
-        return False
-    return payload.get('typ') == IMPERSONATION_TOKEN_TYPE
+    payload = decode_token_payload_best_effort(token)
+    return payload is not None and payload.get('typ') == IMPERSONATION_TOKEN_TYPE
 
 
 def get_current_user(
-    request: Request = None,
+    request: Request,
     token: str = Depends(oauth2_scheme),
     db: Session = Depends(get_db),
 ):
@@ -289,9 +367,12 @@ def get_current_user(
 
     ``request`` is injected so the impersonation read-only rule can see the
     method at the single point every authenticated route already funnels
-    through. It defaults to ``None`` because
-    :func:`get_optional_current_user` calls this directly rather than through
-    dependency injection.
+    through. Required, not defaulted to ``None``: FastAPI injects a real
+    ``Request`` for every HTTP route today, so a default would only ever
+    mask the one case that matters - a future non-HTTP route (a WebSocket,
+    say) wiring this dependency without one, which would silently skip the
+    write-block instead of failing to start. :func:`get_optional_current_user`
+    takes its own ``request`` via DI and forwards it here explicitly.
     """
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
@@ -307,7 +388,7 @@ def get_current_user(
 
 
 def get_current_session_user(
-    request: Request = None,
+    request: Request,
     token: str = Depends(oauth2_scheme),
     db: Session = Depends(get_db),
 ):
@@ -318,6 +399,11 @@ def get_current_session_user(
     deletion uses this dependency so a long-lived MCP or script credential
     cannot delete its owner, while the rest of the API can continue accepting
     both supported bearer credential types through :func:`get_current_user`.
+
+    ``request`` is required for the same reason it is on
+    :func:`get_current_user` - this is the *other* independent decode path
+    into :func:`_user_from_access_token`, and the one the impersonation
+    write-block bug lived in before the swap moved below both of them.
     """
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
@@ -328,6 +414,7 @@ def get_current_session_user(
 
 
 def get_optional_current_user(
+    request: Request,
     token: Optional[str] = Depends(optional_oauth2_scheme),
     db: Session = Depends(get_db),
 ):
@@ -362,11 +449,13 @@ def get_optional_current_user(
     if not token:
         return None
     try:
-        # Keyword arguments, not positional: ``get_current_user`` gained a
+        # Keyword arguments, not positional: ``get_current_user`` takes a
         # leading ``request`` parameter for the impersonation read-only rule,
         # and this is the only direct (non-DI) call to it in the codebase.
-        # Passing no request is correct here - this dependency serves reads.
-        return get_current_user(token=token, db=db)[0]
+        # ``request`` is forwarded, not omitted - this dependency mostly
+        # serves reads today, but a future write route wiring it must still
+        # get the write-block rather than silently skipping it.
+        return get_current_user(request=request, token=token, db=db)[0]
     except HTTPException as exc:
         if exc.status_code == status.HTTP_403_FORBIDDEN:
             raise

--- a/app/auth/oauth2.py
+++ b/app/auth/oauth2.py
@@ -197,6 +197,18 @@ def get_optional_current_user(
         ) from exc
 
 
+def is_admin(current_user: list) -> bool:
+    """
+    Whether the resolved caller belongs to the admin group.
+
+    The one predicate :func:`require_admin` and any mixed admin-or-self
+    route (``app.router.v1.user``) both test against, so "is this user an
+    admin" has a single definition rather than the same string comparison
+    copied at each call site.
+    """
+    return bool(current_user) and current_user[0].user_group == 'admin'
+
+
 def require_admin(current_user: list = Depends(get_current_user)) -> list:
     """
     Dependency that allows only admin users through.
@@ -204,7 +216,7 @@ def require_admin(current_user: list = Depends(get_current_user)) -> list:
     ``get_current_user`` returns a one-element list (``[DbUser]``); reuse it so
     the same object is available to the route.
     """
-    if not current_user or current_user[0].user_group != 'admin':
+    if not is_admin(current_user):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail='Admin privileges required',

--- a/app/auth/oauth2.py
+++ b/app/auth/oauth2.py
@@ -70,6 +70,31 @@ def hash_api_key(key: str) -> str:
     return hashlib.sha256(key.encode()).hexdigest()
 
 
+def _disabled_exception() -> HTTPException:
+    """
+    Raised by both credential resolvers below for a disabled account.
+
+    Distinct from ``credentials_exception`` (401) on purpose: a 401 tells a
+    web BFF the token expired and sends it into a refresh, which also fails
+    for a disabled user and leaves the client looping. 403 says plainly that
+    the credential itself was fine and the account is the reason - the only
+    answer that lets a client stop retrying and show the right message.
+
+    This is the enforcement point, not ``/auth/token``/``/auth/google``/
+    ``/auth/refresh`` alone: access JWTs are stateless with no ``jti``, so a
+    live one keeps resolving successfully for its full TTL unless the
+    resolver itself checks on every use. Refresh tokens and API keys are
+    also revoked/deleted outright when an account is disabled (see
+    ``app.router.v1.router_admin.disable_user``), so this check is a second,
+    belt-and-suspenders layer for anything minted in the window before that
+    ran, not the only thing stopping a disabled account.
+    """
+    return HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail='Account disabled',
+    )
+
+
 def _user_from_api_key(token: str, db: Session, credentials_exception):
     """
     Resolve a ``drk_`` bearer token to its owner, or raise.
@@ -84,6 +109,8 @@ def _user_from_api_key(token: str, db: Session, credentials_exception):
     row = db.query(DbApiKey).filter(DbApiKey.key_hash == hash_api_key(token)).first()
     if row is None:
         raise credentials_exception
+    if row.user.disabled_at is not None:
+        raise _disabled_exception()
     row.last_used_at = datetime.now(timezone.utc)
     db.commit()
     return [row.user]
@@ -103,6 +130,8 @@ def _user_from_access_token(token: str, db: Session, credentials_exception):
     user = db_user.get_user(db, uuid)
     if user is None:
         raise credentials_exception
+    if user[0].disabled_at is not None:
+        raise _disabled_exception()
     return user
 
 
@@ -181,6 +210,10 @@ def get_optional_current_user(
     *Every credential failure answers the same way.* The 404 lookup inside
     :func:`get_current_user` becomes the same 401 as everything else, so an
     expired token and a token for a deleted account are indistinguishable.
+    A disabled account is the one deliberate exception: it stays a 403
+    (see :func:`_disabled_exception`) rather than folding into the generic
+    401, for the same reason it does everywhere else - a 401 here would send
+    a disabled user's client into a refresh loop instead of telling it why.
 
     Unlike :func:`get_current_user`, this returns the ``DbUser`` itself (or
     ``None``) rather than a one-element list - there is nothing to unwrap.
@@ -190,6 +223,8 @@ def get_optional_current_user(
     try:
         return get_current_user(token, db)[0]
     except HTTPException as exc:
+        if exc.status_code == status.HTTP_403_FORBIDDEN:
+            raise
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail='Could not validate credentials',

--- a/app/auth/oauth2.py
+++ b/app/auth/oauth2.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import jwt
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.orm import Session
 
@@ -58,6 +58,15 @@ ACCESS_TOKEN_EXPIRE_MINUTES = settings.access_token_expire_minutes
 # API keys ride the same Authorization: Bearer header as JWTs; the prefix is
 # how we tell them apart (and lets secret scanners recognize leaked keys).
 API_KEY_PREFIX = 'drk_'
+
+# Impersonation access tokens carry this in ``typ`` so an ordinary session
+# token can never be mistaken for one, and vice versa (#341).
+IMPERSONATION_TOKEN_TYPE = 'impersonation'
+# Absolute, and deliberately short. There is no refresh path: expiry is the
+# escape hatch for a session somebody walked away from.
+IMPERSONATION_TOKEN_MINUTES = 15
+# Everything else is refused while impersonating.
+_SAFE_METHODS = frozenset({'GET', 'HEAD', 'OPTIONS'})
 
 
 def generate_api_key() -> str:
@@ -116,7 +125,84 @@ def _user_from_api_key(token: str, db: Session, credentials_exception):
     return [row.user]
 
 
-def _user_from_access_token(token: str, db: Session, credentials_exception):
+def _impersonation_exception(detail: str) -> HTTPException:
+    """Raised when an impersonation credential is presented but not honoured."""
+    return HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
+
+
+def _resolve_impersonation(payload: dict, db: Session, request, credentials_exception):
+    """
+    Swap the resolved identity to the impersonation target, or raise.
+
+    Called from :func:`_user_from_access_token` rather than from
+    :func:`get_current_user`, and that placement is the whole security story.
+    ``get_current_session_user`` is a second, independent decode path into
+    this same function; swapping one level up would leave it resolving an
+    impersonation token's ``sub`` to the target with no impersonation context
+    attached, which reaches the self-delete branch of
+    ``DELETE /v1/users/{uuid}``. A session documented as read-only would
+    delete the account. Swapping here covers both callers, and sitting below
+    the ``drk_`` branch in :func:`get_current_user` means no API key can ever
+    reach impersonation.
+    """
+    # Local import keeps the auth module's import surface narrow, matching
+    # the pattern used for DbApiKey above.
+    from app.db.models import (  # pylint: disable=import-outside-toplevel
+        DbImpersonationSession,
+    )
+
+    session_id = payload.get('sid')
+    admin_id = payload.get('act')
+    if not session_id or not admin_id:
+        raise credentials_exception
+
+    row = (
+        db.query(DbImpersonationSession)
+        .filter(DbImpersonationSession.id == session_id)
+        .first()
+    )
+    now = datetime.now(timezone.utc)
+    if row is None or row.ended_at is not None:
+        raise _impersonation_exception('Impersonation session has ended')
+    if (
+        row.expires_at is not None
+        and row.expires_at.replace(tzinfo=timezone.utc) <= now
+    ):
+        raise _impersonation_exception('Impersonation session has expired')
+
+    # Re-check the acting admin on every request, not just at mint: they can
+    # be demoted, disabled or deleted mid-session, and the session must die
+    # with their privilege rather than outliving it.
+    admin = row.admin
+    if admin is None or admin.user_group != 'admin' or admin.disabled_at is not None:
+        raise _impersonation_exception('Acting admin is no longer an administrator')
+
+    target = row.target
+    if target is None:
+        raise credentials_exception
+    # Also re-checked per request: a target promoted to admin mid-session must
+    # stop being impersonable immediately.
+    if target.user_group == 'admin':
+        raise _impersonation_exception('An admin cannot be impersonated')
+
+    # Read-only, with no override path by design (#341 was amended on
+    # 2026-08-18 to cut "act on their behalf"). Enforced here, at the one
+    # point every authenticated route funnels through, so a route cannot opt
+    # out by forgetting a dependency. Deliberately not middleware: middleware
+    # runs before dependency resolution and would have to decode the token
+    # itself, creating exactly the second decode path this function exists to
+    # avoid.
+    if request is not None and request.method not in _SAFE_METHODS:
+        raise _impersonation_exception(
+            'This view-as session is read-only. End it to act as yourself.'
+        )
+
+    return [target]
+
+
+def _user_from_access_token(
+    token: str, db: Session, credentials_exception, request=None
+):
     """Resolve a signed, expiring access JWT to its user."""
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
@@ -127,6 +213,8 @@ def _user_from_access_token(token: str, db: Session, credentials_exception):
         raise credentials_exception from exc
     except jwt.InvalidTokenError as exc:
         raise credentials_exception from exc
+    if payload.get('typ') == IMPERSONATION_TOKEN_TYPE:
+        return _resolve_impersonation(payload, db, request, credentials_exception)
     user = db_user.get_user(db, uuid)
     if user is None:
         raise credentials_exception
@@ -151,11 +239,59 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
     return encoded_jwt
 
 
+def create_impersonation_token(target_id: str, admin_id: str, session_id: str):
+    """
+    Mint the credential for one view-as session, and only that.
+
+    Deliberately not built on the sign-in helpers in
+    :mod:`app.auth.authentication`: both of those mint a refresh token, and an
+    impersonation session must never be refreshable. Expiry has to be a hard
+    stop, or a diagnostic tool becomes a permanent alternate login.
+    """
+    expires = datetime.now(timezone.utc) + timedelta(
+        minutes=IMPERSONATION_TOKEN_MINUTES
+    )
+    payload = {
+        'sub': target_id,
+        'act': admin_id,
+        'typ': IMPERSONATION_TOKEN_TYPE,
+        'sid': session_id,
+        'exp': expires,
+    }
+    return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM), expires
+
+
+def is_impersonation_token(token: str) -> bool:
+    """
+    Whether a bearer token is an impersonation credential.
+
+    Used to refuse nesting: an impersonated caller must not be able to mint a
+    further session. ``require_admin`` already refuses them (the swapped
+    identity is not an admin), so this is defence in depth for the case where
+    an admin target somehow slipped through.
+    """
+    if not token or token.startswith(API_KEY_PREFIX):
+        return False
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    except jwt.InvalidTokenError:
+        return False
+    return payload.get('typ') == IMPERSONATION_TOKEN_TYPE
+
+
 def get_current_user(
-    token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)
+    request: Request = None,
+    token: str = Depends(oauth2_scheme),
+    db: Session = Depends(get_db),
 ):
     """
     This function verifies the current user
+
+    ``request`` is injected so the impersonation read-only rule can see the
+    method at the single point every authenticated route already funnels
+    through. It defaults to ``None`` because
+    :func:`get_optional_current_user` calls this directly rather than through
+    dependency injection.
     """
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
@@ -163,12 +299,17 @@ def get_current_user(
         headers={'WWW-Authenticate': 'Bearer'},
     )
     if token.startswith(API_KEY_PREFIX):
+        # API keys share this header with JWTs, so an API key must never be
+        # able to carry impersonation claims. It cannot: this branch never
+        # reads the token's payload at all.
         return _user_from_api_key(token, db, credentials_exception)
-    return _user_from_access_token(token, db, credentials_exception)
+    return _user_from_access_token(token, db, credentials_exception, request)
 
 
 def get_current_session_user(
-    token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)
+    request: Request = None,
+    token: str = Depends(oauth2_scheme),
+    db: Session = Depends(get_db),
 ):
     """
     Authenticate only an expiring interactive-session access token.
@@ -183,7 +324,7 @@ def get_current_session_user(
         detail='Could not validate credentials',
         headers={'WWW-Authenticate': 'Bearer'},
     )
-    return _user_from_access_token(token, db, credentials_exception)
+    return _user_from_access_token(token, db, credentials_exception, request)
 
 
 def get_optional_current_user(
@@ -221,7 +362,11 @@ def get_optional_current_user(
     if not token:
         return None
     try:
-        return get_current_user(token, db)[0]
+        # Keyword arguments, not positional: ``get_current_user`` gained a
+        # leading ``request`` parameter for the impersonation read-only rule,
+        # and this is the only direct (non-DI) call to it in the codebase.
+        # Passing no request is correct here - this dependency serves reads.
+        return get_current_user(token=token, db=db)[0]
     except HTTPException as exc:
         if exc.status_code == status.HTTP_403_FORBIDDEN:
             raise

--- a/app/auth/refresh_tokens.py
+++ b/app/auth/refresh_tokens.py
@@ -116,6 +116,22 @@ def revoke_all_for_user(db: Session, user_pk: int) -> None:
     ).update({'revoked_at': _now()}, synchronize_session=False)
 
 
+def owner_pk_for_token(db: Session, token: str):
+    """
+    The ``users.pk`` behind a refresh token, or ``None`` if unrecognised.
+
+    Sign-out needs the owner before revoking, so it can also end any view-as
+    session that admin is running (#341). Read-only on purpose: handed a
+    junk token it must change nothing and say so.
+    """
+    row = (
+        db.query(DbRefreshToken)
+        .filter(DbRefreshToken.token_hash == hash_refresh_token(token))
+        .first()
+    )
+    return row.user_id if row is not None else None
+
+
 def revoke_refresh_token(db: Session, token: str) -> bool:
     """
     Revoke a token and the rest of its family - this is what sign-out calls.

--- a/app/auth/refresh_tokens.py
+++ b/app/auth/refresh_tokens.py
@@ -101,6 +101,21 @@ def revoke_family(db: Session, family_id: str) -> None:
     ).update({'revoked_at': _now()}, synchronize_session=False)
 
 
+def revoke_all_for_user(db: Session, user_pk: int) -> None:
+    """
+    Revoke every unrevoked refresh token belonging to this user, across
+    every rotation family - not just one. Mirrors :func:`revoke_family`, but
+    for admin-initiated account disable (#344), where every session this
+    user has ever started has to die at once, not just the one that happens
+    to be presented next. Does not commit; the caller (disabling an account)
+    folds this into its own transaction.
+    """
+    db.query(DbRefreshToken).filter(
+        DbRefreshToken.user_id == user_pk,
+        DbRefreshToken.revoked_at.is_(None),
+    ).update({'revoked_at': _now()}, synchronize_session=False)
+
+
 def revoke_refresh_token(db: Session, token: str) -> bool:
     """
     Revoke a token and the rest of its family - this is what sign-out calls.

--- a/app/db/db_follow.py
+++ b/app/db/db_follow.py
@@ -56,22 +56,32 @@ def count_followers(db: Session, followee_pk: int) -> int:
 
 
 def list_following(db: Session, user_pk: int) -> List[Tuple[DbFollow, DbUser]]:
-    """Everyone this user follows, each paired with the followee's row."""
+    """
+    Everyone this user follows, each paired with the followee's row.
+
+    Excludes a disabled followee (#344 D2) - they do not appear in this
+    list, the same as if the follow had been deleted outright.
+    """
     return (
         db.query(DbFollow, DbUser)
         .join(DbUser, DbUser.pk == DbFollow.followee_id)
-        .filter(DbFollow.follower_id == user_pk)
+        .filter(DbFollow.follower_id == user_pk, DbUser.disabled_at.is_(None))
         .order_by(DbFollow.followed_at.desc())
         .all()
     )
 
 
 def list_followers(db: Session, user_pk: int) -> List[Tuple[DbFollow, DbUser]]:
-    """Everyone following this user, each paired with the follower's row."""
+    """
+    Everyone following this user, each paired with the follower's row.
+
+    Excludes a disabled follower (#344 D2), same reasoning as
+    :func:`list_following`.
+    """
     return (
         db.query(DbFollow, DbUser)
         .join(DbUser, DbUser.pk == DbFollow.follower_id)
-        .filter(DbFollow.followee_id == user_pk)
+        .filter(DbFollow.followee_id == user_pk, DbUser.disabled_at.is_(None))
         .order_by(DbFollow.followed_at.desc())
         .all()
     )

--- a/app/db/db_friendship.py
+++ b/app/db/db_friendship.py
@@ -111,11 +111,19 @@ def list_with_other_party(
     friends does not fan out into a lookup per row. ``requested_by_me``
     narrows pending rows to one direction: True for requests this user sent,
     False for ones they received, None for both.
+
+    Excludes a disabled other party (#344 D2) - a disabled account does not
+    appear in another user's friends list or pending requests, the same as
+    if the relationship had been deleted outright.
     """
     query = (
         db.query(DbFriendship, DbUser)
         .join(DbUser, DbUser.pk == _other_user_id(user_pk))
-        .filter(_involving(user_pk), DbFriendship.status == status)
+        .filter(
+            _involving(user_pk),
+            DbFriendship.status == status,
+            DbUser.disabled_at.is_(None),
+        )
     )
     if requested_by_me is True:
         query = query.filter(DbFriendship.requested_by_id == user_pk)

--- a/app/db/db_user.py
+++ b/app/db/db_user.py
@@ -271,6 +271,9 @@ def search_users(
     """
     Search users by handle or display name, case-insensitive.
     Returns only public profiles and accepted friends.
+
+    Excludes a disabled account (#344 D2) - not discoverable by search, same
+    as if it had been deleted outright.
     """
     if not query:
         return []
@@ -285,6 +288,7 @@ def search_users(
     return (
         db.query(DbUser)
         .filter(
+            DbUser.disabled_at.is_(None),
             or_(
                 DbUser.display_name.ilike(q_str),
                 DbUser.handle.ilike(q_str),

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -173,6 +173,13 @@ class DbUser(DBBaseModel):
         server_default=text('false'),
     )
 
+    # Admin disable/enable toggle (#344). NULL means active. Adding the
+    # column and reading it (``status`` on the admin endpoints) lands in this
+    # increment; the toggle itself and enforcing it on the auth path are a
+    # later increment - this is only here so the web directory has a real
+    # status column from the start instead of a placeholder computed field.
+    disabled_at = Column(DateTime, nullable=True)
+
 
 class DbApiKey(DBBaseModel):
     """
@@ -373,6 +380,58 @@ class DbFollow(DBBaseModel):
     followed_at = Column(
         DateTime, nullable=False, default=lambda: datetime.now(timezone.utc)
     )
+
+
+class DbAdminAuditLog(DBBaseModel):
+    """
+    Append-only trail of every admin-console action (#344).
+
+    Deliberately has no update or delete path anywhere in the codebase - a
+    row records what happened, and a row that could be edited afterwards
+    would not be a trail. ``target_user_pk`` is ``SET NULL`` rather than
+    cascading so deleting the target does not take the record of having
+    viewed or acted on them with it; ``target_user_id`` and ``target_email``
+    are stored again as plain text for the same reason, so the row still
+    reads sensibly after the user row is gone. ``detail`` is a JSON blob of
+    changed fields only, built by an allowlist in
+    :mod:`app.services.admin_audit` - never a password, hash, bearer token,
+    API key, refresh token, or raw request body.
+    """
+
+    __tablename__ = 'admin_audit_log'
+
+    # Overrides DBBaseModel's un-indexed created_at: the audit endpoint's
+    # default sort and ``created_at``-adjacent filters both need it.
+    created_at = Column(
+        DateTime, default=lambda: datetime.now(timezone.utc), index=True
+    )
+
+    actor_user_pk = Column(
+        Integer,
+        ForeignKey('users.pk', ondelete='SET NULL'),
+        nullable=True,
+        index=True,
+    )
+    target_user_pk = Column(
+        Integer,
+        ForeignKey('users.pk', ondelete='SET NULL'),
+        nullable=True,
+        index=True,
+    )
+    target_user_id = Column(String, nullable=True)
+    target_email = Column(String, nullable=True)
+    action = Column(String, nullable=False, index=True)
+    result = Column(String(length=16), nullable=False)
+    detail = Column(JSON, nullable=True)
+    request_id = Column(String, nullable=True)
+    method = Column(String(length=10), nullable=True)
+    path = Column(String, nullable=True)
+    status_code = Column(Integer, nullable=True)
+    source_ip = Column(String, nullable=True)
+    user_agent = Column(String, nullable=True)
+
+    actor = relationship('DbUser', foreign_keys=[actor_user_pk])
+    target = relationship('DbUser', foreign_keys=[target_user_pk])
 
 
 # Import sandbox models to ensure they are registered with the Base metadata

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -388,14 +388,16 @@ class DbAdminAuditLog(DBBaseModel):
 
     Deliberately has no update or delete path anywhere in the codebase - a
     row records what happened, and a row that could be edited afterwards
-    would not be a trail. ``target_user_pk`` is ``SET NULL`` rather than
-    cascading so deleting the target does not take the record of having
-    viewed or acted on them with it; ``target_user_id`` and ``target_email``
-    are stored again as plain text for the same reason, so the row still
-    reads sensibly after the user row is gone. ``detail`` is a JSON blob of
-    changed fields only, built by an allowlist in
-    :mod:`app.services.admin_audit` - never a password, hash, bearer token,
-    API key, refresh token, or raw request body.
+    would not be a trail. Both ``actor_user_pk`` and ``target_user_pk`` are
+    ``SET NULL`` rather than cascading so deleting either party does not
+    take the record of what they did (or had done to them) with it - an
+    admin can misuse the console and then delete their own account, and the
+    trail of that misuse must survive them. ``actor_user_id``/``actor_email``
+    and ``target_user_id``/``target_email`` are stored again as plain text
+    for the same reason, so a row still reads sensibly after the user row is
+    gone. ``detail`` is a JSON blob of changed fields only, built by an
+    allowlist in :mod:`app.services.admin_audit` - never a password, hash,
+    bearer token, API key, refresh token, or raw request body.
     """
 
     __tablename__ = 'admin_audit_log'
@@ -412,6 +414,8 @@ class DbAdminAuditLog(DBBaseModel):
         nullable=True,
         index=True,
     )
+    actor_user_id = Column(String, nullable=True)
+    actor_email = Column(String, nullable=True)
     target_user_pk = Column(
         Integer,
         ForeignKey('users.pk', ondelete='SET NULL'),

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -181,6 +181,44 @@ class DbUser(DBBaseModel):
     disabled_at = Column(DateTime, nullable=True)
 
 
+class DbImpersonationSession(DBBaseModel):
+    """
+    One admin "view as user" session (#341).
+
+    The impersonation JWT is the capability, but a pure-stateless token cannot
+    satisfy two of the issue's requirements: that an admin can end a session
+    "at any time", and that a session dies when the acting admin is demoted or
+    disabled. Both need server-side state, so every impersonated request loads
+    this row by the token's session id and re-checks it. That is two extra
+    lookups on impersonated requests only; ordinary traffic never touches this
+    table.
+
+    ``ended_at`` is set by the stop endpoint and by sign-out. ``expires_at``
+    mirrors the token's own expiry so a session cannot outlive its credential
+    even if the row is never explicitly ended.
+    """
+
+    __tablename__ = 'impersonation_sessions'
+    admin_user_pk = Column(
+        Integer,
+        ForeignKey('users.pk', ondelete='CASCADE'),
+        nullable=False,
+        index=True,
+    )
+    target_user_pk = Column(
+        Integer,
+        ForeignKey('users.pk', ondelete='CASCADE'),
+        nullable=False,
+        index=True,
+    )
+    reason = Column(String, nullable=True)
+    expires_at = Column(DateTime, nullable=False)
+    ended_at = Column(DateTime, nullable=True)
+
+    admin = relationship('DbUser', foreign_keys=[admin_user_pk])
+    target = relationship('DbUser', foreign_keys=[target_user_pk])
+
+
 class DbApiKey(DBBaseModel):
     """
     Long-lived API key for programmatic access (MCP servers, crons).

--- a/app/migration/seed_dev.py
+++ b/app/migration/seed_dev.py
@@ -36,7 +36,10 @@ Usage::
 Every run also seeds the **fixed dev cast** (#313): six accounts covering the
 relationship/visibility positions the social features (compare, sharing,
 friends' activity) need, anchored to the *target* user -- the ``--email``
-user, default the seed admin -- who becomes "you". They all share the dev
+user, default the seed admin -- who becomes "you". A seventh, unrelated
+account (``admin-two``) is a second admin, so admin-console rules that
+require two admins (#341's "an admin cannot impersonate/disable another
+admin") are demonstrable, not just unit-tested. They all share the dev
 password ``change-me``, so a demo can be driven from any seat.
 
 ``docs/dev-cast.md`` is the reference for who they are: handles, credentials,
@@ -110,8 +113,10 @@ _LEGACY_FAKE_ID_BASE = 900_000
 
 # --- Fixed dev cast (#313) ---------------------------------------------------
 # Six accounts covering the relationship/visibility positions the social
-# features need, anchored to the seed target ("you"). All share one password
-# so any position can be signed into. Documented in the module docstring and
+# features need, anchored to the seed target ("you"), plus a seventh
+# (admin-two, #341) that is not: a second admin so admin-on-admin refusals
+# are demonstrable. All share one password so any position can be signed
+# into. Documented in the module docstring and
 # the README; ``_seed_cast`` is what brings them to life.
 
 _CAST_PASSWORD = 'change-me'
@@ -222,6 +227,25 @@ _CAST_USERS = (
         # hold without turning into another ``ready``.
         'extra_movies': 4,
         'time_zone': 'UTC',
+    },
+    {
+        # Not a relationship-position seat like the six above - the local
+        # dev DB otherwise has exactly one admin (the seed admin from
+        # ADMIN_EMAIL), which makes "an admin cannot impersonate/disable
+        # another admin" (#341) provable only by unit test and never
+        # demonstrable in the console (api#341/#344 review, 2026-08-19).
+        # ``gmail.com``, not ``@example.com`` like the rest of the cast:
+        # this account only ever needs to authenticate through the normal
+        # app paths (sign-in, admin actions), and those validate the email
+        # (MX lookup) unlike this script's direct DB inserts, which don't.
+        'email': 'admin-two@gmail.com',
+        'display_name': 'Admin Two',
+        'handle': 'admin-two',
+        'position': 'admin',
+        'tiers': _cast_tiers('private'),
+        'canon_movies': 0,
+        'time_zone': 'America/Chicago',
+        'admin': True,
     },
 )
 
@@ -749,7 +773,8 @@ def _get_or_create_cast_user(session: Session, spec: dict) -> DbUser:
     The cast account for ``spec``, created on first sight and reused after.
 
     Idempotent by email. The fixed handle is claimed only when the account
-    has none, and the nine tiers and the time zone are re-applied every run.
+    has none, and the nine tiers, the time zone, and (when ``spec['admin']``
+    is set) the admin group are re-applied every run.
     """
     user = session.query(DbUser).filter_by(email=spec['email']).one_or_none()
     if user is None:
@@ -766,6 +791,8 @@ def _get_or_create_cast_user(session: Session, spec: dict) -> DbUser:
     for field, tier in spec['tiers'].items():
         setattr(user, field, tier)
     user.time_zone = spec['time_zone']
+    if spec.get('admin'):
+        user.user_group = 'admin'
     return user
 
 

--- a/app/router/v1/router_activity.py
+++ b/app/router/v1/router_activity.py
@@ -206,7 +206,13 @@ def _social_shelf_rows(  # pylint: disable=too-many-arguments, too-many-position
             catalog_model,
             getattr(tracker_model, shelf.join_col) == catalog_model.pk,
         )
-        .filter(DbUser.share_activity.is_(True), event_visible)
+        .filter(
+            DbUser.share_activity.is_(True),
+            # A disabled account is invisible everywhere a deleted one
+            # would be (#344 D2) - no activity-feed contributions.
+            DbUser.disabled_at.is_(None),
+            event_visible,
+        )
     )
     if cursor is not None:
         query = query.filter(

--- a/app/router/v1/router_admin.py
+++ b/app/router/v1/router_admin.py
@@ -166,14 +166,20 @@ def search_users(  # pylint: disable=too-many-arguments, too-many-positional-arg
             )
         )
     total = query.count()
-    rows = query.order_by(DbUser.created_at.desc()).offset(offset).limit(limit).all()
+    # created_at alone is not unique - a secondary sort on pk keeps paging
+    # stable instead of occasionally skipping or repeating a row that ties.
+    rows = (
+        query.order_by(DbUser.created_at.desc(), DbUser.pk.desc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
 
     admin_audit.record(
-        db,
+        request,
         actor=current_user[0],
         action='admin.user.search',
         result=AdminAuditResult.ALLOWED,
-        request=request,
         detail={'q': q, 'limit': limit, 'offset': offset, 'total': total},
         # These three routes are read-only and either return this exact
         # 200 or raise before reaching this call (get_user_detail's 404),
@@ -201,12 +207,11 @@ def get_user_detail(
     last_tracked_at = _last_tracked_bulk(db, [user.pk])[user.pk]
 
     admin_audit.record(
-        db,
+        request,
         actor=current_user[0],
         target=user,
         action='admin.user.view',
         result=AdminAuditResult.ALLOWED,
-        request=request,
         status_code=200,
     )
     return OutAdminUserDetail(
@@ -244,11 +249,18 @@ def get_user_detail(
 
 
 def _audit_actor_out(row: DbAdminAuditLog) -> Optional[OutAdminAuditActor]:
-    if row.actor is None:
-        return None
-    return OutAdminAuditActor(
-        id=row.actor.id, handle=row.actor.handle, email=row.actor.email
-    )
+    if row.actor is not None:
+        return OutAdminAuditActor(
+            id=row.actor.id, handle=row.actor.handle, email=row.actor.email
+        )
+    if row.actor_user_id or row.actor_email:
+        # The actor row is gone (self-delete is permitted); fall back to
+        # what was denormalized at write time so the row still names who
+        # did it instead of going anonymous.
+        return OutAdminAuditActor(
+            id=row.actor_user_id, handle=None, email=row.actor_email
+        )
+    return None
 
 
 def _audit_target_out(row: DbAdminAuditLog) -> Optional[OutAdminAuditTarget]:
@@ -280,8 +292,18 @@ def list_audit(  # pylint: disable=too-many-arguments, too-many-positional-argum
     limit, offset = _clamp_page(limit, offset)
     query = db.query(DbAdminAuditLog)
     if actor:
-        query = query.join(DbUser, DbAdminAuditLog.actor_user_pk == DbUser.pk).filter(
-            or_(DbUser.handle == actor, DbUser.email == actor, DbUser.id == actor)
+        # outerjoin, not join: an actor whose account is gone (SET NULL on
+        # delete) still has to be findable by the denormalized fields below.
+        query = query.outerjoin(
+            DbUser, DbAdminAuditLog.actor_user_pk == DbUser.pk
+        ).filter(
+            or_(
+                DbUser.handle == actor,
+                DbUser.email == actor,
+                DbUser.id == actor,
+                DbAdminAuditLog.actor_user_id == actor,
+                DbAdminAuditLog.actor_email == actor,
+            )
         )
     if target:
         query = query.filter(
@@ -292,21 +314,28 @@ def list_audit(  # pylint: disable=too-many-arguments, too-many-positional-argum
         )
     if action:
         query = query.filter(DbAdminAuditLog.action == action)
+    else:
+        # Reading the trail is itself an audited action (below). Without
+        # this, paging through the trail during an investigation pushes the
+        # very events under investigation off page one. Still writable and
+        # still retrievable - just excluded from the unfiltered default view.
+        query = query.filter(DbAdminAuditLog.action != 'admin.audit.view')
 
     total = query.count()
+    # created_at alone is not unique - a secondary sort on pk keeps paging
+    # stable instead of occasionally skipping or repeating a row that ties.
     rows = (
-        query.order_by(DbAdminAuditLog.created_at.desc())
+        query.order_by(DbAdminAuditLog.created_at.desc(), DbAdminAuditLog.pk.desc())
         .offset(offset)
         .limit(limit)
         .all()
     )
 
     admin_audit.record(
-        db,
+        request,
         actor=current_user[0],
         action='admin.audit.view',
         result=AdminAuditResult.ALLOWED,
-        request=request,
         detail={
             'limit': limit,
             'offset': offset,

--- a/app/router/v1/router_admin.py
+++ b/app/router/v1/router_admin.py
@@ -14,7 +14,7 @@ request, so it costs no extra query.
 Impersonation and reports are later increments - not built here.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -22,12 +22,25 @@ from sqlalchemy import case, func, or_
 from sqlalchemy.orm import Session
 
 from app.auth import refresh_tokens
-from app.auth.oauth2 import get_current_user, require_admin
+from app.auth.oauth2 import (
+    IMPERSONATION_TOKEN_MINUTES,
+    create_impersonation_token,
+    get_current_user,
+    is_impersonation_token,
+    oauth2_scheme,
+    require_admin,
+)
 from app.db.database import get_db
 from app.db.db_follow import count_followers, list_following
 from app.db.db_friendship import friend_pks
-from app.db.models import DbAdminAuditLog, DbApiKey, DbUser
+from app.db.models import (
+    DbAdminAuditLog,
+    DbApiKey,
+    DbImpersonationSession,
+    DbUser,
+)
 from app.schemas.schemas_admin import (
+    InImpersonationStart,
     OutAdminAuditActor,
     OutAdminAuditEvent,
     OutAdminAuditResponse,
@@ -38,6 +51,8 @@ from app.schemas.schemas_admin import (
     OutAdminUserListResponse,
     OutAdminUserSummary,
     OutAdminVisibility,
+    OutImpersonationParty,
+    OutImpersonationSession,
 )
 from app.services import admin_audit
 from app.services.admin_audit import AdminAuditResult
@@ -480,3 +495,121 @@ def list_audit(  # pylint: disable=too-many-arguments, too-many-positional-argum
             for row in rows
         ],
     )
+
+
+@router.post('/impersonation', response_model=OutImpersonationSession)
+def start_impersonation(
+    request: Request,
+    payload: InImpersonationStart,
+    db: Session = Depends(get_db),
+    token: str = Depends(oauth2_scheme),
+    current_user: list = Depends(get_current_user),
+):
+    """
+    Begin a read-only view-as session (#341).
+
+    Read-only is a blanket denial with no override: the "act on their behalf"
+    criterion was cut from #341 on 2026-08-18, so there is no per-action flag
+    to build. Enforcement lives in the auth resolver, not here, so a route
+    added later cannot opt out of it.
+
+    Impersonating a DISABLED account is allowed on purpose. "Why can't I sign
+    in" is exactly the question this tool exists to answer, and the write
+    block already covers the risk.
+    """
+    actor = current_user[0]
+    target = _get_target_or_404(db, uuid=payload.target_uuid)
+
+    def _deny(reason: str, message: str):
+        admin_audit.record(
+            request,
+            actor=actor,
+            target=target,
+            action='admin.impersonation.start',
+            result=AdminAuditResult.DENIED,
+            status_code=403,
+            detail={'reason': reason},
+        )
+        return HTTPException(status_code=403, detail=message)
+
+    # Nesting: an impersonated caller must not mint a further session.
+    # require_admin already refuses them, since the swapped identity is not an
+    # admin; this covers the case where an admin target slipped through.
+    if is_impersonation_token(token):
+        raise _deny('nested', 'Cannot impersonate from a view-as session')
+    if target.pk == actor.pk:
+        raise _deny('self', 'You are already yourself')
+    if target.user_group == 'admin':
+        raise _deny('target_is_admin', 'An admin cannot be impersonated')
+
+    session = DbImpersonationSession(
+        admin_user_pk=actor.pk,
+        target_user_pk=target.pk,
+        reason=payload.reason,
+        expires_at=datetime.now(timezone.utc)
+        + timedelta(minutes=IMPERSONATION_TOKEN_MINUTES),
+    )
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+
+    impersonation_token, expires = create_impersonation_token(
+        target_id=target.id, admin_id=actor.id, session_id=session.id
+    )
+    admin_audit.record(
+        request,
+        actor=actor,
+        target=target,
+        action='admin.impersonation.start',
+        result=AdminAuditResult.ALLOWED,
+        status_code=200,
+        detail={'session_id': session.id, 'reason': payload.reason},
+    )
+    return OutImpersonationSession(
+        token=impersonation_token,
+        session_id=session.id,
+        expires_at=expires,
+        target=OutImpersonationParty.model_validate(target),
+        acting_admin=OutImpersonationParty.model_validate(actor),
+    )
+
+
+@router.delete('/impersonation')
+def stop_impersonation(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """
+    End every live view-as session this admin owns. Idempotent.
+
+    Reached with the admin's OWN token, not the impersonation one: the
+    impersonation credential cannot call this, because every ``/v1/admin/*``
+    route is behind ``require_admin`` and the swapped identity is not an
+    admin. The web client keeps the admin session in a separate cookie for
+    exactly this reason, so "Back to admin" is one call plus a cookie delete.
+    """
+    actor = current_user[0]
+    now = datetime.now(timezone.utc)
+    live = (
+        db.query(DbImpersonationSession)
+        .filter(
+            DbImpersonationSession.admin_user_pk == actor.pk,
+            DbImpersonationSession.ended_at.is_(None),
+        )
+        .all()
+    )
+    for session in live:
+        session.ended_at = now
+    if live:
+        db.commit()
+    admin_audit.record(
+        request,
+        actor=actor,
+        target=None,
+        action='admin.impersonation.stop',
+        result=AdminAuditResult.ALLOWED,
+        status_code=200,
+        detail={'ended': len(live)},
+    )
+    return {'ended': len(live)}

--- a/app/router/v1/router_admin.py
+++ b/app/router/v1/router_admin.py
@@ -11,22 +11,22 @@ PR). Each route still separately depends on ``get_current_user`` to get the
 resolved actor for the audit row; FastAPI caches that dependency per
 request, so it costs no extra query.
 
-Disable/enable and its auth-path enforcement, impersonation, and reports are
-later increments - not built here. This increment adds the ``disabled_at``
-column and reads it into ``status``, but nothing writes it yet.
+Impersonation and reports are later increments - not built here.
 """
 
+from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy import case, func, or_
 from sqlalchemy.orm import Session
 
+from app.auth import refresh_tokens
 from app.auth.oauth2 import get_current_user, require_admin
 from app.db.database import get_db
 from app.db.db_follow import count_followers, list_following
 from app.db.db_friendship import friend_pks
-from app.db.models import DbAdminAuditLog, DbUser
+from app.db.models import DbAdminAuditLog, DbApiKey, DbUser
 from app.schemas.schemas_admin import (
     OutAdminAuditActor,
     OutAdminAuditEvent,
@@ -191,29 +191,14 @@ def search_users(  # pylint: disable=too-many-arguments, too-many-positional-arg
     )
 
 
-@router.get('/users/{uuid}', response_model=OutAdminUserDetail)
-def get_user_detail(
-    request: Request,
-    uuid: str,
-    db: Session = Depends(get_db),
-    current_user: list = Depends(get_current_user),
-):
-    """Per-user aggregates: tracked counts, visibility tiers, social counts."""
-    user = db.query(DbUser).filter(DbUser.id == uuid).first()
-    if user is None:
-        raise HTTPException(status_code=404, detail='User not found')
-
+def _build_user_detail(db: Session, user: DbUser) -> OutAdminUserDetail:
+    """
+    The full per-user aggregate payload. Shared by ``GET /users/{uuid}`` and
+    the disable/enable actions below, which return this exact shape so the
+    console can swap the row in place without a refetch.
+    """
     domains = _domain_counts_bulk(db, [user.pk])[user.pk]
     last_tracked_at = _last_tracked_bulk(db, [user.pk])[user.pk]
-
-    admin_audit.record(
-        request,
-        actor=current_user[0],
-        target=user,
-        action='admin.user.view',
-        result=AdminAuditResult.ALLOWED,
-        status_code=200,
-    )
     return OutAdminUserDetail(
         id=user.id,
         handle=user.handle,
@@ -246,6 +231,133 @@ def get_user_detail(
             following=len(list_following(db, user.pk)),
         ),
     )
+
+
+def _get_target_or_404(db: Session, uuid: str) -> DbUser:
+    user = db.query(DbUser).filter(DbUser.id == uuid).first()
+    if user is None:
+        raise HTTPException(status_code=404, detail='User not found')
+    return user
+
+
+@router.get('/users/{uuid}', response_model=OutAdminUserDetail)
+def get_user_detail(
+    request: Request,
+    uuid: str,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """Per-user aggregates: tracked counts, visibility tiers, social counts."""
+    user = _get_target_or_404(db, uuid)
+    admin_audit.record(
+        request,
+        actor=current_user[0],
+        target=user,
+        action='admin.user.view',
+        result=AdminAuditResult.ALLOWED,
+        status_code=200,
+    )
+    return _build_user_detail(db, user)
+
+
+@router.post('/users/{uuid}/disable', response_model=OutAdminUserDetail)
+def disable_user(
+    request: Request,
+    uuid: str,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """
+    Disable an account: blocks sign-in, kills every live credential, and
+    (D2, per product decision) makes the user disappear everywhere a
+    deleted user would - see the read-path filters in router_visibility,
+    router_comparison, router_friends, router_follows, router_activity, and
+    db_user.search_users.
+
+    Self-disable and disabling another admin are both refused outright
+    (403) rather than merely discouraged: with a small operator pool,
+    either one risks a lockout with nobody left to undo it. Both refusals
+    are audited as denials, same as the router-level admin gate.
+    """
+    actor = current_user[0]
+    target = _get_target_or_404(db, uuid)
+
+    if target.pk == actor.pk:
+        admin_audit.record(
+            request,
+            actor=actor,
+            target=target,
+            action='admin.user.disable',
+            result=AdminAuditResult.DENIED,
+            status_code=403,
+            detail={'reason': 'self'},
+        )
+        raise HTTPException(
+            status_code=403, detail='You cannot disable your own account'
+        )
+    if target.user_group == 'admin':
+        admin_audit.record(
+            request,
+            actor=actor,
+            target=target,
+            action='admin.user.disable',
+            result=AdminAuditResult.DENIED,
+            status_code=403,
+            detail={'reason': 'target_is_admin'},
+        )
+        raise HTTPException(
+            status_code=403, detail='Cannot disable another admin account'
+        )
+
+    if target.disabled_at is None:
+        # One transaction: the flag, every refresh-token family, and every
+        # API key all have to change together, or a request already mid-
+        # flight against this account could keep a stale credential alive.
+        target.disabled_at = datetime.now(timezone.utc)
+        refresh_tokens.revoke_all_for_user(db, target.pk)
+        db.query(DbApiKey).filter(DbApiKey.user_id == target.pk).delete(
+            synchronize_session=False
+        )
+        db.commit()
+
+    admin_audit.record(
+        request,
+        actor=actor,
+        target=target,
+        action='admin.user.disable',
+        result=AdminAuditResult.ALLOWED,
+        status_code=200,
+    )
+    return _build_user_detail(db, target)
+
+
+@router.post('/users/{uuid}/enable', response_model=OutAdminUserDetail)
+def enable_user(
+    request: Request,
+    uuid: str,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """
+    Re-enable an account. Restores sign-in only - the refresh tokens and
+    API keys a disable revoked are gone for good (this is load-bearing for
+    the confirmation copy on the disable action: re-enabling is not
+    "undo," the user has to sign in again and reissue any API keys).
+    """
+    target = _get_target_or_404(db, uuid)
+    if target.disabled_at is not None:
+        target.disabled_at = None
+        db.commit()
+
+    admin_audit.record(
+        request,
+        actor=current_user[0],
+        target=target,
+        action='admin.user.enable',
+        result=AdminAuditResult.ALLOWED,
+        status_code=200,
+    )
+    return _build_user_detail(db, target)
 
 
 def _audit_actor_out(row: DbAdminAuditLog) -> Optional[OutAdminAuditActor]:

--- a/app/router/v1/router_admin.py
+++ b/app/router/v1/router_admin.py
@@ -15,11 +15,12 @@ Impersonation and reports are later increments - not built here.
 """
 
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from functools import reduce
+from typing import Literal, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request
-from sqlalchemy import case, func, or_
-from sqlalchemy.orm import Session
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from sqlalchemy import and_, case, func, or_, select
+from sqlalchemy.orm import Session, aliased
 
 from app.auth import refresh_tokens
 from app.auth.oauth2 import (
@@ -51,8 +52,10 @@ from app.schemas.schemas_admin import (
     OutAdminUserListResponse,
     OutAdminUserSummary,
     OutAdminVisibility,
+    OutImpersonationLiveSession,
     OutImpersonationParty,
     OutImpersonationSession,
+    OutImpersonationSessionList,
 )
 from app.services import admin_audit
 from app.services.admin_audit import AdminAuditResult
@@ -159,16 +162,108 @@ def _user_summaries(db: Session, users: list[DbUser]) -> list[OutAdminUserSummar
     ]
 
 
+def _greatest_ignoring_nulls(*expressions):
+    """
+    The greatest of several nullable scalar SQL expressions, NULL only when
+    every one of them is.
+
+    Built from plain CASE/comparison rather than a vendor function on
+    purpose: Postgres has no scalar multi-argument ``MAX()`` (it needs
+    ``GREATEST()``), SQLite's multi-argument ``max()`` is not the same
+    function as its single-argument aggregate ``max()``, and the two
+    dialects do not even agree on where a NULL sorts. This only has to
+    behave identically on the Postgres this ships to and the SQLite the
+    test suite runs on, so it is cheaper to avoid the vendor functions
+    than to reconcile them.
+    """
+
+    def _pick(left, right):
+        return case(
+            (and_(left.isnot(None), or_(right.is_(None), left >= right)), left),
+            else_=right,
+        )
+
+    return reduce(_pick, expressions)
+
+
+def _last_tracked_sort_expr():
+    """
+    Correlated scalar subquery: ``max(updated_at)`` across the four tracker
+    tables, for ``ORDER BY``.
+
+    The SQL-level counterpart to :func:`_last_tracked_bulk`, which only
+    runs on the page already fetched and therefore cannot sort the whole
+    corpus - sorting only the loaded page would silently misrepresent
+    every user not on it.
+    """
+    subqueries = [
+        select(func.max(shelf.tracker_model.updated_at))
+        .where(shelf.tracker_model.user_id == DbUser.pk)
+        .correlate(DbUser)
+        .scalar_subquery()
+        for shelf in SHELVES
+    ]
+    return _greatest_ignoring_nulls(*subqueries)
+
+
+def _tracked_total_sort_expr():
+    """
+    Correlated scalar subquery: ranked-or-watchlisted row count summed
+    across the four tracker tables, for ``ORDER BY``. The SQL-level
+    counterpart to :func:`_domain_counts_bulk`, for the same reason as
+    :func:`_last_tracked_sort_expr` above.
+    """
+    subqueries = [
+        select(func.count())  # pylint: disable=not-callable
+        .select_from(shelf.tracker_model)
+        .where(
+            shelf.tracker_model.user_id == DbUser.pk,
+            or_(
+                shelf.tracker_model.on_rankings.is_(True),
+                shelf.tracker_model.on_watchlist.is_(True),
+            ),
+        )
+        .correlate(DbUser)
+        .scalar_subquery()
+        for shelf in SHELVES
+    ]
+    return reduce(lambda left, right: left + right, subqueries)
+
+
+# One entry per value GET /v1/admin/users?sort= accepts. ``joined`` is a
+# bare column; the other two are correlated subqueries, so all three are
+# wrapped as no-arg callables - building the subquery versions eagerly
+# would attach them to a query before one exists.
+_SORT_EXPRESSIONS = {
+    'joined': lambda: DbUser.created_at,
+    'last_tracked': _last_tracked_sort_expr,
+    'tracked_total': _tracked_total_sort_expr,
+    'status': lambda: case((DbUser.disabled_at.is_(None), 0), else_=1),
+}
+
+
 @router.get('/users', response_model=OutAdminUserListResponse)
 def search_users(  # pylint: disable=too-many-arguments, too-many-positional-arguments
     request: Request,
     q: Optional[str] = None,
+    status: Optional[Literal['active', 'disabled']] = None,
+    sort: Optional[Literal['joined', 'last_tracked', 'tracked_total', 'status']] = None,
+    direction: Literal['asc', 'desc'] = 'desc',
     limit: int = DEFAULT_PAGE_SIZE,
     offset: int = 0,
     db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
 ):
-    """Search the directory by display name, handle, or email; paginated."""
+    """
+    Search the directory by display name, handle, or email; paginated.
+
+    Sorted and filtered in SQL, not on the page already fetched:
+    ``last_tracked``/``tracked_total`` are corpus-wide aggregates
+    (:func:`_last_tracked_sort_expr`/:func:`_tracked_total_sort_expr`), so
+    sorting only the returned page would answer "who joined this week" or
+    "show me the disabled accounts" correctly for the visible rows and
+    silently wrong for everyone else.
+    """
     limit, offset = _clamp_page(limit, offset)
     query = db.query(DbUser)
     if q:
@@ -180,15 +275,19 @@ def search_users(  # pylint: disable=too-many-arguments, too-many-positional-arg
                 DbUser.email.ilike(like),
             )
         )
+    if status == 'active':
+        query = query.filter(DbUser.disabled_at.is_(None))
+    elif status == 'disabled':
+        query = query.filter(DbUser.disabled_at.isnot(None))
     total = query.count()
-    # created_at alone is not unique - a secondary sort on pk keeps paging
-    # stable instead of occasionally skipping or repeating a row that ties.
-    rows = (
-        query.order_by(DbUser.created_at.desc(), DbUser.pk.desc())
-        .offset(offset)
-        .limit(limit)
-        .all()
-    )
+
+    sort_expr = _SORT_EXPRESSIONS[sort]() if sort else DbUser.created_at
+    primary = sort_expr.asc() if direction == 'asc' else sort_expr.desc()
+    # The sort column alone is not unique - a secondary sort on pk keeps
+    # paging stable instead of occasionally skipping or repeating a row
+    # that ties (every sort here can tie: two accounts created in the same
+    # second, two with no tracked rows, two active accounts, ...).
+    rows = query.order_by(primary, DbUser.pk.desc()).offset(offset).limit(limit).all()
 
     admin_audit.record(
         request,
@@ -409,8 +508,12 @@ def list_audit(  # pylint: disable=too-many-arguments, too-many-positional-argum
     request: Request,
     limit: int = DEFAULT_PAGE_SIZE,
     offset: int = 0,
-    actor: Optional[str] = None,
-    target: Optional[str] = None,
+    actor: Optional[str] = Query(
+        default=None, description='Match by handle, email, or id.'
+    ),
+    target: Optional[str] = Query(
+        default=None, description='Match by handle, email, or id.'
+    ),
     action: Optional[str] = None,
     db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
@@ -419,22 +522,40 @@ def list_audit(  # pylint: disable=too-many-arguments, too-many-positional-argum
     limit, offset = _clamp_page(limit, offset)
     query = db.query(DbAdminAuditLog)
     if actor:
-        # outerjoin, not join: an actor whose account is gone (SET NULL on
-        # delete) still has to be findable by the denormalized fields below.
+        # outerjoin against an alias, not the bare mapped class: target
+        # below joins DbUser too, and joining the same unaliased table
+        # twice in one query is invalid SQL once both filters are used
+        # together. outerjoin (not join) because an actor whose account is
+        # gone (SET NULL on delete) still has to be findable by the
+        # denormalized fields below.
+        actor_user = aliased(DbUser)
         query = query.outerjoin(
-            DbUser, DbAdminAuditLog.actor_user_pk == DbUser.pk
+            actor_user, DbAdminAuditLog.actor_user_pk == actor_user.pk
         ).filter(
             or_(
-                DbUser.handle == actor,
-                DbUser.email == actor,
-                DbUser.id == actor,
+                actor_user.handle == actor,
+                actor_user.email == actor,
+                actor_user.id == actor,
                 DbAdminAuditLog.actor_user_id == actor,
                 DbAdminAuditLog.actor_email == actor,
             )
         )
     if target:
-        query = query.filter(
+        # Same shape as actor above - the console's audit table renders the
+        # TARGET column as a handle, so a filter that could not match one
+        # would confidently return "no events" while matching rows exist
+        # (api#341 review). The denormalized id/email columns remain the
+        # source of truth for a row whose target user was later deleted;
+        # the join only adds the handle (and, for symmetry, a live id/email
+        # match) for a target that still exists.
+        target_user = aliased(DbUser)
+        query = query.outerjoin(
+            target_user, DbAdminAuditLog.target_user_pk == target_user.pk
+        ).filter(
             or_(
+                target_user.handle == target,
+                target_user.email == target,
+                target_user.id == target,
                 DbAdminAuditLog.target_user_id == target,
                 DbAdminAuditLog.target_email == target,
             )
@@ -495,6 +616,109 @@ def list_audit(  # pylint: disable=too-many-arguments, too-many-positional-argum
             for row in rows
         ],
     )
+
+
+@router.get('/impersonation', response_model=OutImpersonationSessionList)
+def list_impersonation_sessions(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """
+    Every live (unended, unexpired) view-as session, across every admin -
+    not scoped to the caller.
+
+    Scoped admin-wide rather than to "my own sessions", the same choice
+    ``GET /v1/admin/audit`` already made: that endpoint shows the whole
+    trail, not just the caller's own rows, on the theory that an admin
+    action is everyone's business on this surface, not just the acting
+    admin's. A forgotten or abandoned session is exactly the case this
+    endpoint exists to catch, and it has to be visible - and endable, see
+    :func:`stop_impersonation_session` below - to an admin other than the
+    one who started it.
+
+    Never returns the bearer token itself: this is a status/oversight view,
+    not a way to acquire someone else's live credential.
+    """
+    now = datetime.now(timezone.utc)
+    rows = (
+        db.query(DbImpersonationSession)
+        .filter(
+            DbImpersonationSession.ended_at.is_(None),
+            DbImpersonationSession.expires_at > now,
+        )
+        .order_by(DbImpersonationSession.created_at.desc())
+        .all()
+    )
+    # A session whose admin or target row is gone (deleted after the fact)
+    # is already meaningless to show - it cannot be resumed and nobody
+    # would recognize either party without the very fields that are
+    # missing. Silently excluded rather than surfaced half-populated.
+    live = [row for row in rows if row.admin is not None and row.target is not None]
+
+    admin_audit.record(
+        request,
+        actor=current_user[0],
+        action='admin.impersonation.list',
+        result=AdminAuditResult.ALLOWED,
+        status_code=200,
+        detail={'live_count': len(live)},
+    )
+    return OutImpersonationSessionList(
+        sessions=[
+            OutImpersonationLiveSession(
+                session_id=row.id,
+                acting_admin=OutImpersonationParty.model_validate(row.admin),
+                target=OutImpersonationParty.model_validate(row.target),
+                started_at=row.created_at,
+                expires_at=row.expires_at,
+            )
+            for row in live
+        ]
+    )
+
+
+@router.delete('/impersonation/{session_id}')
+def stop_impersonation_session(
+    request: Request,
+    session_id: str,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """
+    End one specific live view-as session by id, whichever admin started
+    it - the console-oversight counterpart to :func:`list_impersonation_
+    sessions` above: a listing nobody could act on would not be much of a
+    revoke capability. ``DELETE /v1/admin/impersonation`` (no id) still
+    ends every session the CALLER owns, for the web's existing "back to
+    admin" flow; this is for ending someone else's, or one of several of
+    your own, without taking down the rest.
+
+    Idempotent: an unknown, already-ended, or already-expired session id is
+    a 200 with ``{"ended": 0}``, not an error - the caller asked for that
+    session to be gone, and it is, one way or another.
+    """
+    actor = current_user[0]
+    row = (
+        db.query(DbImpersonationSession)
+        .filter(DbImpersonationSession.id == session_id)
+        .first()
+    )
+    ended = row is not None and row.ended_at is None
+    if ended:
+        row.ended_at = datetime.now(timezone.utc)
+        db.commit()
+
+    admin_audit.record(
+        request,
+        actor=actor,
+        target=row.target if ended else None,
+        action='admin.impersonation.stop',
+        result=AdminAuditResult.ALLOWED,
+        status_code=200,
+        detail={'session_id': session_id, 'ended': 1 if ended else 0},
+    )
+    return {'ended': 1 if ended else 0}
 
 
 @router.post('/impersonation', response_model=OutImpersonationSession)

--- a/app/router/v1/router_admin.py
+++ b/app/router/v1/router_admin.py
@@ -175,6 +175,10 @@ def search_users(  # pylint: disable=too-many-arguments, too-many-positional-arg
         result=AdminAuditResult.ALLOWED,
         request=request,
         detail={'q': q, 'limit': limit, 'offset': offset, 'total': total},
+        # These three routes are read-only and either return this exact
+        # 200 or raise before reaching this call (get_user_detail's 404),
+        # so the response's real status is already known here.
+        status_code=200,
     )
     return OutAdminUserListResponse(
         total=total, limit=limit, offset=offset, users=_user_summaries(db, rows)
@@ -203,6 +207,7 @@ def get_user_detail(
         action='admin.user.view',
         result=AdminAuditResult.ALLOWED,
         request=request,
+        status_code=200,
     )
     return OutAdminUserDetail(
         id=user.id,
@@ -310,6 +315,7 @@ def list_audit(  # pylint: disable=too-many-arguments, too-many-positional-argum
             'target_filter': target,
             'action_filter': action,
         },
+        status_code=200,
     )
     return OutAdminAuditResponse(
         total=total,

--- a/app/router/v1/router_admin.py
+++ b/app/router/v1/router_admin.py
@@ -1,0 +1,334 @@
+# pylint: disable=missing-function-docstring
+"""
+Admin user directory (#344): search, per-user aggregates, and the audit
+trail those actions leave.
+
+``dependencies=[Depends(require_admin)]`` sits on the router, not on each
+route. That is deliberate: a route added here later can't ship ungated by
+someone forgetting a decorator, the way the ad-hoc admin checks in
+``app.router.v1.user`` could (and did - see the cleanup there in this same
+PR). Each route still separately depends on ``get_current_user`` to get the
+resolved actor for the audit row; FastAPI caches that dependency per
+request, so it costs no extra query.
+
+Disable/enable and its auth-path enforcement, impersonation, and reports are
+later increments - not built here. This increment adds the ``disabled_at``
+column and reads it into ``status``, but nothing writes it yet.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy import case, func, or_
+from sqlalchemy.orm import Session
+
+from app.auth.oauth2 import get_current_user, require_admin
+from app.db.database import get_db
+from app.db.db_follow import count_followers, list_following
+from app.db.db_friendship import friend_pks
+from app.db.models import DbAdminAuditLog, DbUser
+from app.schemas.schemas_admin import (
+    OutAdminAuditActor,
+    OutAdminAuditEvent,
+    OutAdminAuditResponse,
+    OutAdminAuditTarget,
+    OutAdminDomainCounts,
+    OutAdminSocialCounts,
+    OutAdminUserDetail,
+    OutAdminUserListResponse,
+    OutAdminUserSummary,
+    OutAdminVisibility,
+)
+from app.services import admin_audit
+from app.services.admin_audit import AdminAuditResult
+from app.services.shelves import SHELVES
+
+router = APIRouter(
+    prefix='/v1/admin',
+    tags=['Admin'],
+    dependencies=[Depends(require_admin)],
+)
+
+MAX_PAGE_SIZE = 200
+DEFAULT_PAGE_SIZE = 50
+
+
+def _clamp_page(limit: int, offset: int) -> tuple[int, int]:
+    return max(1, min(limit, MAX_PAGE_SIZE)), max(0, offset)
+
+
+def _user_status(user: DbUser) -> str:
+    return 'disabled' if user.disabled_at is not None else 'active'
+
+
+def _domain_counts_bulk(db: Session, user_pks: list[int]) -> dict[int, dict[str, dict]]:
+    """
+    Ranked/watchlist/total per shelf for every pk in ``user_pks``, in one
+    grouped query per shelf rather than one query per user per shelf - a
+    page of 50 users costs 4 queries here, not 200.
+    """
+    counts: dict[int, dict[str, dict]] = {
+        user_pk: {
+            shelf.category: {'ranked': 0, 'watchlist': 0, 'total': 0}
+            for shelf in SHELVES
+        }
+        for user_pk in user_pks
+    }
+    if not user_pks:
+        return counts
+    for shelf in SHELVES:
+        tracker = shelf.tracker_model
+        rows = (
+            db.query(
+                tracker.user_id,
+                func.count(  # pylint: disable=not-callable
+                    case((tracker.on_rankings.is_(True), 1))
+                ),
+                func.count(  # pylint: disable=not-callable
+                    case((tracker.on_watchlist.is_(True), 1))
+                ),
+            )
+            .filter(tracker.user_id.in_(user_pks))
+            .group_by(tracker.user_id)
+            .all()
+        )
+        for user_pk, ranked, watchlist in rows:
+            counts[user_pk][shelf.category] = {
+                'ranked': ranked,
+                'watchlist': watchlist,
+                'total': ranked + watchlist,
+            }
+    return counts
+
+
+def _last_tracked_bulk(db: Session, user_pks: list[int]) -> dict[int, Optional[object]]:
+    """
+    ``max(updated_at)`` across the four tracker tables, per pk - "wrote
+    something", never relabeled as "last active" (real sign-in data is a
+    later increment).
+    """
+    latest: dict[int, Optional[object]] = dict.fromkeys(user_pks)
+    if not user_pks:
+        return latest
+    for shelf in SHELVES:
+        tracker = shelf.tracker_model
+        rows = (
+            db.query(tracker.user_id, func.max(tracker.updated_at))
+            .filter(tracker.user_id.in_(user_pks))
+            .group_by(tracker.user_id)
+            .all()
+        )
+        for user_pk, timestamp in rows:
+            if timestamp and (latest[user_pk] is None or timestamp > latest[user_pk]):
+                latest[user_pk] = timestamp
+    return latest
+
+
+def _user_summaries(db: Session, users: list[DbUser]) -> list[OutAdminUserSummary]:
+    pks = [user.pk for user in users]
+    domains_by_pk = _domain_counts_bulk(db, pks)
+    last_tracked_by_pk = _last_tracked_bulk(db, pks)
+    return [
+        OutAdminUserSummary(
+            id=user.id,
+            handle=user.handle,
+            display_name=user.display_name,
+            email=user.email,
+            user_group=user.user_group,
+            status=_user_status(user),
+            created_at=user.created_at,
+            last_tracked_at=last_tracked_by_pk[user.pk],
+            tracked_total=sum(d['total'] for d in domains_by_pk[user.pk].values()),
+        )
+        for user in users
+    ]
+
+
+@router.get('/users', response_model=OutAdminUserListResponse)
+def search_users(  # pylint: disable=too-many-arguments, too-many-positional-arguments
+    request: Request,
+    q: Optional[str] = None,
+    limit: int = DEFAULT_PAGE_SIZE,
+    offset: int = 0,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """Search the directory by display name, handle, or email; paginated."""
+    limit, offset = _clamp_page(limit, offset)
+    query = db.query(DbUser)
+    if q:
+        like = f'%{q}%'
+        query = query.filter(
+            or_(
+                DbUser.display_name.ilike(like),
+                DbUser.handle.ilike(like),
+                DbUser.email.ilike(like),
+            )
+        )
+    total = query.count()
+    rows = query.order_by(DbUser.created_at.desc()).offset(offset).limit(limit).all()
+
+    admin_audit.record(
+        db,
+        actor=current_user[0],
+        action='admin.user.search',
+        result=AdminAuditResult.ALLOWED,
+        request=request,
+        detail={'q': q, 'limit': limit, 'offset': offset, 'total': total},
+    )
+    return OutAdminUserListResponse(
+        total=total, limit=limit, offset=offset, users=_user_summaries(db, rows)
+    )
+
+
+@router.get('/users/{uuid}', response_model=OutAdminUserDetail)
+def get_user_detail(
+    request: Request,
+    uuid: str,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """Per-user aggregates: tracked counts, visibility tiers, social counts."""
+    user = db.query(DbUser).filter(DbUser.id == uuid).first()
+    if user is None:
+        raise HTTPException(status_code=404, detail='User not found')
+
+    domains = _domain_counts_bulk(db, [user.pk])[user.pk]
+    last_tracked_at = _last_tracked_bulk(db, [user.pk])[user.pk]
+
+    admin_audit.record(
+        db,
+        actor=current_user[0],
+        target=user,
+        action='admin.user.view',
+        result=AdminAuditResult.ALLOWED,
+        request=request,
+    )
+    return OutAdminUserDetail(
+        id=user.id,
+        handle=user.handle,
+        display_name=user.display_name,
+        email=user.email,
+        user_group=user.user_group,
+        status=_user_status(user),
+        created_at=user.created_at,
+        last_tracked_at=last_tracked_at,
+        visibility=OutAdminVisibility(
+            profile=user.visibility_profile,
+            default_privacy=user.default_privacy,
+            movies=user.visibility_movies,
+            tv=user.visibility_tv,
+            books=user.visibility_books,
+            games=user.visibility_games,
+            watchlist_movies=user.visibility_watchlist_movies,
+            watchlist_tv=user.visibility_watchlist_tv,
+            watchlist_books=user.visibility_watchlist_books,
+            watchlist_games=user.visibility_watchlist_games,
+            share_activity=user.share_activity,
+        ),
+        domains={
+            category: OutAdminDomainCounts(**counts)
+            for category, counts in domains.items()
+        },
+        social=OutAdminSocialCounts(
+            friends=len(friend_pks(db, user.pk)),
+            followers=count_followers(db, user.pk),
+            following=len(list_following(db, user.pk)),
+        ),
+    )
+
+
+def _audit_actor_out(row: DbAdminAuditLog) -> Optional[OutAdminAuditActor]:
+    if row.actor is None:
+        return None
+    return OutAdminAuditActor(
+        id=row.actor.id, handle=row.actor.handle, email=row.actor.email
+    )
+
+
+def _audit_target_out(row: DbAdminAuditLog) -> Optional[OutAdminAuditTarget]:
+    if row.target is not None:
+        return OutAdminAuditTarget(
+            id=row.target.id, handle=row.target.handle, email=row.target.email
+        )
+    if row.target_user_id or row.target_email:
+        # The target row is gone; fall back to what was denormalized at
+        # write time so the entry still reads sensibly.
+        return OutAdminAuditTarget(
+            id=row.target_user_id, handle=None, email=row.target_email
+        )
+    return None
+
+
+@router.get('/audit', response_model=OutAdminAuditResponse)
+def list_audit(  # pylint: disable=too-many-arguments, too-many-positional-arguments
+    request: Request,
+    limit: int = DEFAULT_PAGE_SIZE,
+    offset: int = 0,
+    actor: Optional[str] = None,
+    target: Optional[str] = None,
+    action: Optional[str] = None,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """The audit trail itself: every admin action, allowed or denied."""
+    limit, offset = _clamp_page(limit, offset)
+    query = db.query(DbAdminAuditLog)
+    if actor:
+        query = query.join(DbUser, DbAdminAuditLog.actor_user_pk == DbUser.pk).filter(
+            or_(DbUser.handle == actor, DbUser.email == actor, DbUser.id == actor)
+        )
+    if target:
+        query = query.filter(
+            or_(
+                DbAdminAuditLog.target_user_id == target,
+                DbAdminAuditLog.target_email == target,
+            )
+        )
+    if action:
+        query = query.filter(DbAdminAuditLog.action == action)
+
+    total = query.count()
+    rows = (
+        query.order_by(DbAdminAuditLog.created_at.desc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
+
+    admin_audit.record(
+        db,
+        actor=current_user[0],
+        action='admin.audit.view',
+        result=AdminAuditResult.ALLOWED,
+        request=request,
+        detail={
+            'limit': limit,
+            'offset': offset,
+            'total': total,
+            'actor_filter': actor,
+            'target_filter': target,
+            'action_filter': action,
+        },
+    )
+    return OutAdminAuditResponse(
+        total=total,
+        limit=limit,
+        offset=offset,
+        events=[
+            OutAdminAuditEvent(
+                id=row.pk,
+                created_at=row.created_at,
+                actor=_audit_actor_out(row),
+                target=_audit_target_out(row),
+                action=row.action,
+                result=row.result,
+                detail=row.detail,
+                request_id=row.request_id,
+                method=row.method,
+                path=row.path,
+                status_code=row.status_code,
+            )
+            for row in rows
+        ],
+    )

--- a/app/router/v1/router_admin.py
+++ b/app/router/v1/router_admin.py
@@ -535,6 +535,12 @@ def start_impersonation(
     # Nesting: an impersonated caller must not mint a further session.
     # require_admin already refuses them, since the swapped identity is not an
     # admin; this covers the case where an admin target slipped through.
+    # In practice this line is currently unreachable: POST is a non-safe
+    # method, so an impersonation token gets refused by the write-block in
+    # _resolve_impersonation before this handler body ever runs. Left in as
+    # defense in depth for that check's own placement changing later - two
+    # independent reasons a nested session can never mint is a better
+    # invariant than relying on one.
     if is_impersonation_token(token):
         raise _deny('nested', 'Cannot impersonate from a view-as session')
     if target.pk == actor.pk:
@@ -542,19 +548,26 @@ def start_impersonation(
     if target.user_group == 'admin':
         raise _deny('target_is_admin', 'An admin cannot be impersonated')
 
+    # One instant for both the row and the token below, so their expiries
+    # cannot drift apart by however long two separate `now()` calls take.
+    expires_at = datetime.now(timezone.utc) + timedelta(
+        minutes=IMPERSONATION_TOKEN_MINUTES
+    )
     session = DbImpersonationSession(
         admin_user_pk=actor.pk,
         target_user_pk=target.pk,
         reason=payload.reason,
-        expires_at=datetime.now(timezone.utc)
-        + timedelta(minutes=IMPERSONATION_TOKEN_MINUTES),
+        expires_at=expires_at,
     )
     db.add(session)
     db.commit()
     db.refresh(session)
 
     impersonation_token, expires = create_impersonation_token(
-        target_id=target.id, admin_id=actor.id, session_id=session.id
+        target_id=target.id,
+        admin_id=actor.id,
+        session_id=session.id,
+        expires_at=expires_at,
     )
     admin_audit.record(
         request,
@@ -599,17 +612,34 @@ def stop_impersonation(
         )
         .all()
     )
+    # One target per row, not one row for the whole call: an admin can have
+    # more than one live session, and a single aggregate row with no target
+    # cannot say which one ended or who was being viewed.
     for session in live:
         session.ended_at = now
     if live:
         db.commit()
-    admin_audit.record(
-        request,
-        actor=actor,
-        target=None,
-        action='admin.impersonation.stop',
-        result=AdminAuditResult.ALLOWED,
-        status_code=200,
-        detail={'ended': len(live)},
-    )
+    if live:
+        for session in live:
+            admin_audit.record(
+                request,
+                actor=actor,
+                target=session.target,
+                action='admin.impersonation.stop',
+                result=AdminAuditResult.ALLOWED,
+                status_code=200,
+            )
+    else:
+        # Still worth a row: a stop call with nothing live is a caller
+        # asking to end a session that was already gone (or never existed),
+        # not a no-op that vanishes without a trace.
+        admin_audit.record(
+            request,
+            actor=actor,
+            target=None,
+            action='admin.impersonation.stop',
+            result=AdminAuditResult.ALLOWED,
+            status_code=200,
+            detail={'ended': 0},
+        )
     return {'ended': len(live)}

--- a/app/router/v1/router_admin.py
+++ b/app/router/v1/router_admin.py
@@ -475,6 +475,7 @@ def list_audit(  # pylint: disable=too-many-arguments, too-many-positional-argum
                 method=row.method,
                 path=row.path,
                 status_code=row.status_code,
+                source_ip=row.source_ip,
             )
             for row in rows
         ],

--- a/app/router/v1/router_comparison.py
+++ b/app/router/v1/router_comparison.py
@@ -36,7 +36,14 @@ def _not_found() -> HTTPException:
 
 
 def _target_access(db: Session, viewer: DbUser, handle: str):
-    target = db.query(DbUser).filter(DbUser.handle == handle.lower()).first()
+    # A disabled account is invisible everywhere a deleted one would be
+    # (#344 D2) - excluded at the lookup so it 404s the same way an
+    # unclaimed handle does, below.
+    target = (
+        db.query(DbUser)
+        .filter(DbUser.handle == handle.lower(), DbUser.disabled_at.is_(None))
+        .first()
+    )
     if target is None or target.pk == viewer.pk:
         raise _not_found()
     relationship = viewer_relationship(db, target, viewer)

--- a/app/router/v1/router_follows.py
+++ b/app/router/v1/router_follows.py
@@ -66,9 +66,15 @@ def _followable_target(db: Session, handle: str) -> DbUser:
     asked directly rather than through a viewer-relationship ceiling, since a
     follow ignores who is asking. An unknown handle and a handle that
     resolves to a non-public profile are the same 404, so neither leaks
-    anything the other doesn't.
+    anything the other doesn't. A disabled account folds into the same
+    404 (#344 D2) - it is not newly followable, same as an unclaimed
+    handle.
     """
-    target = db.query(DbUser).filter(DbUser.handle == handle.lower()).first()
+    target = (
+        db.query(DbUser)
+        .filter(DbUser.handle == handle.lower(), DbUser.disabled_at.is_(None))
+        .first()
+    )
     if target is None or not is_public(target.visibility_profile):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=NOT_FOUND_PROFILE

--- a/app/router/v1/router_friends.py
+++ b/app/router/v1/router_friends.py
@@ -120,7 +120,14 @@ def send_friend_request(
 
     # No format validation on purpose: a malformed handle simply matches
     # nobody and takes the same generic path a valid-but-unused one does.
-    target = db.query(DbUser).filter(DbUser.handle == handle).first()
+    # A disabled account is excluded the same way (#344 D2) - a request
+    # aimed at one gets the identical "sent" non-answer an unused handle
+    # does, not a distinct signal that the handle belongs to someone.
+    target = (
+        db.query(DbUser)
+        .filter(DbUser.handle == handle, DbUser.disabled_at.is_(None))
+        .first()
+    )
     if target is None:
         return OutFriendAck(message=SENT_MESSAGE)
 

--- a/app/router/v1/router_visibility.py
+++ b/app/router/v1/router_visibility.py
@@ -435,7 +435,14 @@ def public_profile(  # pylint: disable=too-many-arguments, too-many-positional-a
     only applies once a single ``shelf`` is named; the multi-shelf hub view
     always gets the small preview size for every shelf.
     """
-    user = db.query(DbUser).filter(DbUser.handle == handle.lower()).first()
+    # A disabled account is invisible everywhere a deleted one would be
+    # (#344 D2) - folded into the same lookup as an unclaimed handle, not a
+    # separate branch, so it gets the same 404 for the same reason below.
+    user = (
+        db.query(DbUser)
+        .filter(DbUser.handle == handle.lower(), DbUser.disabled_at.is_(None))
+        .first()
+    )
     # One object for every "you get nothing" outcome, so they cannot drift
     # apart. Vary rides on it as well: whether this handle 404s is itself
     # viewer-dependent, so a shared cache must not answer one viewer from

--- a/app/router/v1/user.py
+++ b/app/router/v1/user.py
@@ -5,7 +5,12 @@ This module contains the API routes for user-related operations.
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
-from app.auth.oauth2 import get_current_session_user, get_current_user
+from app.auth.oauth2 import (
+    get_current_session_user,
+    get_current_user,
+    is_admin,
+    require_admin,
+)
 from app.config import get_settings
 from app.db import db_user
 from app.db.database import get_db
@@ -17,10 +22,10 @@ router = APIRouter(
 
 
 # Read all users
-@router.get('', response_model=OutResponseUserModel)
-def get_all_users(
-    db: Session = Depends(get_db), current_user: InUserBase = Depends(get_current_user)
-):
+@router.get(
+    '', response_model=OutResponseUserModel, dependencies=[Depends(require_admin)]
+)
+def get_all_users(db: Session = Depends(get_db)):
     """
     Retrieve all users from the database. Must be an admin to view all users.
 
@@ -30,14 +35,8 @@ def get_all_users(
     Returns:
         List: OutUserDisplay: A list of users.
     """
-    if current_user[0].user_group == 'admin':
-        users = db_user.get_all_users(db)
-        return OutResponseUserModel(data=users, message='Users found')
-
-    raise HTTPException(
-        status_code=403,
-        detail='User does not have permission to view all users.',
-    )
+    users = db_user.get_all_users(db)
+    return OutResponseUserModel(data=users, message='Users found')
 
 
 # Read user
@@ -117,7 +116,7 @@ def update_user(
     Returns:
         List: OutUserDisplay: The updated user data.
     """
-    if current_user[0].user_group == 'admin':
+    if is_admin(current_user):
         user = db_user.update_user(db, uuid, request)
         return OutResponseUserModel(data=user, message='User updated')
 

--- a/app/run.py
+++ b/app/run.py
@@ -196,6 +196,13 @@ async def admin_audit_denial_middleware(request, call_next):
     token) - a prober who never authenticates at all is exactly the case an
     audit trail of an admin surface should not go blind on.
 
+    Skipped when ``request.state.admin_audit_recorded`` is set: a handler
+    that reached its own body and denied the action for a business reason
+    (``disable_user`` refusing a self- or another-admin target) already
+    wrote its own, more specific row via ``admin_audit.record`` - logging
+    again here would duplicate it as a generic, less informative
+    ``admin.access`` entry for the exact same request.
+
     The whole block is guarded: a DB failure here must come back as the
     denial response the caller already has, not an unhandled exception. An
     exception escaping a ``@app.middleware`` handler surfaces at
@@ -205,11 +212,11 @@ async def admin_audit_denial_middleware(request, call_next):
     underlying error.
     """
     response = await call_next(request)
-    is_admin_denial = request.url.path.startswith(
-        '/v1/admin'
-    ) and response.status_code in (
-        status.HTTP_401_UNAUTHORIZED,
-        status.HTTP_403_FORBIDDEN,
+    is_admin_denial = (
+        request.url.path.startswith('/v1/admin')
+        and response.status_code
+        in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+        and not getattr(request.state, 'admin_audit_recorded', False)
     )
     if is_admin_denial:
         try:

--- a/app/run.py
+++ b/app/run.py
@@ -230,13 +230,20 @@ async def admin_audit_denial_middleware(request, call_next):
             db_generator = db_dependency()
             db = next(db_generator)
             try:
-                actor = admin_audit.resolve_actor_best_effort(request, db)
+                actor, via_impersonation = admin_audit.resolve_actor_best_effort(
+                    request, db
+                )
                 admin_audit.record(
                     request,
                     actor=actor,
                     action='admin.access',
                     result=admin_audit.AdminAuditResult.DENIED,
                     status_code=response.status_code,
+                    # Marks a denial made from a live impersonation session
+                    # so the trail is explicit that this was the acting
+                    # admin probing the admin surface from behind another
+                    # user's identity, not that user themself doing it.
+                    detail=({'via_impersonation': True} if via_impersonation else None),
                 )
             finally:
                 next(db_generator, None)

--- a/app/run.py
+++ b/app/run.py
@@ -162,11 +162,19 @@ async def request_id_middleware(request, call_next):
     """
     Stamp every request with an id an application log line and, for the
     admin router, an audit row can both carry - the only way to join the two
-    later. Starlette runs ``@app.middleware`` handlers in registration order
-    on the way in (each wraps everything registered after it), so as long as
-    this is registered before ``router_admin`` and its audit-denial
-    middleware are reached, ``request.state.request_id`` is set before
-    either one runs.
+    later.
+
+    Starlette actually wraps ``@app.middleware`` handlers in *reverse*
+    registration order - the last one added is outermost, so
+    ``admin_audit_denial_middleware`` below (registered after this one) runs
+    its own "before ``call_next``" code first, ahead of this middleware's.
+    That does not matter here: ``admin_audit_denial_middleware`` only reads
+    ``request.state.request_id`` *after* its own ``call_next`` returns, and
+    that call is what invokes this middleware (and everything inside it) in
+    the first place - by the time control comes back, the id has already
+    been set. ``scope['state']`` (which ``request.state`` reads and writes)
+    is shared across the whole chain, not copied per middleware, so this
+    holds regardless of nesting order. Confirmed on a live 403.
     """
     request.state.request_id = uuid.uuid4().hex
     response = await call_next(request)
@@ -177,43 +185,62 @@ async def request_id_middleware(request, call_next):
 @app.middleware('http')
 async def admin_audit_denial_middleware(request, call_next):
     """
-    Log a denied admin-router request that never reached a route handler.
+    Log a denied (or unauthenticated) admin-router request that never
+    reached a route handler.
 
     ``require_admin`` is a router-level dependency (see
     ``router_admin.router``), so it raises before any endpoint body - and
     therefore before that endpoint's own ``admin_audit.record`` call - runs.
-    This is the one place a denial can still be recorded. A 403 here always
-    followed a successful ``get_current_user`` resolution (an invalid or
-    missing token is a 401, raised earlier), so the actor lookup below is
-    expected to succeed; it degrades to an actor-less row rather than ever
-    turning a denial into a 500.
+    This is the one place such a denial can still be recorded. Covers both
+    403 (authenticated, not an admin) and 401 (missing/invalid/expired
+    token) - a prober who never authenticates at all is exactly the case an
+    audit trail of an admin surface should not go blind on.
+
+    The whole block is guarded: a DB failure here must come back as the
+    denial response the caller already has, not an unhandled exception. An
+    exception escaping a ``@app.middleware`` handler surfaces at
+    ``ServerErrorMiddleware``, which sits *outside* ``CORSMiddleware`` - so
+    an unguarded failure here would turn a clean, CORS-headered 403 into an
+    opaque CORS error in the browser instead of either the denial or the
+    underlying error.
     """
     response = await call_next(request)
-    is_admin_denial = (
-        request.url.path.startswith('/v1/admin')
-        and response.status_code == status.HTTP_403_FORBIDDEN
+    is_admin_denial = request.url.path.startswith(
+        '/v1/admin'
+    ) and response.status_code in (
+        status.HTTP_401_UNAUTHORIZED,
+        status.HTTP_403_FORBIDDEN,
     )
     if is_admin_denial:
-        # Middleware sits outside FastAPI's dependency graph, so a bare
-        # SessionLocal() would bind to the real engine even under a test
-        # client that has overridden ``get_db`` (dependency_overrides only
-        # intercepts Depends() resolution). Going through the same override
-        # lookup FastAPI itself uses keeps this on the test's session too.
-        db_dependency = app.dependency_overrides.get(get_db, get_db)
-        db_generator = db_dependency()
-        db = next(db_generator)
         try:
-            actor = admin_audit.resolve_actor_best_effort(request, db)
-            admin_audit.record(
-                db,
-                actor=actor,
-                action='admin.access',
-                result=admin_audit.AdminAuditResult.DENIED,
-                request=request,
-                status_code=response.status_code,
+            # Middleware sits outside FastAPI's dependency graph, so a bare
+            # SessionLocal() would bind to the real engine even under a test
+            # client that has overridden ``get_db`` (dependency_overrides
+            # only intercepts Depends() resolution). Going through the same
+            # override lookup FastAPI itself uses keeps this on the test's
+            # session too.
+            db_dependency = app.dependency_overrides.get(get_db, get_db)
+            db_generator = db_dependency()
+            db = next(db_generator)
+            try:
+                actor = admin_audit.resolve_actor_best_effort(request, db)
+                admin_audit.record(
+                    request,
+                    actor=actor,
+                    action='admin.access',
+                    result=admin_audit.AdminAuditResult.DENIED,
+                    status_code=response.status_code,
+                )
+            finally:
+                next(db_generator, None)
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Never let a logging failure replace the real response - see
+            # docstring. Full traceback so it's still investigable.
+            logger.exception(
+                'Failed to record admin denial audit row for %s %s',
+                request.method,
+                request.url.path,
             )
-        finally:
-            next(db_generator, None)
     return response
 
 

--- a/app/run.py
+++ b/app/run.py
@@ -6,9 +6,10 @@ import asyncio
 import json
 import os
 import time
+import uuid
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
@@ -23,6 +24,7 @@ from .log.logging_config import logger
 from .router.v1 import (
     user,
     router_activity,
+    router_admin,
     router_api_keys,
     router_export,
     router_follows,
@@ -40,6 +42,7 @@ from .router.v1 import (
     router_tv,
 )
 from .schemas.model_schemas import OutResponseBaseModel
+from .services import admin_audit
 from .utils.exceptions import (
     generic_exception_handler,
     http_exception_handler,
@@ -102,6 +105,10 @@ app = FastAPI(
             'name': 'Summary',
             'description': 'Home summary - per-shelf Top 5 and counts',
         },
+        {
+            'name': 'Admin',
+            'description': 'Admin-only user directory and audit trail',
+        },
     ],
     openapi_url='/openapi.json',
     servers=[
@@ -150,6 +157,66 @@ async def log_request_latency(request, call_next):
     return response
 
 
+@app.middleware('http')
+async def request_id_middleware(request, call_next):
+    """
+    Stamp every request with an id an application log line and, for the
+    admin router, an audit row can both carry - the only way to join the two
+    later. Starlette runs ``@app.middleware`` handlers in registration order
+    on the way in (each wraps everything registered after it), so as long as
+    this is registered before ``router_admin`` and its audit-denial
+    middleware are reached, ``request.state.request_id`` is set before
+    either one runs.
+    """
+    request.state.request_id = uuid.uuid4().hex
+    response = await call_next(request)
+    response.headers['X-Request-Id'] = request.state.request_id
+    return response
+
+
+@app.middleware('http')
+async def admin_audit_denial_middleware(request, call_next):
+    """
+    Log a denied admin-router request that never reached a route handler.
+
+    ``require_admin`` is a router-level dependency (see
+    ``router_admin.router``), so it raises before any endpoint body - and
+    therefore before that endpoint's own ``admin_audit.record`` call - runs.
+    This is the one place a denial can still be recorded. A 403 here always
+    followed a successful ``get_current_user`` resolution (an invalid or
+    missing token is a 401, raised earlier), so the actor lookup below is
+    expected to succeed; it degrades to an actor-less row rather than ever
+    turning a denial into a 500.
+    """
+    response = await call_next(request)
+    is_admin_denial = (
+        request.url.path.startswith('/v1/admin')
+        and response.status_code == status.HTTP_403_FORBIDDEN
+    )
+    if is_admin_denial:
+        # Middleware sits outside FastAPI's dependency graph, so a bare
+        # SessionLocal() would bind to the real engine even under a test
+        # client that has overridden ``get_db`` (dependency_overrides only
+        # intercepts Depends() resolution). Going through the same override
+        # lookup FastAPI itself uses keeps this on the test's session too.
+        db_dependency = app.dependency_overrides.get(get_db, get_db)
+        db_generator = db_dependency()
+        db = next(db_generator)
+        try:
+            actor = admin_audit.resolve_actor_best_effort(request, db)
+            admin_audit.record(
+                db,
+                actor=actor,
+                action='admin.access',
+                result=admin_audit.AdminAuditResult.DENIED,
+                request=request,
+                status_code=response.status_code,
+            )
+        finally:
+            next(db_generator, None)
+    return response
+
+
 app.include_router(authentication.router, prefix='/v1/auth')
 app.include_router(user.router, prefix='/v1/users')
 app.include_router(router_movies.router)
@@ -168,6 +235,7 @@ app.include_router(router_friends.router)
 app.include_router(router_follows.router)
 app.include_router(router_preferences.router)
 app.include_router(router_summary.router)
+app.include_router(router_admin.router)
 
 # Serve static files
 app.mount('/static', StaticFiles(directory='app/static'), name='static')

--- a/app/schemas/schemas_admin.py
+++ b/app/schemas/schemas_admin.py
@@ -1,0 +1,132 @@
+"""
+Pydantic schemas for the admin console's user-directory endpoints (#344).
+
+Kept separate from :mod:`app.schemas.model_schemas` and
+:mod:`app.schemas.schemas_sandbox`: these shapes are operator-only, never
+returned from a user-facing route, and none of them reuse an existing
+response model.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+from app.services.visibility import VisibilityTier
+
+
+class OutAdminUserSummary(BaseModel):
+    """One row of ``GET /v1/admin/users``."""
+
+    id: str
+    handle: Optional[str] = None
+    display_name: str
+    email: str
+    user_group: str
+    status: str
+    created_at: datetime
+    # Max(updated_at) across the four tracker tables - "wrote something",
+    # not "visited". Deliberately not last_active_at; real sign-in data is a
+    # later increment's separate field.
+    last_tracked_at: Optional[datetime] = None
+    tracked_total: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class OutAdminUserListResponse(BaseModel):
+    """``GET /v1/admin/users``."""
+
+    total: int
+    limit: int
+    offset: int
+    users: list[OutAdminUserSummary]
+
+
+class OutAdminDomainCounts(BaseModel):
+    """Ranked/watchlist/total for one tracked domain."""
+
+    ranked: int
+    watchlist: int
+    total: int
+
+
+class OutAdminVisibility(BaseModel):
+    """The nine visibility settings, plus activity sharing, for one user."""
+
+    profile: VisibilityTier
+    default_privacy: VisibilityTier
+    movies: Optional[VisibilityTier] = None
+    tv: Optional[VisibilityTier] = None
+    books: Optional[VisibilityTier] = None
+    games: Optional[VisibilityTier] = None
+    watchlist_movies: Optional[VisibilityTier] = None
+    watchlist_tv: Optional[VisibilityTier] = None
+    watchlist_books: Optional[VisibilityTier] = None
+    watchlist_games: Optional[VisibilityTier] = None
+    share_activity: bool
+
+
+class OutAdminSocialCounts(BaseModel):
+    """Friend-graph size for one user."""
+
+    friends: int
+    followers: int
+    following: int
+
+
+class OutAdminUserDetail(BaseModel):
+    """``GET /v1/admin/users/{uuid}``."""
+
+    id: str
+    handle: Optional[str] = None
+    display_name: str
+    email: str
+    user_group: str
+    status: str
+    created_at: datetime
+    last_tracked_at: Optional[datetime] = None
+    visibility: OutAdminVisibility
+    domains: dict[str, OutAdminDomainCounts]
+    social: OutAdminSocialCounts
+
+
+class OutAdminAuditActor(BaseModel):
+    """Who performed one audit-logged action."""
+
+    id: str
+    handle: Optional[str] = None
+    email: Optional[str] = None
+
+
+class OutAdminAuditTarget(BaseModel):
+    """Who one audit-logged action was about, if anyone."""
+
+    id: Optional[str] = None
+    handle: Optional[str] = None
+    email: Optional[str] = None
+
+
+class OutAdminAuditEvent(BaseModel):
+    """One row of ``GET /v1/admin/audit``."""
+
+    id: int
+    created_at: datetime
+    actor: Optional[OutAdminAuditActor] = None
+    target: Optional[OutAdminAuditTarget] = None
+    action: str
+    result: str
+    detail: Optional[dict] = None
+    request_id: Optional[str] = None
+    method: Optional[str] = None
+    path: Optional[str] = None
+    status_code: Optional[int] = None
+
+
+class OutAdminAuditResponse(BaseModel):
+    """``GET /v1/admin/audit``."""
+
+    total: int
+    limit: int
+    offset: int
+    events: list[OutAdminAuditEvent]

--- a/app/schemas/schemas_admin.py
+++ b/app/schemas/schemas_admin.py
@@ -151,6 +151,14 @@ class OutAdminAuditEvent(BaseModel):
     method: Optional[str] = None
     path: Optional[str] = None
     status_code: Optional[int] = None
+    # Captured via services.rate_limit.client_ip (rightmost X-Forwarded-For
+    # hop) since request.client.host is the ingress proxy in prod. Exposed
+    # deliberately - attribution is the whole point of an audit trail, and
+    # this is the field that answers "where was this taken from" without
+    # someone opening psql. user_agent is captured too but stays
+    # database-only: long, wrecks a table row, and nobody scans it - it
+    # belongs in a future detail expansion, not the list view.
+    source_ip: Optional[str] = None
 
 
 class OutAdminAuditResponse(BaseModel):

--- a/app/schemas/schemas_admin.py
+++ b/app/schemas/schemas_admin.py
@@ -113,9 +113,18 @@ class OutAdminUserDetail(BaseModel):
 
 
 class OutAdminAuditActor(BaseModel):
-    """Who performed one audit-logged action."""
+    """
+    Who performed one audit-logged action.
 
-    id: str
+    ``id`` is optional, not just ``handle``/``email``: the actor's account
+    can be deleted (self-delete is permitted), which SETs ``actor_user_pk``
+    NULL - the row falls back to whatever of ``actor_user_id``/
+    ``actor_email`` was denormalized at write time, and either can be
+    missing if the actor could not be resolved at all (an expired-token
+    denial, for instance).
+    """
+
+    id: Optional[str] = None
     handle: Optional[str] = None
     email: Optional[str] = None
 

--- a/app/schemas/schemas_admin.py
+++ b/app/schemas/schemas_admin.py
@@ -196,3 +196,19 @@ class OutImpersonationSession(BaseModel):
     expires_at: UtcDatetime
     target: OutImpersonationParty
     acting_admin: OutImpersonationParty
+
+
+class OutImpersonationLiveSession(BaseModel):
+    """One row of ``GET /v1/admin/impersonation``. Never carries the token."""
+
+    session_id: str
+    acting_admin: OutImpersonationParty
+    target: OutImpersonationParty
+    started_at: UtcDatetime
+    expires_at: UtcDatetime
+
+
+class OutImpersonationSessionList(BaseModel):
+    """``GET /v1/admin/impersonation``."""
+
+    sessions: list[OutImpersonationLiveSession]

--- a/app/schemas/schemas_admin.py
+++ b/app/schemas/schemas_admin.py
@@ -7,12 +7,33 @@ returned from a user-facing route, and none of them reuse an existing
 response model.
 """
 
-from datetime import datetime
-from typing import Optional
+from datetime import datetime, timezone
+from typing import Annotated, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, PlainSerializer
 
 from app.services.visibility import VisibilityTier
+
+
+def _serialize_utc(value: datetime) -> str:
+    """
+    Stamp a naive datetime as UTC before emitting it (aware ones are just
+    normalized to UTC). The backing columns are Postgres ``timestamp without
+    time zone``, but every value written to them is already UTC
+    (:func:`datetime.now` called with ``timezone.utc`` throughout the
+    codebase) - only the serialization was silently dropping the
+    designator. Per ECMAScript, a date-time string with no offset parses as
+    *local* time, so every JS client was quietly shifting these by its own
+    UTC offset (api#344 review).
+    """
+    aware = value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+    return aware.astimezone(timezone.utc).isoformat().replace('+00:00', 'Z')
+
+
+# Same wire type as `datetime`, but always serializes with an explicit UTC
+# designator. See `_serialize_utc`. Use this in place of a bare `datetime`
+# on any field this branch introduces.
+UtcDatetime = Annotated[datetime, PlainSerializer(_serialize_utc, return_type=str)]
 
 
 class OutAdminUserSummary(BaseModel):
@@ -24,11 +45,11 @@ class OutAdminUserSummary(BaseModel):
     email: str
     user_group: str
     status: str
-    created_at: datetime
+    created_at: UtcDatetime
     # Max(updated_at) across the four tracker tables - "wrote something",
     # not "visited". Deliberately not last_active_at; real sign-in data is a
     # later increment's separate field.
-    last_tracked_at: Optional[datetime] = None
+    last_tracked_at: Optional[UtcDatetime] = None
     tracked_total: int
 
     model_config = ConfigDict(from_attributes=True)
@@ -84,8 +105,8 @@ class OutAdminUserDetail(BaseModel):
     email: str
     user_group: str
     status: str
-    created_at: datetime
-    last_tracked_at: Optional[datetime] = None
+    created_at: UtcDatetime
+    last_tracked_at: Optional[UtcDatetime] = None
     visibility: OutAdminVisibility
     domains: dict[str, OutAdminDomainCounts]
     social: OutAdminSocialCounts
@@ -111,7 +132,7 @@ class OutAdminAuditEvent(BaseModel):
     """One row of ``GET /v1/admin/audit``."""
 
     id: int
-    created_at: datetime
+    created_at: UtcDatetime
     actor: Optional[OutAdminAuditActor] = None
     target: Optional[OutAdminAuditTarget] = None
     action: str

--- a/app/schemas/schemas_admin.py
+++ b/app/schemas/schemas_admin.py
@@ -168,3 +168,31 @@ class OutAdminAuditResponse(BaseModel):
     limit: int
     offset: int
     events: list[OutAdminAuditEvent]
+
+
+class InImpersonationStart(BaseModel):
+    """``POST /v1/admin/impersonation`` request."""
+
+    target_uuid: str
+    reason: Optional[str] = None
+
+
+class OutImpersonationParty(BaseModel):
+    """Either side of a view-as session."""
+
+    id: str
+    handle: Optional[str] = None
+    display_name: Optional[str] = None
+    email: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class OutImpersonationSession(BaseModel):
+    """``POST /v1/admin/impersonation``."""
+
+    token: str
+    session_id: str
+    expires_at: UtcDatetime
+    target: OutImpersonationParty
+    acting_admin: OutImpersonationParty

--- a/app/services/admin_audit.py
+++ b/app/services/admin_audit.py
@@ -43,6 +43,7 @@ ALLOWED_DETAIL_FIELDS = frozenset(
         'actor_filter',
         'target_filter',
         'action_filter',
+        'reason',
     }
 )
 
@@ -122,6 +123,14 @@ def record(  # pylint: disable=too-many-arguments
         audit_db.add(row)
         audit_db.commit()
         audit_db.refresh(row)
+    # Lets admin_audit_denial_middleware (app/run.py) tell "this request
+    # never reached a handler" (require_admin's own 403/401 - the one case
+    # it exists to catch) apart from "the handler ran and denied the action
+    # itself" (disable_user's self/another-admin guards, which call this
+    # directly). Without the flag, a handler-level denial gets logged twice:
+    # once here with the specific action, once more by the middleware as a
+    # generic admin.access - both true, but the second is redundant noise.
+    request.state.admin_audit_recorded = True
     return row
 
 

--- a/app/services/admin_audit.py
+++ b/app/services/admin_audit.py
@@ -44,6 +44,9 @@ ALLOWED_DETAIL_FIELDS = frozenset(
         'target_filter',
         'action_filter',
         'reason',
+        'session_id',
+        'ended',
+        'via_impersonation',
     }
 )
 
@@ -134,7 +137,9 @@ def record(  # pylint: disable=too-many-arguments
     return row
 
 
-def resolve_actor_best_effort(request: Request, db: Session) -> Optional[DbUser]:
+def resolve_actor_best_effort(
+    request: Request, db: Session
+) -> tuple[Optional[DbUser], bool]:
     """
     Best-effort bearer-token resolution for a request that never reached a
     route handler, used only to attribute a denied admin request in the
@@ -145,25 +150,39 @@ def resolve_actor_best_effort(request: Request, db: Session) -> Optional[DbUser]
     bumps and commits ``last_used_at`` as a matter of course on every real
     request.
 
+    Returns ``(actor, via_impersonation)``. An impersonation token's
+    resolved identity is the swapped-in TARGET, not the caller - if this
+    attributed a denial to that resolved identity the way the normal auth
+    path does, a denied admin-route probe made while impersonating would
+    land on the innocent target's permanent audit record and hide the
+    acting admin behind it. So an impersonation token is attributed to the
+    admin named in its ``act`` claim instead, decoded directly rather than
+    through the normal resolver (which would apply the read-only write-block
+    and other session checks that do not matter for mere attribution, and
+    would return the target regardless).
+
     A 403 or 401 on ``/v1/admin/*`` is the only case this is called for. A
     403 always follows a successful token resolution (an invalid/missing
     token fails earlier as a 401), so this succeeds whenever it's called for
     one; a 401 means resolution already failed once, so this fails closed
-    (returns ``None``) the same way rather than raise - losing one denial's
-    actor is far cheaper than a 500 in a piece of logging middleware.
+    (returns ``(None, False)``) the same way rather than raise - losing one
+    denial's actor is far cheaper than a 500 in a piece of logging
+    middleware.
     """
     # Local imports: keeps this module's import surface centered on the
     # audit table rather than the whole auth stack.
     from app.auth.oauth2 import (  # pylint: disable=import-outside-toplevel
         API_KEY_PREFIX,
+        IMPERSONATION_TOKEN_TYPE,
         _user_from_access_token,
+        decode_token_payload_best_effort,
         hash_api_key,
     )
     from app.db.models import DbApiKey  # pylint: disable=import-outside-toplevel
 
     auth_header = request.headers.get('authorization', '')
     if not auth_header.lower().startswith('bearer '):
-        return None
+        return None, False
     token = auth_header[len('bearer ') :]
     try:
         if token.startswith(API_KEY_PREFIX):
@@ -172,7 +191,23 @@ def resolve_actor_best_effort(request: Request, db: Session) -> Optional[DbUser]
                 .filter(DbApiKey.key_hash == hash_api_key(token))
                 .first()
             )
-            return row.user if row else None
-        return _user_from_access_token(token, db, ValueError('unresolvable actor'))[0]
+            return (row.user if row else None), False
+
+        payload = decode_token_payload_best_effort(token)
+        if payload is not None and payload.get('typ') == IMPERSONATION_TOKEN_TYPE:
+            admin_id = payload.get('act')
+            admin = (
+                db.query(DbUser).filter(DbUser.id == admin_id).first()
+                if admin_id
+                else None
+            )
+            return admin, True
+
+        return (
+            _user_from_access_token(
+                token, db, ValueError('unresolvable actor'), request
+            )[0],
+            False,
+        )
     except Exception:  # pylint: disable=broad-exception-caught
-        return None
+        return None, False

--- a/app/services/admin_audit.py
+++ b/app/services/admin_audit.py
@@ -12,14 +12,17 @@ because it happened to be sitting in the same dict as something worth
 recording - it has to be named in :data:`ALLOWED_DETAIL_FIELDS` first.
 """
 
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from enum import StrEnum
-from typing import Optional
+from typing import Iterator, Optional
 
 from fastapi import Request
 from sqlalchemy.orm import Session
 
+from app.db.database import get_db
 from app.db.models import DbAdminAuditLog, DbUser
+from app.services.rate_limit import client_ip
 
 
 class AdminAuditResult(StrEnum):
@@ -54,43 +57,71 @@ def _redact(detail: Optional[dict]) -> Optional[dict]:
     return allowed or None
 
 
+@contextmanager
+def _short_lived_session(request: Request) -> Iterator[Session]:
+    """
+    A session of its own for the audit write, resolved the same way FastAPI
+    resolves ``get_db`` (so a test's ``dependency_overrides`` is honored,
+    and the write lands in the same database the caller is using).
+
+    Writing through the caller's own request-scoped session would work, but
+    that session has ``expire_on_commit=True`` (the default on
+    ``SessionLocal``): committing on it invalidates every ORM object the
+    caller already loaded, so the next attribute access on any of them
+    refetches one row at a time. In ``search_users`` that turned the bulk
+    aggregate queries this router exists to batch into one query per user
+    again. A short-lived session sidesteps that entirely, and as a bonus
+    means the audit row still gets written even if the caller's own
+    transaction later rolls back.
+    """
+    db_dependency = request.app.dependency_overrides.get(get_db, get_db)
+    generator = db_dependency()
+    try:
+        session = next(generator)
+    except StopIteration as exc:
+        # PEP 479: an un-caught StopIteration inside this generator function
+        # (this is a @contextmanager) becomes a confusing RuntimeError -
+        # translate it into a real error about what actually went wrong.
+        raise RuntimeError('get_db dependency yielded no session') from exc
+    try:
+        yield session
+    finally:
+        next(generator, None)
+
+
 def record(  # pylint: disable=too-many-arguments
-    db: Session,
+    request: Request,
     *,
     actor: Optional[DbUser],
     action: str,
     result: AdminAuditResult,
-    request: Optional[Request] = None,
     target: Optional[DbUser] = None,
     detail: Optional[dict] = None,
     status_code: Optional[int] = None,
 ) -> DbAdminAuditLog:
-    """
-    Write one audit row and commit it immediately.
-
-    Committed on its own rather than folded into the caller's transaction:
-    the trail has to survive even if the surrounding request later rolls
-    back, and it must never be the reason a read endpoint fails.
-    """
+    """Write one audit row, on its own short-lived session, and commit it."""
     row = DbAdminAuditLog(
         actor_user_pk=actor.pk if actor else None,
+        actor_user_id=actor.id if actor else None,
+        actor_email=actor.email if actor else None,
         target_user_pk=target.pk if target else None,
         target_user_id=target.id if target else None,
         target_email=target.email if target else None,
         action=action,
         result=AdminAuditResult(result).value,
         detail=_redact(detail),
-        request_id=getattr(request.state, 'request_id', None) if request else None,
-        method=request.method if request else None,
-        path=request.url.path if request else None,
+        request_id=getattr(request.state, 'request_id', None),
+        method=request.method,
+        path=request.url.path,
         status_code=status_code,
-        source_ip=request.client.host if request and request.client else None,
-        user_agent=request.headers.get('user-agent') if request else None,
+        source_ip=client_ip(request),
+        user_agent=request.headers.get('user-agent'),
         created_at=datetime.now(timezone.utc),
     )
-    db.add(row)
-    db.commit()
-    db.refresh(row)
+    with _short_lived_session(request) as audit_db:
+        audit_db.add(row)
+        audit_db.commit()
+        audit_db.refresh(row)
     return row
 
 
@@ -98,29 +129,41 @@ def resolve_actor_best_effort(request: Request, db: Session) -> Optional[DbUser]
     """
     Best-effort bearer-token resolution for a request that never reached a
     route handler, used only to attribute a denied admin request in the
-    audit log. A 403 from :func:`app.auth.oauth2.require_admin` only ever
-    follows a *successful* :func:`app.auth.oauth2.get_current_user`
-    resolution (an invalid/missing token fails earlier, with a 401), so this
-    is expected to succeed whenever it is called; it still fails closed
-    (returns ``None``) rather than raise, since losing one denial's actor is
-    far cheaper than a 500 in a piece of logging middleware.
+    audit log. Deliberately read-only: unlike the normal auth path, this
+    must never have a side effect on the credential it is only trying to
+    attribute, so it looks up an API key directly instead of going through
+    :func:`app.auth.oauth2.get_current_user`'s ``_user_from_api_key`, which
+    bumps and commits ``last_used_at`` as a matter of course on every real
+    request.
+
+    A 403 or 401 on ``/v1/admin/*`` is the only case this is called for. A
+    403 always follows a successful token resolution (an invalid/missing
+    token fails earlier as a 401), so this succeeds whenever it's called for
+    one; a 401 means resolution already failed once, so this fails closed
+    (returns ``None``) the same way rather than raise - losing one denial's
+    actor is far cheaper than a 500 in a piece of logging middleware.
     """
-    # Local import: keeps this module's import surface centered on the audit
-    # table rather than the whole auth stack.
+    # Local imports: keeps this module's import surface centered on the
+    # audit table rather than the whole auth stack.
     from app.auth.oauth2 import (  # pylint: disable=import-outside-toplevel
         API_KEY_PREFIX,
         _user_from_access_token,
-        _user_from_api_key,
+        hash_api_key,
     )
+    from app.db.models import DbApiKey  # pylint: disable=import-outside-toplevel
 
     auth_header = request.headers.get('authorization', '')
     if not auth_header.lower().startswith('bearer '):
         return None
     token = auth_header[len('bearer ') :]
-    unresolvable = ValueError('unresolvable actor')
     try:
         if token.startswith(API_KEY_PREFIX):
-            return _user_from_api_key(token, db, unresolvable)[0]
-        return _user_from_access_token(token, db, unresolvable)[0]
+            row = (
+                db.query(DbApiKey)
+                .filter(DbApiKey.key_hash == hash_api_key(token))
+                .first()
+            )
+            return row.user if row else None
+        return _user_from_access_token(token, db, ValueError('unresolvable actor'))[0]
     except Exception:  # pylint: disable=broad-exception-caught
         return None

--- a/app/services/admin_audit.py
+++ b/app/services/admin_audit.py
@@ -47,6 +47,7 @@ ALLOWED_DETAIL_FIELDS = frozenset(
         'session_id',
         'ended',
         'via_impersonation',
+        'live_count',
     }
 )
 

--- a/app/services/admin_audit.py
+++ b/app/services/admin_audit.py
@@ -1,0 +1,126 @@
+"""
+Append-only audit trail for the admin console (#344).
+
+:func:`record` is the only way a row gets written; there is deliberately no
+update or delete path anywhere in this module or its callers - a trail that
+can be edited after the fact is not a trail.
+
+``detail`` is built by allowlisting fields in, never by blocklisting fields
+out. A payload dict handed to a future admin action can never leak a
+password, hash, bearer token, API key, or refresh token into the log just
+because it happened to be sitting in the same dict as something worth
+recording - it has to be named in :data:`ALLOWED_DETAIL_FIELDS` first.
+"""
+
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Optional
+
+from fastapi import Request
+from sqlalchemy.orm import Session
+
+from app.db.models import DbAdminAuditLog, DbUser
+
+
+class AdminAuditResult(StrEnum):
+    """Outcome of one admin action, as recorded in ``result``."""
+
+    ALLOWED = 'allowed'
+    DENIED = 'denied'
+
+
+# Every key a caller is allowed to put in ``detail``. A new admin action has
+# to add its fields here before they show up in the log - never the reverse.
+ALLOWED_DETAIL_FIELDS = frozenset(
+    {
+        'q',
+        'limit',
+        'offset',
+        'total',
+        'actor_filter',
+        'target_filter',
+        'action_filter',
+    }
+)
+
+
+def _redact(detail: Optional[dict]) -> Optional[dict]:
+    """Drop everything not on the allowlist; ``None``/empty stays ``None``."""
+    if not detail:
+        return None
+    allowed = {
+        key: value for key, value in detail.items() if key in ALLOWED_DETAIL_FIELDS
+    }
+    return allowed or None
+
+
+def record(  # pylint: disable=too-many-arguments
+    db: Session,
+    *,
+    actor: Optional[DbUser],
+    action: str,
+    result: AdminAuditResult,
+    request: Optional[Request] = None,
+    target: Optional[DbUser] = None,
+    detail: Optional[dict] = None,
+    status_code: Optional[int] = None,
+) -> DbAdminAuditLog:
+    """
+    Write one audit row and commit it immediately.
+
+    Committed on its own rather than folded into the caller's transaction:
+    the trail has to survive even if the surrounding request later rolls
+    back, and it must never be the reason a read endpoint fails.
+    """
+    row = DbAdminAuditLog(
+        actor_user_pk=actor.pk if actor else None,
+        target_user_pk=target.pk if target else None,
+        target_user_id=target.id if target else None,
+        target_email=target.email if target else None,
+        action=action,
+        result=AdminAuditResult(result).value,
+        detail=_redact(detail),
+        request_id=getattr(request.state, 'request_id', None) if request else None,
+        method=request.method if request else None,
+        path=request.url.path if request else None,
+        status_code=status_code,
+        source_ip=request.client.host if request and request.client else None,
+        user_agent=request.headers.get('user-agent') if request else None,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def resolve_actor_best_effort(request: Request, db: Session) -> Optional[DbUser]:
+    """
+    Best-effort bearer-token resolution for a request that never reached a
+    route handler, used only to attribute a denied admin request in the
+    audit log. A 403 from :func:`app.auth.oauth2.require_admin` only ever
+    follows a *successful* :func:`app.auth.oauth2.get_current_user`
+    resolution (an invalid/missing token fails earlier, with a 401), so this
+    is expected to succeed whenever it is called; it still fails closed
+    (returns ``None``) rather than raise, since losing one denial's actor is
+    far cheaper than a 500 in a piece of logging middleware.
+    """
+    # Local import: keeps this module's import surface centered on the audit
+    # table rather than the whole auth stack.
+    from app.auth.oauth2 import (  # pylint: disable=import-outside-toplevel
+        API_KEY_PREFIX,
+        _user_from_access_token,
+        _user_from_api_key,
+    )
+
+    auth_header = request.headers.get('authorization', '')
+    if not auth_header.lower().startswith('bearer '):
+        return None
+    token = auth_header[len('bearer ') :]
+    unresolvable = ValueError('unresolvable actor')
+    try:
+        if token.startswith(API_KEY_PREFIX):
+            return _user_from_api_key(token, db, unresolvable)[0]
+        return _user_from_access_token(token, db, unresolvable)[0]
+    except Exception:  # pylint: disable=broad-exception-caught
+        return None

--- a/docs/dev-cast.md
+++ b/docs/dev-cast.md
@@ -1,8 +1,12 @@
 # The dev cast
 
-Seven local accounts that cover every relationship, visibility and time-zone
-position the social features have. They exist so a demo can *show* a rule
-instead of describing it: sign into the seat the rule applies to and look.
+Eight local accounts. Seven cover every relationship, visibility and
+time-zone position the social features have; the eighth (`admin-two`) is
+unrelated to that matrix - it exists so admin-console rules that need a
+*second* admin (#341: an admin cannot impersonate or disable another admin)
+are demonstrable, not just unit-tested. They exist so a demo can *show* a
+rule instead of describing it: sign into the seat the rule applies to and
+look.
 
 Created by `task seed:dev` (`app/migration/seed_dev.py`). The seeder refuses
 to run against anything but the local dev Postgres, so **these credentials
@@ -22,9 +26,12 @@ is the seed admin from `env/dev.env` and keeps its own `ADMIN_PASSWORD`.
 | `public-user` | `public@example.com` | `change-me` | public | 3 | Australia/Sydney |
 | `private-user` | `private@example.com` | `change-me` | private | 6 | America/New_York |
 | `stranger` | `stranger@example.com` | `change-me` | public | 4 | UTC |
+| `admin-two` | `admin-two@gmail.com` | `change-me` | private | 0 | America/Chicago |
 
 Read `$ADMIN_EMAIL` / `$ADMIN_PASSWORD` out of `env/dev.env` - they are
-per-clone, so never hardcode them into a script or a report.
+per-clone, so never hardcode them into a script or a report. `admin-two`'s
+own credentials are the literal ones above, no env var - it is a fixed cast
+account like the rest, just an admin one.
 
 ### What each seat is for
 
@@ -36,6 +43,7 @@ per-clone, so never hardcode them into a script or a report.
 | `public-user` | none | a stranger whose shelves are readable anyway |
 | `private-user` | none, private profile | a profile that 404s - with a stocked shelf behind it, so the 404 is the tier and not emptiness |
 | `stranger` | none | `not_enough_overlap`: a real shelf, still under the five shared titles alignment needs |
+| `admin-two` | none - both are `user_group='admin'` | the only seat that can demo an admin acting *on* another admin: sign in as `you` (or `admin-two`), try to disable or impersonate the other, and get refused. With one admin in the seed this rule was provable only by unit test. |
 
 **The movie counts are load-bearing.** Every title a cast member ranks is
 also ranked by `you` (the target is seeded with the whole fixture), so shelf
@@ -91,6 +99,10 @@ rest of the run looks like a broken endpoint.
 - **Time zone, greeting, schedule** - see below.
 - **Anything list-shaped (pagination, ranking, filters)** - `you` is the
   only seat with enough rows; the cast shelves are single-page on purpose.
+- **Admin console rules involving a second admin** (disable, impersonate) -
+  the only pair that can demo this is `you` and `admin-two`; every other
+  seat is `user_group='user'` and gets the ordinary non-admin 403 instead
+  of the admin-on-admin refusal.
 
 ### Demoing per-user time zones
 

--- a/openapi.json
+++ b/openapi.json
@@ -8656,6 +8656,17 @@
               }
             ],
             "title": "Status Code"
+          },
+          "source_ip": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Ip"
           }
         },
         "type": "object",

--- a/openapi.json
+++ b/openapi.json
@@ -6008,6 +6008,102 @@
         }
       }
     },
+    "/v1/admin/users/{uuid}/disable": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Disable User",
+        "description": "Disable an account: blocks sign-in, kills every live credential, and\n(D2, per product decision) makes the user disappear everywhere a\ndeleted user would - see the read-path filters in router_visibility,\nrouter_comparison, router_friends, router_follows, router_activity, and\ndb_user.search_users.\n\nSelf-disable and disabling another admin are both refused outright\n(403) rather than merely discouraged: with a small operator pool,\neither one risks a lockout with nobody left to undo it. Both refusals\nare audited as denials, same as the router-level admin gate.",
+        "operationId": "disable_user_v1_admin_users__uuid__disable_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutAdminUserDetail"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/users/{uuid}/enable": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Enable User",
+        "description": "Re-enable an account. Restores sign-in only - the refresh tokens and\nAPI keys a disable revoked are gone for good (this is load-bearing for\nthe confirmation copy on the disable action: re-enabling is not\n\"undo,\" the user has to sign in again and reissue any API keys).",
+        "operationId": "enable_user_v1_admin_users__uuid__enable_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutAdminUserDetail"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/admin/audit": {
       "get": {
         "tags": [

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "druthers.io API local",
-    "description": "API for druthers.io \u2014 track and rank the movies, TV, books, and games you actually care about.",
+    "description": "API for druthers.io - track and rank the movies, TV, books, and games you actually care about.",
     "contact": {
       "name": "Druthers",
       "url": "https://www.druthers.io/"
@@ -72,7 +72,7 @@
           "authentication"
         ],
         "summary": "Google Login",
-        "description": "Sign in with a Google Identity Services ID token.\n\nVerifies the token against the configured Google client id, then upserts the\nuser (creating one on first sign-in) and returns a JWT \u2014 the same shape as\nthe password flow.",
+        "description": "Sign in with a Google Identity Services ID token.\n\nVerifies the token against the configured Google client id, then upserts the\nuser (creating one on first sign-in) and returns a JWT - the same shape as\nthe password flow.",
         "operationId": "google_login_v1_auth_google_post",
         "requestBody": {
           "content": {
@@ -156,7 +156,7 @@
           "authentication"
         ],
         "summary": "Logout",
-        "description": "Sign out server-side: the refresh token and its family stop working.\n\nDeliberately 204 whether or not the token was recognised \u2014 sign-out must\nnot depend on the client still holding a valid credential, and the status\nshouldn't reveal whether a guessed token existed.",
+        "description": "Sign out server-side: the refresh token and its family stop working.\n\nDeliberately 204 whether or not the token was recognised - sign-out must\nnot depend on the client still holding a valid credential, and the status\nshouldn't reveal whether a guessed token existed.",
         "operationId": "logout_v1_auth_logout_post",
         "requestBody": {
           "content": {
@@ -409,17 +409,72 @@
         ],
         "summary": "Get All Movies",
         "operationId": "get_all_movies_v1_movies_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "tmdb",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tmdb"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 25,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
+                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/MovieResponse"
                   },
-                  "type": "array",
                   "title": "Response Get All Movies V1 Movies Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -432,15 +487,20 @@
         ],
         "summary": "Create Movie",
         "operationId": "create_movie_v1_movies_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/MovieCreate"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "201": {
@@ -463,12 +523,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
+        }
       }
     },
     "/v1/movies/search": {
@@ -669,7 +724,7 @@
           "Movies"
         ],
         "summary": "Get Movie Watch Providers",
-        "description": "Where this movie can be streamed, rented or bought in ``region`` (web#26).\n\nLive TMDB/JustWatch data, not catalog data, so nothing here is stored. A\nmovie with no availability \u2014 or one the backfill never keyed onto TMDB \u2014\nreturns empty buckets rather than an error; only an unknown movie 404s.",
+        "description": "Where this movie can be streamed, rented or bought in ``region`` (web#26).\n\nLive TMDB/JustWatch data, not catalog data, so nothing here is stored. A\nmovie with no availability - or one the backfill never keyed onto TMDB -\nreturns empty buckets rather than an error; only an unknown movie 404s.",
         "operationId": "get_movie_watch_providers_v1_movies__movie_id__watch_providers_get",
         "security": [
           {
@@ -796,6 +851,55 @@
               "title": "Offset"
             },
             "description": "Entries to skip"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "pattern": "^-?(rank|title|completed_at)$"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Order by rank, title, or completed_at; prefix with - for descending",
+              "title": "Sort"
+            },
+            "description": "Order by rank, title, or completed_at; prefix with - for descending"
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Case-insensitive substring match against the title",
+              "title": "Search"
+            },
+            "description": "Case-insensitive substring match against the title"
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Return an {items, total, limit, offset} envelope instead of the legacy array response",
+              "default": false,
+              "title": "Include Total"
+            },
+            "description": "Return an {items, total, limit, offset} envelope instead of the legacy array response"
           }
         ],
         "responses": {
@@ -804,10 +908,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/UserMovieResponse"
-                  },
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/UserMovieResponse"
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/TrackerListPage_UserMovieResponse_"
+                    }
+                  ],
                   "title": "Response Get User Movies V1 Users Me Movies Get"
                 }
               }
@@ -878,7 +989,7 @@
           "Movies"
         ],
         "summary": "Mark Movie",
-        "description": "Add a movie to the user's lists (idempotent \u2014 merges list membership).",
+        "description": "Add a movie to the user's lists (idempotent - merges list membership).",
         "operationId": "mark_movie_v1_users_me_movies__movie_id__post",
         "security": [
           {
@@ -1140,17 +1251,72 @@
         ],
         "summary": "Get All Games",
         "operationId": "get_all_games_v1_games_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "igdb",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Igdb"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 25,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
+                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/VideoGameSummary"
                   },
-                  "type": "array",
                   "title": "Response Get All Games V1 Games Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1163,15 +1329,20 @@
         ],
         "summary": "Create Game",
         "operationId": "create_game_v1_games_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/VideoGameCreate"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "201": {
@@ -1194,12 +1365,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
+        }
       }
     },
     "/v1/games/search": {
@@ -1469,6 +1635,55 @@
               "title": "Offset"
             },
             "description": "Entries to skip"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "pattern": "^-?(rank|title|completed_at)$"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Order by rank, title, or completed_at; prefix with - for descending",
+              "title": "Sort"
+            },
+            "description": "Order by rank, title, or completed_at; prefix with - for descending"
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Case-insensitive substring match against the title",
+              "title": "Search"
+            },
+            "description": "Case-insensitive substring match against the title"
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Return an {items, total, limit, offset} envelope instead of the legacy array response",
+              "default": false,
+              "title": "Include Total"
+            },
+            "description": "Return an {items, total, limit, offset} envelope instead of the legacy array response"
           }
         ],
         "responses": {
@@ -1477,10 +1692,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/UserVideoGameResponse"
-                  },
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/UserVideoGameResponse"
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/TrackerListPage_UserVideoGameResponse_"
+                    }
+                  ],
                   "title": "Response Get User Games V1 Users Me Games Get"
                 }
               }
@@ -1602,7 +1824,7 @@
           "Video Games"
         ],
         "summary": "Mark Game",
-        "description": "Add a game to the user's lists (idempotent \u2014 merges list membership).",
+        "description": "Add a game to the user's lists (idempotent - merges list membership).",
         "operationId": "mark_game_v1_users_me_games__game_id__post",
         "security": [
           {
@@ -1813,17 +2035,88 @@
         ],
         "summary": "Get All Books",
         "operationId": "get_all_books_v1_books_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "googleid",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Googleid"
+            }
+          },
+          {
+            "name": "isbn",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Isbn"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 25,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
+                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/BookSummary"
                   },
-                  "type": "array",
                   "title": "Response Get All Books V1 Books Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1836,15 +2129,20 @@
         ],
         "summary": "Create Book",
         "operationId": "create_book_v1_books_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/BookCreate"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "201": {
@@ -1867,12 +2165,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
+        }
       }
     },
     "/v1/books/search": {
@@ -2142,6 +2435,55 @@
               "title": "Offset"
             },
             "description": "Entries to skip"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "pattern": "^-?(rank|title|completed_at)$"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Order by rank, title, or completed_at; prefix with - for descending",
+              "title": "Sort"
+            },
+            "description": "Order by rank, title, or completed_at; prefix with - for descending"
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Case-insensitive substring match against the title",
+              "title": "Search"
+            },
+            "description": "Case-insensitive substring match against the title"
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Return an {items, total, limit, offset} envelope instead of the legacy array response",
+              "default": false,
+              "title": "Include Total"
+            },
+            "description": "Return an {items, total, limit, offset} envelope instead of the legacy array response"
           }
         ],
         "responses": {
@@ -2150,10 +2492,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/UserBookResponse"
-                  },
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/UserBookResponse"
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/TrackerListPage_UserBookResponse_"
+                    }
+                  ],
                   "title": "Response Get User Books V1 Users Me Books Get"
                 }
               }
@@ -2275,7 +2624,7 @@
           "Books"
         ],
         "summary": "Mark Book",
-        "description": "Add a book to the user's lists (idempotent \u2014 merges list membership).",
+        "description": "Add a book to the user's lists (idempotent - merges list membership).",
         "operationId": "mark_book_v1_users_me_books__book_id__post",
         "security": [
           {
@@ -2486,17 +2835,88 @@
         ],
         "summary": "Get All Tv Shows",
         "operationId": "get_all_tv_shows_v1_tv_shows_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "tvmaze",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tvmaze"
+            }
+          },
+          {
+            "name": "imdb",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Imdb"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 25,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
+                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/TVShowSummary"
                   },
-                  "type": "array",
                   "title": "Response Get All Tv Shows V1 Tv Shows Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -2509,15 +2929,20 @@
         ],
         "summary": "Create Tv Show",
         "operationId": "create_tv_show_v1_tv_shows_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/TVShowCreate"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "201": {
@@ -2540,12 +2965,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
+        }
       }
     },
     "/v1/tv-shows/search": {
@@ -2805,6 +3225,11 @@
         ],
         "summary": "Get All Episodes",
         "operationId": "get_all_episodes_v1_tv_shows__show_id__episodes_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "show_id",
@@ -3121,6 +3546,55 @@
               "title": "Offset"
             },
             "description": "Entries to skip"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "pattern": "^-?(rank|title|completed_at)$"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Order by rank, title, or completed_at; prefix with - for descending",
+              "title": "Sort"
+            },
+            "description": "Order by rank, title, or completed_at; prefix with - for descending"
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Case-insensitive substring match against the title",
+              "title": "Search"
+            },
+            "description": "Case-insensitive substring match against the title"
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Return an {items, total, limit, offset} envelope instead of the legacy array response",
+              "default": false,
+              "title": "Include Total"
+            },
+            "description": "Return an {items, total, limit, offset} envelope instead of the legacy array response"
           }
         ],
         "responses": {
@@ -3129,10 +3603,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/UserTVShowWithStatus"
-                  },
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/UserTVShowWithStatus"
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/TrackerListPage_UserTVShowWithStatus_"
+                    }
+                  ],
                   "title": "Response Get User Tv Shows V1 Users Me Tv Shows Get"
                 }
               }
@@ -3157,7 +3638,7 @@
           "TV"
         ],
         "summary": "Get Schedule",
-        "description": "What to watch: unwatched episodes airing within +/- ``window_days`` of\ntoday, everything overdue and unwatched (catch-up), and shows the user\nhas frozen (paused tracking on, so they're excluded from both).",
+        "description": "What to watch: unwatched episodes airing within +/- ``window_days`` of\ntoday, everything overdue and unwatched (catch-up), and shows the user\nhas frozen (paused tracking on, so they're excluded from both).\n\n\"Today\" is the caller's own calendar day (their ``time_zone``\npreference, falling back to the deployment's ``TIME_ZONE``), so the\nwindow turns over at their midnight rather than the server's.",
         "operationId": "get_schedule_v1_users_me_schedule_get",
         "security": [
           {
@@ -3303,7 +3784,7 @@
           "TV"
         ],
         "summary": "Mark Tv Show",
-        "description": "Add a show to the user's lists (idempotent \u2014 merges list membership).",
+        "description": "Add a show to the user's lists (idempotent - merges list membership).",
         "operationId": "mark_tv_show_v1_users_me_tv_shows__show_id__post",
         "security": [
           {
@@ -3868,6 +4349,74 @@
         }
       }
     },
+    "/v1/users/me/feed": {
+      "get": {
+        "tags": [
+          "Activity"
+        ],
+        "summary": "Get Social Activity",
+        "description": "Recent ranking and watchlist activity from friends and followed users.\n\nRelationships and the owner's current sharing tiers are joined into each\nshelf query. Nothing about visibility is copied onto a tracker row, so an\nunfriend, unfollow, opt-out, or tier reduction takes effect on old entries\nimmediately. Keyset paging avoids an increasingly expensive offset scan\nas a caller moves deeper into the feed.",
+        "operationId": "get_social_activity_v1_users_me_feed_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 256
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SocialActivityPage"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/users/me/bored": {
       "get": {
         "tags": [
@@ -4131,6 +4680,53 @@
         }
       }
     },
+    "/v1/search/users": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Search Users Route",
+        "operationId": "search_users_route_v1_search_users_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Q"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutUserSearchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/users/me/api-keys": {
       "get": {
         "tags": [
@@ -4165,7 +4761,7 @@
           "API keys"
         ],
         "summary": "Create Api Key",
-        "description": "Mint a new key. The plaintext secret is in this response and nowhere\nelse \u2014 it is never stored or shown again.",
+        "description": "Mint a new key. The plaintext secret is in this response and nowhere\nelse - it is never stored or shown again.",
         "operationId": "create_api_key_v1_users_me_api_keys_post",
         "requestBody": {
           "content": {
@@ -4212,7 +4808,7 @@
           "API keys"
         ],
         "summary": "Revoke Api Key",
-        "description": "Revocation is deletion \u2014 the hash is gone, the key can never auth again.",
+        "description": "Revocation is deletion - the hash is gone, the key can never auth again.",
         "operationId": "revoke_api_key_v1_users_me_api_keys__key_id__delete",
         "security": [
           {
@@ -4253,7 +4849,7 @@
           "Export"
         ],
         "summary": "Export Json",
-        "description": "Full-fidelity JSON export of every domain, using the same schemas the\nAPI serves \u2014 anything the UI can show is in here.",
+        "description": "Full-fidelity JSON export of every domain, using the same schemas the\nAPI serves - anything the UI can show is in here.",
         "operationId": "export_json_v1_users_me_export_get",
         "responses": {
           "200": {
@@ -4318,13 +4914,100 @@
         }
       }
     },
+    "/v1/users/me/import/movies/template.csv": {
+      "get": {
+        "tags": [
+          "Import"
+        ],
+        "summary": "Download Movie Csv Template",
+        "description": "Download the movies CSV template.\n\nRequired columns are ``title`` (text, max 255 characters),\n``release_year`` (YYYY), ``tmdb_id`` (positive integer), and\n``watched_date`` (YYYY-MM-DD, not in the future). Every field is required;\ntitle and release year must agree with the referenced TMDB movie. Uploads\nare limited to 5 MiB and 5,000 movie rows.",
+        "operationId": "download_movie_csv_template_v1_users_me_import_movies_template_csv_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/v1/users/me/import/movies/template.xlsx": {
+      "get": {
+        "tags": [
+          "Import"
+        ],
+        "summary": "Download Movie Xlsx Template",
+        "description": "Download the movies XLSX template.\n\nThe Movies sheet has the required upload columns. The Instructions sheet\ndocuments accepted formats, examples, TMDB matching rules, and row limits.",
+        "operationId": "download_movie_xlsx_template_v1_users_me_import_movies_template_xlsx_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/v1/users/me/import/movies": {
+      "post": {
+        "tags": [
+          "Import"
+        ],
+        "summary": "Import Movies",
+        "description": "Validate and atomically import a filled movies CSV or XLSX template.\n\nValidation checks the required columns and values, rejects duplicate TMDB\nIDs, resolves each reference against the local catalog or TMDB, and checks\nthat title and release year identify the same movie. A 422 returns every\nfield error with its source row and performs no writes.\n\nA valid file commits once and returns one outcome per row: ``imported``\nfor a new history tracker, ``matched`` when an existing tracker was\npromoted or completed, and ``skipped`` when it was already present.\nRe-importing the same file is therefore safe and creates no duplicates.",
+        "operationId": "import_movies_v1_users_me_import_movies_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_import_movies_v1_users_me_import_movies_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MovieImportResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The complete per-row validation report; no rows were written.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MovieImportResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
     "/v1/users/me/import/goodreads": {
       "post": {
         "tags": [
           "Import"
         ],
         "summary": "Import Goodreads",
-        "description": "Upload the standard Goodreads library export CSV. Idempotent \u2014 re-running\nthe same file updates rather than duplicates. Returns counts plus any\nskipped rows with reasons (nothing is dropped silently).",
+        "description": "Upload the standard Goodreads library export CSV. Idempotent - re-running\nthe same file updates rather than duplicates. Returns counts plus any\nskipped rows with reasons (nothing is dropped silently).",
         "operationId": "import_goodreads_v1_users_me_import_goodreads_post",
         "requestBody": {
           "content": {
@@ -4393,7 +5076,7 @@
           "Visibility"
         ],
         "summary": "Update Visibility",
-        "description": "Update the handle and/or any of the nine visibility tiers.\n\nOnly fields present in the body change. The result has to satisfy both\ninvariants \u2014 a handle for anything non-private, and a profile at least as\nopen as its most-open shelf \u2014 or the whole update is rejected. Both are\nchecked against the *resulting* state before anything is written, so a\nrejection leaves the row exactly as it was.",
+        "description": "Update the handle, activity sharing, and/or any of the nine visibility tiers.\n\nOnly fields present in the body change. The result has to satisfy both\ninvariants - a handle for anything non-private, and a profile at least as\nopen as its most-open shelf - or the whole update is rejected. Both are\nchecked against the *resulting* state before anything is written, so a\nrejection leaves the row exactly as it was.",
         "operationId": "update_visibility_v1_users_me_visibility_put",
         "requestBody": {
           "content": {
@@ -4440,7 +5123,7 @@
           "Visibility"
         ],
         "summary": "Public Profile",
-        "description": "Read-only profile: ranked lists of the categories the owner has opted in,\nbest first, filtered to what *this* caller may see.\n\nAuthentication is optional (#277). Anonymous callers and signed-in\nstrangers get ``public`` and nothing else; an accepted friend also gets\n``friends``; the owner gets everything of their own \u2014 including private\nshelves, and so never a 404 on their own handle \u2014 which is why the\nresponse carries ``viewer.relationship``: a client rendering this page has\nto be able to say *whose* view it is showing. ``viewer.following`` (#276)\nrides alongside it for the same reason \u2014 whether to render a Follow or\nFollowing button \u2014 and is computed only *after* every access decision\nabove has already been made: following is never part of the ceiling a\ncaller is served, only a fact about the payload once that's settled.\n\n**One ceiling, resolved once.** The caller's relationship is turned into a\nsingle tier ceiling before any shelf is read, and every shelf \u2014 ranked\nlist and watchlist alike \u2014 is then compared against that one value. The\nalternative, asking \"is this viewer a friend?\" per shelf, is what lets two\nshelves end up evaluated under different assumptions.\n\n**Nothing visible is indistinguishable from nothing there.** An unknown\nhandle, a profile whose tier is above this caller, and a profile with no\nshelf this caller may see all raise the *same* exception object: same\nstatus, same body, same headers. Since visibility is now\nviewer-dependent, so is the 404 \u2014 a profile a friend can see 404s for\neverybody else exactly as a handle nobody ever claimed does.",
+        "description": "Read-only profile: ranked lists of the categories the owner has opted in,\nbest first, filtered to what *this* caller may see.\n\nAuthentication is optional (#277). Anonymous callers and signed-in\nstrangers get ``public`` and nothing else; an accepted friend also gets\n``friends``; the owner gets everything of their own - including private\nshelves, and so never a 404 on their own handle - which is why the\nresponse carries ``viewer.relationship``: a client rendering this page has\nto be able to say *whose* view it is showing. ``viewer.following`` (#276)\nand ``viewer.friend_request_state`` (#357) ride alongside it for the same\nreason - whether to render a Follow, Following, Add friend, or Request\nsent button - and are computed only *after* every access decision above\nhas already been made. Neither affects the ceiling a caller is served;\nthey are facts about the payload once that is settled.\n\n**One ceiling, resolved once.** The caller's relationship is turned into a\nsingle tier ceiling before any shelf is read, and every shelf - ranked\nlist and watchlist alike - is then compared against that one value. The\nalternative, asking \"is this viewer a friend?\" per shelf, is what lets two\nshelves end up evaluated under different assumptions.\n\n**Nothing visible is indistinguishable from nothing there.** An unknown\nhandle, a profile whose tier is above this caller, and a profile with no\nshelf this caller may see all raise the *same* exception object: same\nstatus, same body, same headers. Since visibility is now\nviewer-dependent, so is the 404 - a profile a friend can see 404s for\neverybody else exactly as a handle nobody ever claimed does. A named\n``shelf`` that doesn't exist, or that this ceiling doesn't admit, folds\ninto the same 404 rather than a distinct error - see #279.\n\n**Depth is viewer-controlled, not owner-controlled** (#279): the owner\npicks a tier, the viewer picks how much of an admitted shelf to read.\n``limit`` clamps to ``MAX_PUBLIC_SHELF_LIMIT`` rather than erroring - a\nshared link has to survive a hand-edited or scraped query string - and\nonly applies once a single ``shelf`` is named; the multi-shelf hub view\nalways gets the small preview size for every shelf.",
         "operationId": "public_profile_v1_public__handle__get",
         "security": [
           {
@@ -4457,10 +5140,180 @@
               "type": "string",
               "title": "Handle"
             }
+          },
+          {
+            "name": "shelf",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Shelf"
+            }
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ranked",
+                "watchlist"
+              ],
+              "type": "string",
+              "default": "ranked",
+              "title": "Kind"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 25,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
           }
         ],
         "responses": {
           "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/users/me/comparison/{handle}": {
+      "get": {
+        "tags": [
+          "Comparison"
+        ],
+        "summary": "Compare With User",
+        "description": "Return the four domain comparisons visible to this viewer.",
+        "operationId": "compare_with_user_v1_users_me_comparison__handle__get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "handle",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Handle"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/users/me/comparison/{handle}/{category}/{item_id}": {
+      "post": {
+        "tags": [
+          "Comparison"
+        ],
+        "summary": "Save Recommendation",
+        "description": "Save a visible ranked recommendation and retain its first source.",
+        "operationId": "save_recommendation_v1_users_me_comparison__handle___category___item_id__post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "handle",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Handle"
+            }
+          },
+          {
+            "name": "category",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Category"
+            }
+          },
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Item Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SaveRecommendation"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
             "description": "Successful Response",
             "content": {
               "application/json": {
@@ -4511,7 +5364,7 @@
           "Friends"
         ],
         "summary": "Send Friend Request",
-        "description": "Send a friend request to an exact handle.\n\nAlways 202 unless the caller is already a party to the relationship (or\nis the target) \u2014 see the module docstring for why the shape of the\nnon-answers matters as much as the answer.",
+        "description": "Send a friend request to an exact handle.\n\nAlways 202 unless the caller is already a party to the relationship (or\nis the target) - see the module docstring for why the shape of the\nnon-answers matters as much as the answer.",
         "operationId": "send_friend_request_v1_users_me_friends_requests_post",
         "requestBody": {
           "content": {
@@ -4725,7 +5578,7 @@
           "Friends"
         ],
         "summary": "Unfriend",
-        "description": "End a friendship. Symmetric: either side may do this, and one row going\naway ends it for both \u2014 there is no second row to leave behind.",
+        "description": "End a friendship. Symmetric: either side may do this, and one row going\naway ends it for both - there is no second row to leave behind.",
         "operationId": "unfriend_v1_users_me_friends__friendship_id__delete",
         "security": [
           {
@@ -4812,7 +5665,7 @@
           "Follows"
         ],
         "summary": "Unfollow User",
-        "description": "Stop following someone.\n\nDeliberately does not require the target to still be public \u2014 a follow\npersists through a followee tightening their profile (that's the whole\npoint of #276's \"grants nothing, persists anyway\" rule), and the follower\nmust still be able to unfollow after that happens.",
+        "description": "Stop following someone.\n\nDeliberately does not require the target to still be public - a follow\npersists through a followee tightening their profile (that's the whole\npoint of #276's \"grants nothing, persists anyway\" rule), and the follower\nmust still be able to unfollow after that happens.",
         "operationId": "unfollow_user_v1_users_me_following__handle__delete",
         "security": [
           {
@@ -4909,6 +5762,76 @@
         ]
       }
     },
+    "/v1/users/me/preferences": {
+      "get": {
+        "tags": [
+          "Preferences"
+        ],
+        "summary": "Get Preferences",
+        "operationId": "get_preferences_v1_users_me_preferences_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutPreferences"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Preferences"
+        ],
+        "summary": "Update Preferences",
+        "operationId": "update_preferences_v1_users_me_preferences_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InPreferencesUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutPreferences"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
     "/v1/users/me/summary": {
       "get": {
         "tags": [
@@ -4962,6 +5885,236 @@
         }
       }
     },
+    "/v1/admin/users": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Search Users",
+        "description": "Search the directory by display name, handle, or email; paginated.",
+        "operationId": "search_users_v1_admin_users_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutAdminUserListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/users/{uuid}": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Get User Detail",
+        "description": "Per-user aggregates: tracked counts, visibility tiers, social counts.",
+        "operationId": "get_user_detail_v1_admin_users__uuid__get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutAdminUserDetail"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/audit": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "List Audit",
+        "description": "The audit trail itself: every admin action, allowed or denied.",
+        "operationId": "list_audit_v1_admin_audit_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
+          },
+          {
+            "name": "actor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Actor"
+            }
+          },
+          {
+            "name": "target",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Target"
+            }
+          },
+          {
+            "name": "action",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Action"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutAdminAuditResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/": {
       "get": {
         "tags": [
@@ -4987,6 +6140,42 @@
   },
   "components": {
     "schemas": {
+      "ActivityActor": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Handle"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "title": "ActivityActor",
+        "description": "The person whose tracker change produced a social-feed event."
+      },
       "ActivityItem": {
         "properties": {
           "category": {
@@ -5128,6 +6317,20 @@
           "file"
         ],
         "title": "Body_import_goodreads_v1_users_me_import_goodreads_post"
+      },
+      "Body_import_movies_v1_users_me_import_movies_post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "contentMediaType": "application/octet-stream",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_import_movies_v1_users_me_import_movies_post"
       },
       "BookCreate": {
         "properties": {
@@ -5593,7 +6796,7 @@
           "title"
         ],
         "title": "BookSummary",
-        "description": "Lightweight book for list responses \u2014 omits the large ``description``."
+        "description": "Lightweight book for list responses - omits the large ``description``."
       },
       "BookUpdate": {
         "properties": {
@@ -6008,6 +7211,73 @@
         "title": "InFriendRequest",
         "description": "Request body for sending a friend request (#275).\n\nA handle and nothing else: there is no endpoint that lists or searches\nusers, so an exact handle someone told you is the only way to reach them."
       },
+      "InPreferencesUpdate": {
+        "properties": {
+          "ranked_list_length": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RankedListLength"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "onboarding_completed": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Onboarding Completed"
+          },
+          "time_zone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Time Zone"
+          },
+          "shelf_order": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shelf Order"
+          },
+          "enabled_shelves": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Enabled Shelves"
+          }
+        },
+        "type": "object",
+        "title": "InPreferencesUpdate",
+        "description": "Request body for display preferences (#122). Only sent fields change."
+      },
       "InRefreshToken": {
         "properties": {
           "refresh_token": {
@@ -6059,6 +7329,16 @@
               }
             ],
             "title": "Handle"
+          },
+          "default_privacy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VisibilityTier"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "visibility_profile": {
             "anyOf": [
@@ -6149,11 +7429,22 @@
                 "type": "null"
               }
             ]
+          },
+          "share_activity": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Share Activity"
           }
         },
         "type": "object",
         "title": "InVisibilityUpdate",
-        "description": "Request body for visibility settings (#274). Every setting is a tier \u2014\n``private``, ``friends`` or ``public`` \u2014 not a boolean.\n\nOnly sent fields change; a null handle clears it (allowed only while\neverything is private). An unsent field and an explicit null are both\nleft alone, so a client can PUT one radio button without echoing the\nother eight."
+        "description": "Request body for visibility settings (#274) and activity sharing (#280).\nEvery shelf setting is a ``private``, ``friends`` or ``public`` tier;\n``share_activity`` is the independent whole-feed opt-out.\n\nOnly sent fields change; a null handle clears it (allowed only while\neverything is private). A null shelf tier clears its override and resumes\nusing ``default_privacy``; an omitted field is left alone."
       },
       "MovieCreate": {
         "properties": {
@@ -6322,6 +7613,148 @@
           "title"
         ],
         "title": "MovieCreate"
+      },
+      "MovieImportErrorResponse": {
+        "properties": {
+          "row": {
+            "type": "integer",
+            "title": "Row"
+          },
+          "column": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Column"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "type": "object",
+        "required": [
+          "row",
+          "message"
+        ],
+        "title": "MovieImportErrorResponse",
+        "description": "One field-level template validation error."
+      },
+      "MovieImportResponse": {
+        "properties": {
+          "valid": {
+            "type": "boolean",
+            "title": "Valid"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/MovieImportSummaryResponse"
+          },
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/MovieImportRowResponse"
+            },
+            "type": "array",
+            "title": "Rows"
+          },
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/MovieImportErrorResponse"
+            },
+            "type": "array",
+            "title": "Errors"
+          }
+        },
+        "type": "object",
+        "required": [
+          "valid"
+        ],
+        "title": "MovieImportResponse",
+        "description": "Validation failure or per-row outcome report for a movie import."
+      },
+      "MovieImportRowResponse": {
+        "properties": {
+          "row": {
+            "type": "integer",
+            "title": "Row"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "imported",
+              "matched",
+              "skipped"
+            ],
+            "title": "Status"
+          },
+          "tmdb_id": {
+            "type": "integer",
+            "title": "Tmdb Id"
+          },
+          "movie_id": {
+            "type": "string",
+            "title": "Movie Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "catalog_created": {
+            "type": "boolean",
+            "title": "Catalog Created"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "row",
+          "status",
+          "tmdb_id",
+          "movie_id",
+          "title",
+          "catalog_created",
+          "message"
+        ],
+        "title": "MovieImportRowResponse",
+        "description": "Outcome for one row after a successful atomic import."
+      },
+      "MovieImportSummaryResponse": {
+        "properties": {
+          "imported": {
+            "type": "integer",
+            "title": "Imported",
+            "default": 0
+          },
+          "matched": {
+            "type": "integer",
+            "title": "Matched",
+            "default": 0
+          },
+          "skipped": {
+            "type": "integer",
+            "title": "Skipped",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "title": "MovieImportSummaryResponse"
       },
       "MovieResponse": {
         "properties": {
@@ -6540,6 +7973,17 @@
             ],
             "title": "Year"
           },
+          "release_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Release Date"
+          },
           "poster_url": {
             "anyOf": [
               {
@@ -6742,7 +8186,7 @@
           "title"
         ],
         "title": "MovieSummary",
-        "description": "Lightweight movie for list responses \u2014 omits the large ``plot`` field."
+        "description": "Lightweight movie for list responses - omits the large ``plot`` field."
       },
       "MovieUpdate": {
         "properties": {
@@ -6983,6 +8427,548 @@
         ],
         "title": "NotificationResponse"
       },
+      "OutAdminAuditActor": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Handle"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          }
+        },
+        "type": "object",
+        "title": "OutAdminAuditActor",
+        "description": "Who performed one audit-logged action.\n\n``id`` is optional, not just ``handle``/``email``: the actor's account\ncan be deleted (self-delete is permitted), which SETs ``actor_user_pk``\nNULL - the row falls back to whatever of ``actor_user_id``/\n``actor_email`` was denormalized at write time, and either can be\nmissing if the actor could not be resolved at all (an expired-token\ndenial, for instance)."
+      },
+      "OutAdminAuditEvent": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "actor": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutAdminAuditActor"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "target": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutAdminAuditTarget"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "action": {
+            "type": "string",
+            "title": "Action"
+          },
+          "result": {
+            "type": "string",
+            "title": "Result"
+          },
+          "detail": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail"
+          },
+          "request_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Request Id"
+          },
+          "method": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Method"
+          },
+          "path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Path"
+          },
+          "status_code": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Code"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "created_at",
+          "action",
+          "result"
+        ],
+        "title": "OutAdminAuditEvent",
+        "description": "One row of ``GET /v1/admin/audit``."
+      },
+      "OutAdminAuditResponse": {
+        "properties": {
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          },
+          "events": {
+            "items": {
+              "$ref": "#/components/schemas/OutAdminAuditEvent"
+            },
+            "type": "array",
+            "title": "Events"
+          }
+        },
+        "type": "object",
+        "required": [
+          "total",
+          "limit",
+          "offset",
+          "events"
+        ],
+        "title": "OutAdminAuditResponse",
+        "description": "``GET /v1/admin/audit``."
+      },
+      "OutAdminAuditTarget": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Handle"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          }
+        },
+        "type": "object",
+        "title": "OutAdminAuditTarget",
+        "description": "Who one audit-logged action was about, if anyone."
+      },
+      "OutAdminDomainCounts": {
+        "properties": {
+          "ranked": {
+            "type": "integer",
+            "title": "Ranked"
+          },
+          "watchlist": {
+            "type": "integer",
+            "title": "Watchlist"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ranked",
+          "watchlist",
+          "total"
+        ],
+        "title": "OutAdminDomainCounts",
+        "description": "Ranked/watchlist/total for one tracked domain."
+      },
+      "OutAdminSocialCounts": {
+        "properties": {
+          "friends": {
+            "type": "integer",
+            "title": "Friends"
+          },
+          "followers": {
+            "type": "integer",
+            "title": "Followers"
+          },
+          "following": {
+            "type": "integer",
+            "title": "Following"
+          }
+        },
+        "type": "object",
+        "required": [
+          "friends",
+          "followers",
+          "following"
+        ],
+        "title": "OutAdminSocialCounts",
+        "description": "Friend-graph size for one user."
+      },
+      "OutAdminUserDetail": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Handle"
+          },
+          "display_name": {
+            "type": "string",
+            "title": "Display Name"
+          },
+          "email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "user_group": {
+            "type": "string",
+            "title": "User Group"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "last_tracked_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Tracked At"
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/OutAdminVisibility"
+          },
+          "domains": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/OutAdminDomainCounts"
+            },
+            "type": "object",
+            "title": "Domains"
+          },
+          "social": {
+            "$ref": "#/components/schemas/OutAdminSocialCounts"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "display_name",
+          "email",
+          "user_group",
+          "status",
+          "created_at",
+          "visibility",
+          "domains",
+          "social"
+        ],
+        "title": "OutAdminUserDetail",
+        "description": "``GET /v1/admin/users/{uuid}``."
+      },
+      "OutAdminUserListResponse": {
+        "properties": {
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          },
+          "users": {
+            "items": {
+              "$ref": "#/components/schemas/OutAdminUserSummary"
+            },
+            "type": "array",
+            "title": "Users"
+          }
+        },
+        "type": "object",
+        "required": [
+          "total",
+          "limit",
+          "offset",
+          "users"
+        ],
+        "title": "OutAdminUserListResponse",
+        "description": "``GET /v1/admin/users``."
+      },
+      "OutAdminUserSummary": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Handle"
+          },
+          "display_name": {
+            "type": "string",
+            "title": "Display Name"
+          },
+          "email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "user_group": {
+            "type": "string",
+            "title": "User Group"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "last_tracked_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Tracked At"
+          },
+          "tracked_total": {
+            "type": "integer",
+            "title": "Tracked Total"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "display_name",
+          "email",
+          "user_group",
+          "status",
+          "created_at",
+          "tracked_total"
+        ],
+        "title": "OutAdminUserSummary",
+        "description": "One row of ``GET /v1/admin/users``."
+      },
+      "OutAdminVisibility": {
+        "properties": {
+          "profile": {
+            "$ref": "#/components/schemas/VisibilityTier"
+          },
+          "default_privacy": {
+            "$ref": "#/components/schemas/VisibilityTier"
+          },
+          "movies": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VisibilityTier"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tv": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VisibilityTier"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "books": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VisibilityTier"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "games": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VisibilityTier"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "watchlist_movies": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VisibilityTier"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "watchlist_tv": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VisibilityTier"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "watchlist_books": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VisibilityTier"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "watchlist_games": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VisibilityTier"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "share_activity": {
+            "type": "boolean",
+            "title": "Share Activity"
+          }
+        },
+        "type": "object",
+        "required": [
+          "profile",
+          "default_privacy",
+          "share_activity"
+        ],
+        "title": "OutAdminVisibility",
+        "description": "The nine visibility settings, plus activity sharing, for one user."
+      },
       "OutApiKey": {
         "properties": {
           "id": {
@@ -7023,7 +9009,7 @@
           "created_at"
         ],
         "title": "OutApiKey",
-        "description": "An API key as shown in listings \u2014 never includes the secret."
+        "description": "An API key as shown in listings - never includes the secret."
       },
       "OutApiKeyCreated": {
         "properties": {
@@ -7168,7 +9154,7 @@
           "message"
         ],
         "title": "OutFriendAck",
-        "description": "Deliberately contentless acknowledgement of a friend-graph write.\n\nSend and decline both answer with this, and send answers with *exactly*\nthis whether or not the handle resolved to anybody \u2014 see\n``router_friends`` for why the response must not vary."
+        "description": "Deliberately contentless acknowledgement of a friend-graph write.\n\nSend and decline both answer with this, and send answers with *exactly*\nthis whether or not the handle resolved to anybody - see\n``router_friends`` for why the response must not vary."
       },
       "OutFriendRequest": {
         "properties": {
@@ -7228,7 +9214,7 @@
           "id"
         ],
         "title": "OutFriendUser",
-        "description": "The other party in a friendship, as much of them as a friend may see.\n\nNo email, no visibility settings \u2014 a friendship is not an introduction to\nsomeone's account."
+        "description": "The other party in a friendship, as much of them as a friend may see.\n\nNo email, no visibility settings - a friendship is not an introduction to\nsomeone's account."
       },
       "OutPendingFriendRequests": {
         "properties": {
@@ -7252,6 +9238,53 @@
         "type": "object",
         "title": "OutPendingFriendRequests",
         "description": "Both directions in one response.\n\nThe inbox badge and the \"pending\" state of an outgoing request are drawn\ntogether, so splitting these across two endpoints would only ever mean\ntwo calls."
+      },
+      "OutPreferences": {
+        "properties": {
+          "ranked_list_length": {
+            "$ref": "#/components/schemas/RankedListLength",
+            "default": "25"
+          },
+          "onboarding_completed": {
+            "type": "boolean",
+            "title": "Onboarding Completed",
+            "default": false
+          },
+          "time_zone": {
+            "type": "string",
+            "title": "Time Zone",
+            "default": "UTC"
+          },
+          "shelf_order": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Shelf Order",
+            "default": [
+              "movies",
+              "tv",
+              "games",
+              "books"
+            ]
+          },
+          "enabled_shelves": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Enabled Shelves",
+            "default": [
+              "movies",
+              "tv",
+              "games",
+              "books"
+            ]
+          }
+        },
+        "type": "object",
+        "title": "OutPreferences",
+        "description": "The caller's display preferences, defaulted where unset."
       },
       "OutResponseBaseModel": {
         "properties": {
@@ -7363,15 +9396,30 @@
           "total_ranked": {
             "type": "integer",
             "title": "Total Ranked"
+          },
+          "total_items": {
+            "type": "integer",
+            "title": "Total Items"
+          },
+          "onboarding_completed": {
+            "type": "boolean",
+            "title": "Onboarding Completed"
+          },
+          "needs_onboarding": {
+            "type": "boolean",
+            "title": "Needs Onboarding"
           }
         },
         "type": "object",
         "required": [
           "shelves",
-          "total_ranked"
+          "total_ranked",
+          "total_items",
+          "onboarding_completed",
+          "needs_onboarding"
         ],
         "title": "OutSummary",
-        "description": "Everything the home page renders, in one bounded response \u2014 see\napp/services/summary.py for why this endpoint exists."
+        "description": "Everything the home page renders, in one bounded response - see\napp/services/summary.py for why this endpoint exists."
       },
       "OutSummaryEntry": {
         "properties": {
@@ -7495,6 +9543,17 @@
           "email": {
             "type": "string",
             "title": "Email"
+          },
+          "time_zone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Time Zone"
           }
         },
         "type": "object",
@@ -7508,7 +9567,7 @@
           "email"
         ],
         "title": "OutToken",
-        "description": "What every sign-in and refresh returns.\n\nBoth lifetimes are reported in seconds so a client can size its cookies\noff the response instead of hardcoding guesses that drift from\n``ACCESS_TOKEN_EXPIRE_MINUTES`` and ``REFRESH_TOKEN_EXPIRE_DAYS`` \u2014 which\nis exactly how the web session cookie ended up outliving its token."
+        "description": "What every sign-in and refresh returns.\n\nBoth lifetimes are reported in seconds so a client can size its cookies\noff the response instead of hardcoding guesses that drift from\n``ACCESS_TOKEN_EXPIRE_MINUTES`` and ``REFRESH_TOKEN_EXPIRE_DAYS`` - which\nis exactly how the web session cookie ended up outliving its token."
       },
       "OutUserDisplay": {
         "properties": {
@@ -7552,6 +9611,80 @@
         "title": "OutUserDisplay",
         "description": "Schema for displaying user data."
       },
+      "OutUserSearchResponse": {
+        "properties": {
+          "query": {
+            "type": "string",
+            "title": "Query"
+          },
+          "corrected": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Corrected"
+          },
+          "users": {
+            "items": {
+              "$ref": "#/components/schemas/OutUserSearchResult"
+            },
+            "type": "array",
+            "title": "Users"
+          }
+        },
+        "type": "object",
+        "required": [
+          "query",
+          "users"
+        ],
+        "title": "OutUserSearchResponse",
+        "description": "Response shape for user search, mirroring GlobalSearchResponse."
+      },
+      "OutUserSearchResult": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "display_name": {
+            "type": "string",
+            "title": "Display Name"
+          },
+          "handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Handle"
+          },
+          "follower_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Follower Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "display_name"
+        ],
+        "title": "OutUserSearchResult",
+        "description": "One user returned from search."
+      },
       "OutVisibility": {
         "properties": {
           "handle": {
@@ -7565,46 +9698,103 @@
             ],
             "title": "Handle"
           },
+          "default_privacy": {
+            "$ref": "#/components/schemas/VisibilityTier",
+            "default": "friends"
+          },
           "visibility_profile": {
             "$ref": "#/components/schemas/VisibilityTier",
             "default": "private"
           },
           "visibility_movies": {
-            "$ref": "#/components/schemas/VisibilityTier",
-            "default": "private"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VisibilityTier"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "visibility_tv": {
-            "$ref": "#/components/schemas/VisibilityTier",
-            "default": "private"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VisibilityTier"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "visibility_books": {
-            "$ref": "#/components/schemas/VisibilityTier",
-            "default": "private"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VisibilityTier"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "visibility_games": {
-            "$ref": "#/components/schemas/VisibilityTier",
-            "default": "private"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VisibilityTier"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "visibility_watchlist_movies": {
-            "$ref": "#/components/schemas/VisibilityTier",
-            "default": "private"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VisibilityTier"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "visibility_watchlist_tv": {
-            "$ref": "#/components/schemas/VisibilityTier",
-            "default": "private"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VisibilityTier"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "visibility_watchlist_books": {
-            "$ref": "#/components/schemas/VisibilityTier",
-            "default": "private"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VisibilityTier"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "visibility_watchlist_games": {
-            "$ref": "#/components/schemas/VisibilityTier",
-            "default": "private"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VisibilityTier"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "share_activity": {
+            "type": "boolean",
+            "title": "Share Activity",
+            "default": true
           }
         },
         "type": "object",
         "title": "OutVisibility",
-        "description": "The caller's visibility settings, one tier per setting."
+        "description": "The caller's shelf tiers and activity-sharing setting."
       },
       "RankPlacement": {
         "properties": {
@@ -7620,6 +9810,17 @@
         ],
         "title": "RankPlacement",
         "description": "Target 1-based position at which to place a movie in the ranked list."
+      },
+      "RankedListLength": {
+        "type": "string",
+        "enum": [
+          "25",
+          "50",
+          "100",
+          "all"
+        ],
+        "title": "RankedListLength",
+        "description": "25/50/100/all. 25 is the default, applied whenever the column is NULL."
       },
       "RankingReorder": {
         "properties": {
@@ -7637,6 +9838,24 @@
         ],
         "title": "RankingReorder",
         "description": "Ordered list of movie (catalog) ids defining the new ranking order."
+      },
+      "SaveRecommendation": {
+        "properties": {
+          "destination": {
+            "type": "string",
+            "enum": [
+              "watchlist",
+              "rankings"
+            ],
+            "title": "Destination"
+          }
+        },
+        "type": "object",
+        "required": [
+          "destination"
+        ],
+        "title": "SaveRecommendation",
+        "description": "The destination list; ranking placement happens later in its normal UI."
       },
       "ScheduleEpisodeItem": {
         "properties": {
@@ -7751,6 +9970,107 @@
         ],
         "title": "ScheduleResponse",
         "description": "Mirrors the legacy schedule page: what's airing in the +/- window around\ntoday (``upcoming``), everything overdue and unwatched (``catch_up``),\nand shows the user has paused tracking on (``frozen_shows``)."
+      },
+      "SocialActivityItem": {
+        "properties": {
+          "category": {
+            "type": "string",
+            "title": "Category"
+          },
+          "action": {
+            "type": "string",
+            "title": "Action"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "subtitle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subtitle"
+          },
+          "entity_id": {
+            "type": "string",
+            "title": "Entity Id"
+          },
+          "poster_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Poster Url"
+          },
+          "rank": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rank"
+          },
+          "occurred_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Occurred At"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/ActivityActor"
+          }
+        },
+        "type": "object",
+        "required": [
+          "category",
+          "action",
+          "title",
+          "entity_id",
+          "occurred_at",
+          "actor"
+        ],
+        "title": "SocialActivityItem",
+        "description": "One authorized activity event from a friend or followed user."
+      },
+      "SocialActivityPage": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SocialActivityItem"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "SocialActivityPage",
+        "description": "One bounded keyset page of the caller's social activity feed."
       },
       "TVEpisodeCreate": {
         "properties": {
@@ -8495,7 +10815,7 @@
           "title"
         ],
         "title": "TVShowSummary",
-        "description": "Lightweight show for list responses \u2014 omits the large ``summary``."
+        "description": "Lightweight show for list responses - omits the large ``summary``."
       },
       "TVShowUpdate": {
         "properties": {
@@ -8646,6 +10966,130 @@
         },
         "type": "object",
         "title": "TVShowUpdate"
+      },
+      "TrackerListPage_UserBookResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/UserBookResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "TrackerListPage[UserBookResponse]"
+      },
+      "TrackerListPage_UserMovieResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/UserMovieResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "TrackerListPage[UserMovieResponse]"
+      },
+      "TrackerListPage_UserTVShowWithStatus_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/UserTVShowWithStatus"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "TrackerListPage[UserTVShowWithStatus]"
+      },
+      "TrackerListPage_UserVideoGameResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/UserVideoGameResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "TrackerListPage[UserVideoGameResponse]"
       },
       "UnreadCountResponse": {
         "properties": {
@@ -8820,6 +11264,17 @@
             "type": "string",
             "format": "date-time",
             "title": "Updated At"
+          },
+          "source_handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Handle"
           }
         },
         "type": "object",
@@ -9065,6 +11520,17 @@
             "type": "string",
             "format": "date-time",
             "title": "Updated At"
+          },
+          "source_handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Handle"
           }
         },
         "type": "object",
@@ -9409,6 +11875,17 @@
             "type": "string",
             "format": "date-time",
             "title": "Updated At"
+          },
+          "source_handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Handle"
           }
         },
         "type": "object",
@@ -9602,6 +12079,17 @@
             "type": "string",
             "format": "date-time",
             "title": "Updated At"
+          },
+          "source_handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Handle"
           },
           "watch_status": {
             "type": "string",
@@ -9811,6 +12299,17 @@
             "type": "string",
             "format": "date-time",
             "title": "Updated At"
+          },
+          "source_handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Handle"
           }
         },
         "type": "object",
@@ -10341,7 +12840,7 @@
           "title"
         ],
         "title": "VideoGameSummary",
-        "description": "Lightweight game for list responses \u2014 omits the large ``summary``."
+        "description": "Lightweight game for list responses - omits the large ``summary``."
       },
       "VideoGameUpdate": {
         "properties": {
@@ -10491,7 +12990,7 @@
           "public"
         ],
         "title": "VisibilityTier",
-        "description": "How widely one shelf \u2014 or the whole profile \u2014 is shared."
+        "description": "How widely one shelf - or the whole profile - is shared."
       },
       "WatchProvider": {
         "properties": {
@@ -10589,7 +13088,7 @@
           "attribution"
         ],
         "title": "WatchProviders",
-        "description": "Where a title can be watched in one region (web#26).\n\nNever 404s and never errors: a title with no availability \u2014 or one TMDB\ncan't resolve \u2014 comes back with empty buckets, so the detail page renders\nthe same either way. ``attribution`` carries the credit TMDB requires\nwherever this data is displayed."
+        "description": "Where a title can be watched in one region (web#26).\n\nNever 404s and never errors: a title with no availability - or one TMDB\ncan't resolve - comes back with empty buckets, so the detail page renders\nthe same either way. ``attribution`` carries the credit TMDB requires\nwherever this data is displayed."
       }
     },
     "securitySchemes": {
@@ -10647,7 +13146,7 @@
     },
     {
       "name": "Follows",
-      "description": "Asymmetric, unapproved follows \u2014 grants no extra visibility"
+      "description": "Asymmetric, unapproved follows - grants no extra visibility"
     },
     {
       "name": "Search",
@@ -10655,7 +13154,11 @@
     },
     {
       "name": "Summary",
-      "description": "Home summary \u2014 per-shelf Top 5 and counts"
+      "description": "Home summary - per-shelf Top 5 and counts"
+    },
+    {
+      "name": "Admin",
+      "description": "Admin-only user directory and audit trail"
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -5891,7 +5891,7 @@
           "Admin"
         ],
         "summary": "Search Users",
-        "description": "Search the directory by display name, handle, or email; paginated.",
+        "description": "Search the directory by display name, handle, or email; paginated.\n\nSorted and filtered in SQL, not on the page already fetched:\n``last_tracked``/``tracked_total`` are corpus-wide aggregates\n(:func:`_last_tracked_sort_expr`/:func:`_tracked_total_sort_expr`), so\nsorting only the returned page would answer \"who joined this week\" or\n\"show me the disabled accounts\" correctly for the visible rows and\nsilently wrong for everyone else.",
         "operationId": "search_users_v1_admin_users_get",
         "security": [
           {
@@ -5913,6 +5913,62 @@
                 }
               ],
               "title": "Q"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "active",
+                    "disabled"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "joined",
+                    "last_tracked",
+                    "tracked_total",
+                    "status"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Sort"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string",
+              "default": "desc",
+              "title": "Direction"
             }
           },
           {
@@ -6151,8 +6207,10 @@
                   "type": "null"
                 }
               ],
+              "description": "Match by handle, email, or id.",
               "title": "Actor"
-            }
+            },
+            "description": "Match by handle, email, or id."
           },
           {
             "name": "target",
@@ -6167,8 +6225,10 @@
                   "type": "null"
                 }
               ],
+              "description": "Match by handle, email, or id.",
               "title": "Target"
-            }
+            },
+            "description": "Match by handle, email, or id."
           },
           {
             "name": "action",
@@ -6212,6 +6272,31 @@
       }
     },
     "/v1/admin/impersonation": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "List Impersonation Sessions",
+        "description": "Every live (unended, unexpired) view-as session, across every admin -\nnot scoped to the caller.\n\nScoped admin-wide rather than to \"my own sessions\", the same choice\n``GET /v1/admin/audit`` already made: that endpoint shows the whole\ntrail, not just the caller's own rows, on the theory that an admin\naction is everyone's business on this surface, not just the acting\nadmin's. A forgotten or abandoned session is exactly the case this\nendpoint exists to catch, and it has to be visible - and endable, see\n:func:`stop_impersonation_session` below - to an admin other than the\none who started it.\n\nNever returns the bearer token itself: this is a status/oversight view,\nnot a way to acquire someone else's live credential.",
+        "operationId": "list_impersonation_sessions_v1_admin_impersonation_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutImpersonationSessionList"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
       "post": {
         "tags": [
           "Admin"
@@ -6279,6 +6364,52 @@
             "OAuth2PasswordBearer": []
           }
         ]
+      }
+    },
+    "/v1/admin/impersonation/{session_id}": {
+      "delete": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Stop Impersonation Session",
+        "description": "End one specific live view-as session by id, whichever admin started\nit - the console-oversight counterpart to :func:`list_impersonation_\nsessions` above: a listing nobody could act on would not be much of a\nrevoke capability. ``DELETE /v1/admin/impersonation`` (no id) still\nends every session the CALLER owns, for the web's existing \"back to\nadmin\" flow; this is for ending someone else's, or one of several of\nyour own, without taking down the rest.\n\nIdempotent: an unknown, already-ended, or already-expired session id is\na 200 with ``{\"ended\": 0}``, not an error - the caller asked for that\nsession to be gone, and it is, one way or another.",
+        "operationId": "stop_impersonation_session_v1_admin_impersonation__session_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/": {
@@ -9418,6 +9549,38 @@
         "title": "OutFriendUser",
         "description": "The other party in a friendship, as much of them as a friend may see.\n\nNo email, no visibility settings - a friendship is not an introduction to\nsomeone's account."
       },
+      "OutImpersonationLiveSession": {
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "title": "Session Id"
+          },
+          "acting_admin": {
+            "$ref": "#/components/schemas/OutImpersonationParty"
+          },
+          "target": {
+            "$ref": "#/components/schemas/OutImpersonationParty"
+          },
+          "started_at": {
+            "type": "string",
+            "title": "Started At"
+          },
+          "expires_at": {
+            "type": "string",
+            "title": "Expires At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "session_id",
+          "acting_admin",
+          "target",
+          "started_at",
+          "expires_at"
+        ],
+        "title": "OutImpersonationLiveSession",
+        "description": "One row of ``GET /v1/admin/impersonation``. Never carries the token."
+      },
       "OutImpersonationParty": {
         "properties": {
           "id": {
@@ -9496,6 +9659,23 @@
         ],
         "title": "OutImpersonationSession",
         "description": "``POST /v1/admin/impersonation``."
+      },
+      "OutImpersonationSessionList": {
+        "properties": {
+          "sessions": {
+            "items": {
+              "$ref": "#/components/schemas/OutImpersonationLiveSession"
+            },
+            "type": "array",
+            "title": "Sessions"
+          }
+        },
+        "type": "object",
+        "required": [
+          "sessions"
+        ],
+        "title": "OutImpersonationSessionList",
+        "description": "``GET /v1/admin/impersonation``."
       },
       "OutPendingFriendRequests": {
         "properties": {

--- a/openapi.json
+++ b/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "druthers.io API local",
+    "title": "druthers.io API dev",
     "description": "API for druthers.io - track and rank the movies, TV, books, and games you actually care about.",
     "contact": {
       "name": "Druthers",
@@ -156,7 +156,7 @@
           "authentication"
         ],
         "summary": "Logout",
-        "description": "Sign out server-side: the refresh token and its family stop working.\n\nDeliberately 204 whether or not the token was recognised - sign-out must\nnot depend on the client still holding a valid credential, and the status\nshouldn't reveal whether a guessed token existed.",
+        "description": "Sign out server-side: the refresh token and its family stop working.\n\nDeliberately 204 whether or not the token was recognised - sign-out must\nnot depend on the client still holding a valid credential, and the status\nshouldn't reveal whether a guessed token existed.\n\nSigning out also ends any view-as session the owner of that refresh token\nis running (#341). Otherwise an admin could sign out believing they had\nclosed everything down while a live impersonation token kept working\nuntil its own expiry.",
         "operationId": "logout_v1_auth_logout_post",
         "requestBody": {
           "content": {
@@ -6211,6 +6211,76 @@
         }
       }
     },
+    "/v1/admin/impersonation": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Start Impersonation",
+        "description": "Begin a read-only view-as session (#341).\n\nRead-only is a blanket denial with no override: the \"act on their behalf\"\ncriterion was cut from #341 on 2026-08-18, so there is no per-action flag\nto build. Enforcement lives in the auth resolver, not here, so a route\nadded later cannot opt out of it.\n\nImpersonating a DISABLED account is allowed on purpose. \"Why can't I sign\nin\" is exactly the question this tool exists to answer, and the write\nblock already covers the risk.",
+        "operationId": "start_impersonation_v1_admin_impersonation_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InImpersonationStart"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutImpersonationSession"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Stop Impersonation",
+        "description": "End every live view-as session this admin owns. Idempotent.\n\nReached with the admin's OWN token, not the impersonation one: the\nimpersonation credential cannot call this, because every ``/v1/admin/*``\nroute is behind ``require_admin`` and the swapped identity is not an\nadmin. The web client keeps the admin session in a separate cookie for\nexactly this reason, so \"Back to admin\" is one call plus a cookie delete.",
+        "operationId": "stop_impersonation_v1_admin_impersonation_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
     "/": {
       "get": {
         "tags": [
@@ -7306,6 +7376,31 @@
         ],
         "title": "InFriendRequest",
         "description": "Request body for sending a friend request (#275).\n\nA handle and nothing else: there is no endpoint that lists or searches\nusers, so an exact handle someone told you is the only way to reach them."
+      },
+      "InImpersonationStart": {
+        "properties": {
+          "target_uuid": {
+            "type": "string",
+            "title": "Target Uuid"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          }
+        },
+        "type": "object",
+        "required": [
+          "target_uuid"
+        ],
+        "title": "InImpersonationStart",
+        "description": "``POST /v1/admin/impersonation`` request."
       },
       "InPreferencesUpdate": {
         "properties": {
@@ -9322,6 +9417,85 @@
         ],
         "title": "OutFriendUser",
         "description": "The other party in a friendship, as much of them as a friend may see.\n\nNo email, no visibility settings - a friendship is not an introduction to\nsomeone's account."
+      },
+      "OutImpersonationParty": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Handle"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "title": "OutImpersonationParty",
+        "description": "Either side of a view-as session."
+      },
+      "OutImpersonationSession": {
+        "properties": {
+          "token": {
+            "type": "string",
+            "title": "Token"
+          },
+          "session_id": {
+            "type": "string",
+            "title": "Session Id"
+          },
+          "expires_at": {
+            "type": "string",
+            "title": "Expires At"
+          },
+          "target": {
+            "$ref": "#/components/schemas/OutImpersonationParty"
+          },
+          "acting_admin": {
+            "$ref": "#/components/schemas/OutImpersonationParty"
+          }
+        },
+        "type": "object",
+        "required": [
+          "token",
+          "session_id",
+          "expires_at",
+          "target",
+          "acting_admin"
+        ],
+        "title": "OutImpersonationSession",
+        "description": "``POST /v1/admin/impersonation``."
       },
       "OutPendingFriendRequests": {
         "properties": {

--- a/openapi.json
+++ b/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "druthers.io API dev",
+    "title": "druthers.io API local",
     "description": "API for druthers.io - track and rank the movies, TV, books, and games you actually care about.",
     "contact": {
       "name": "Druthers",

--- a/tests/integration/router_admin_disable_test.py
+++ b/tests/integration/router_admin_disable_test.py
@@ -1,0 +1,418 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+from fastapi.testclient import TestClient
+
+from app.db.models import DbAdminAuditLog, DbApiKey, DbFriendship, DbRefreshToken
+from app.db.models_sandbox import DbMovie, DbUserMovie
+from app.services.friendships import FriendshipStatus
+from app.services.visibility import VisibilityTier
+
+PROBE = '/v1/users/me/notifications/unread-count'
+
+
+def _admin(test_client: TestClient) -> dict:
+    return {'Authorization': f"Bearer {test_client.admin_user.token}"}
+
+
+def _as(user) -> dict:
+    return {'Authorization': f"Bearer {user.token}"}
+
+
+def _sign_in(client: TestClient, user) -> dict:
+    response = client.post(
+        '/v1/auth/token',
+        files={
+            'username': (None, user.email),
+            'password': (None, user.plain_password),
+        },
+    )
+    return response
+
+
+def _create_api_key(test_client: TestClient, token: str) -> str:
+    resp = test_client.post(
+        '/v1/users/me/api-keys',
+        json={'name': 'test key'},
+        headers={'Authorization': f'Bearer {token}'},
+    )
+    assert resp.status_code == 201
+    return resp.json()['key']
+
+
+def test_disable_requires_admin(test_client: TestClient):
+    target = test_client.second_user
+    resp = test_client.post(
+        f'/v1/admin/users/{target.id}/disable', headers=_as(test_client.first_user)
+    )
+    assert resp.status_code == 403
+    assert resp.json()['message'] == 'Admin privileges required'
+
+
+def test_disable_sets_status_and_returns_user_detail(test_client: TestClient):
+    target = test_client.first_user
+    resp = test_client.post(
+        f'/v1/admin/users/{target.id}/disable', headers=_admin(test_client)
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body['status'] == 'disabled'
+    assert body['id'] == target.id
+    # Same shape as GET /v1/admin/users/{uuid}.
+    assert 'domains' in body and 'visibility' in body and 'social' in body
+
+
+def test_disable_is_audited(test_client: TestClient):
+    db = test_client.test_db_session
+    target = test_client.first_user
+    test_client.post(
+        f'/v1/admin/users/{target.id}/disable', headers=_admin(test_client)
+    )
+    db.expire_all()
+    row = (
+        db.query(DbAdminAuditLog)
+        .filter(DbAdminAuditLog.action == 'admin.user.disable')
+        .order_by(DbAdminAuditLog.pk.desc())
+        .first()
+    )
+    assert row is not None
+    assert row.result == 'allowed'
+    assert row.target_user_pk == target.pk
+    assert row.actor_user_pk == test_client.admin_user.pk
+
+
+def test_disabled_users_live_access_token_stops_working(test_client: TestClient):
+    """
+    The test that proves enforcement is real, not sign-in-only: a token
+    minted before the disable keeps its full JWT TTL, so only a resolver
+    check on every use can stop it mid-flight.
+    """
+    target = test_client.first_user
+    assert test_client.get(PROBE, headers=_as(target)).status_code == 200
+
+    test_client.post(
+        f'/v1/admin/users/{target.id}/disable', headers=_admin(test_client)
+    )
+
+    denied = test_client.get(PROBE, headers=_as(target))
+    assert denied.status_code == 403
+    assert denied.json()['message'] == 'Account disabled'
+
+
+def test_disabled_users_api_key_stops_working(test_client: TestClient):
+    """
+    Disabling deletes the key outright (see test_disable_deletes_api_keys_
+    outright), so a probe with the old key gets the generic "unknown
+    credential" 401, not a 403 - there is no live row left for the
+    resolver's disabled check to even run against. The key is just gone,
+    which is the stronger guarantee.
+    """
+    target = test_client.first_user
+    key = _create_api_key(test_client, target.token)
+    assert (
+        test_client.get(
+            '/v1/users/me/api-keys', headers={'Authorization': f'Bearer {key}'}
+        ).status_code
+        == 200
+    )
+
+    test_client.post(
+        f'/v1/admin/users/{target.id}/disable', headers=_admin(test_client)
+    )
+
+    denied = test_client.get(
+        '/v1/users/me/api-keys', headers={'Authorization': f'Bearer {key}'}
+    )
+    assert denied.status_code == 401
+
+
+def test_disable_deletes_api_keys_outright(test_client: TestClient):
+    db = test_client.test_db_session
+    target = test_client.first_user
+    _create_api_key(test_client, target.token)
+    assert db.query(DbApiKey).filter(DbApiKey.user_id == target.pk).count() == 1
+
+    test_client.post(
+        f'/v1/admin/users/{target.id}/disable', headers=_admin(test_client)
+    )
+
+    db.expire_all()
+    assert db.query(DbApiKey).filter(DbApiKey.user_id == target.pk).count() == 0
+
+
+def test_disable_revokes_every_refresh_token_family(test_client: TestClient):
+    db = test_client.test_db_session
+    target = test_client.first_user
+    signed_in = _sign_in(test_client, target).json()
+    refresh_token = signed_in['refresh_token']
+
+    test_client.post(
+        f'/v1/admin/users/{target.id}/disable', headers=_admin(test_client)
+    )
+
+    db.expire_all()
+    live = (
+        db.query(DbRefreshToken)
+        .filter(
+            DbRefreshToken.user_id == target.pk, DbRefreshToken.revoked_at.is_(None)
+        )
+        .count()
+    )
+    assert live == 0
+
+    refresh_resp = test_client.post(
+        '/v1/auth/refresh', json={'refresh_token': refresh_token}
+    )
+    assert refresh_resp.status_code == 401
+
+
+def test_disable_rejects_new_sign_in(test_client: TestClient):
+    target = test_client.first_user
+    test_client.post(
+        f'/v1/admin/users/{target.id}/disable', headers=_admin(test_client)
+    )
+    resp = _sign_in(test_client, target)
+    assert resp.status_code == 403
+    assert resp.json()['message'] == 'Account disabled'
+
+
+def test_admin_cannot_disable_self(test_client: TestClient):
+    db = test_client.test_db_session
+    admin = test_client.admin_user
+    resp = test_client.post(
+        f'/v1/admin/users/{admin.id}/disable', headers=_admin(test_client)
+    )
+    assert resp.status_code == 403
+    assert resp.json()['message'] == 'You cannot disable your own account'
+
+    db.expire_all()
+    row = (
+        db.query(DbAdminAuditLog)
+        .filter(DbAdminAuditLog.action == 'admin.user.disable')
+        .order_by(DbAdminAuditLog.pk.desc())
+        .first()
+    )
+    assert row.result == 'denied'
+    assert row.target_user_pk == admin.pk
+
+    # A handler-level denial must not also generate the middleware's
+    # generic admin.access row for the same request - one, specific row,
+    # not a duplicate.
+    access_rows = (
+        db.query(DbAdminAuditLog)
+        .filter(
+            DbAdminAuditLog.action == 'admin.access',
+            DbAdminAuditLog.request_id == row.request_id,
+        )
+        .count()
+    )
+    assert access_rows == 0
+
+
+def test_admin_cannot_disable_another_admin(
+    test_client: TestClient, test_create_admin_user
+):
+    db = test_client.test_db_session
+    second_admin = test_create_admin_user(test_client)[0]
+    resp = test_client.post(
+        f'/v1/admin/users/{second_admin.id}/disable', headers=_admin(test_client)
+    )
+    assert resp.status_code == 403
+    assert resp.json()['message'] == 'Cannot disable another admin account'
+
+    db.expire_all()
+    row = (
+        db.query(DbAdminAuditLog)
+        .filter(DbAdminAuditLog.action == 'admin.user.disable')
+        .order_by(DbAdminAuditLog.pk.desc())
+        .first()
+    )
+    assert row.result == 'denied'
+    assert row.target_user_pk == second_admin.pk
+
+    db.refresh(second_admin)
+    assert second_admin.disabled_at is None
+
+
+def test_enable_restores_sign_in(test_client: TestClient):
+    target = test_client.first_user
+    test_client.post(
+        f'/v1/admin/users/{target.id}/disable', headers=_admin(test_client)
+    )
+    assert _sign_in(test_client, target).status_code == 403
+
+    enable_resp = test_client.post(
+        f'/v1/admin/users/{target.id}/enable', headers=_admin(test_client)
+    )
+    assert enable_resp.status_code == 200
+    assert enable_resp.json()['status'] == 'active'
+
+    assert _sign_in(test_client, target).status_code == 200
+
+
+def test_enable_does_not_restore_the_old_refresh_token(test_client: TestClient):
+    """
+    Re-enabling is not "undo" - the refresh token a disable revoked stays
+    revoked; the user has to sign in again. Load-bearing for the console's
+    confirmation copy.
+    """
+    target = test_client.first_user
+    signed_in = _sign_in(test_client, target).json()
+    refresh_token = signed_in['refresh_token']
+
+    test_client.post(
+        f'/v1/admin/users/{target.id}/disable', headers=_admin(test_client)
+    )
+    test_client.post(f'/v1/admin/users/{target.id}/enable', headers=_admin(test_client))
+
+    refresh_resp = test_client.post(
+        '/v1/auth/refresh', json={'refresh_token': refresh_token}
+    )
+    assert refresh_resp.status_code == 401
+
+
+def test_enable_is_audited(test_client: TestClient):
+    db = test_client.test_db_session
+    target = test_client.first_user
+    test_client.post(
+        f'/v1/admin/users/{target.id}/disable', headers=_admin(test_client)
+    )
+    test_client.post(f'/v1/admin/users/{target.id}/enable', headers=_admin(test_client))
+    db.expire_all()
+    row = (
+        db.query(DbAdminAuditLog)
+        .filter(DbAdminAuditLog.action == 'admin.user.enable')
+        .order_by(DbAdminAuditLog.pk.desc())
+        .first()
+    )
+    assert row is not None
+    assert row.result == 'allowed'
+    assert row.target_user_pk == target.pk
+
+
+def test_disable_not_found(test_client: TestClient):
+    resp = test_client.post(
+        '/v1/admin/users/not-a-real-id/disable', headers=_admin(test_client)
+    )
+    assert resp.status_code == 404
+
+
+def test_disabled_user_absent_from_public_profile(test_client: TestClient):
+    target = test_client.first_user
+    target.handle = 'ghost-profile'
+    target.visibility_profile = VisibilityTier.PUBLIC.value
+    test_client.test_db_session.commit()
+
+    assert test_client.get('/v1/public/ghost-profile').status_code == 200
+
+    test_client.post(
+        f'/v1/admin/users/{target.id}/disable', headers=_admin(test_client)
+    )
+
+    resp = test_client.get('/v1/public/ghost-profile')
+    assert resp.status_code == 404
+
+
+def test_disabled_user_absent_from_friends_and_follows_listings(
+    test_client: TestClient,
+):
+    owner = test_client.second_user
+    target = test_client.first_user
+    target.handle = 'ghost-social'
+    target.visibility_profile = VisibilityTier.PUBLIC.value
+    db = test_client.test_db_session
+    db.commit()
+
+    # Establish a friendship and a follow before disabling.
+    sent = test_client.post(
+        '/v1/users/me/friends/requests',
+        headers=_as(owner),
+        json={'handle': target.handle},
+    )
+    assert sent.status_code == 202
+    accept_target_view = test_client.get(
+        '/v1/users/me/friends/requests', headers=_as(target)
+    )
+    request_id = accept_target_view.json()['incoming'][0]['id']
+    assert (
+        test_client.put(
+            f'/v1/users/me/friends/requests/{request_id}/accept', headers=_as(target)
+        ).status_code
+        == 200
+    )
+    assert (
+        test_client.put(
+            f'/v1/users/me/following/{target.handle}', headers=_as(owner)
+        ).status_code
+        == 200
+    )
+
+    before_friends = test_client.get('/v1/users/me/friends', headers=_as(owner))
+    assert any(f['user']['id'] == target.id for f in before_friends.json())
+    before_following = test_client.get('/v1/users/me/following', headers=_as(owner))
+    assert any(f['user']['id'] == target.id for f in before_following.json())
+
+    test_client.post(
+        f'/v1/admin/users/{target.id}/disable', headers=_admin(test_client)
+    )
+
+    after_friends = test_client.get('/v1/users/me/friends', headers=_as(owner))
+    assert not any(f['user']['id'] == target.id for f in after_friends.json())
+    after_following = test_client.get('/v1/users/me/following', headers=_as(owner))
+    assert not any(f['user']['id'] == target.id for f in after_following.json())
+
+
+def test_disabled_user_absent_from_friends_social_feed(
+    test_client: TestClient,
+):
+    owner = test_client.second_user
+    target = test_client.first_user
+    db = test_client.test_db_session
+
+    movie = DbMovie(title='Ghost Movie')
+    db.add(movie)
+    db.flush()
+    db.add(DbUserMovie(user_id=target.pk, movie_id=movie.pk, on_rankings=True, rank=1))
+    db.add(
+        DbFriendship(
+            user_low_id=min(target.pk, owner.pk),
+            user_high_id=max(target.pk, owner.pk),
+            requested_by_id=target.pk,
+            status=FriendshipStatus.ACCEPTED,
+        )
+    )
+    db.commit()
+
+    before = test_client.get('/v1/users/me/feed', headers=_as(owner))
+    assert before.status_code == 200
+    assert any(item['actor']['id'] == target.id for item in before.json()['items'])
+
+    test_client.post(
+        f'/v1/admin/users/{target.id}/disable', headers=_admin(test_client)
+    )
+
+    after = test_client.get('/v1/users/me/feed', headers=_as(owner))
+    assert after.status_code == 200
+    assert not any(item['actor']['id'] == target.id for item in after.json()['items'])
+
+
+def test_disabled_user_absent_from_global_search(test_client: TestClient):
+    target = test_client.first_user
+    target.handle = 'ghost-search'
+    target.display_name = 'Ghost Searchable'
+    target.visibility_profile = VisibilityTier.PUBLIC.value
+    test_client.test_db_session.commit()
+
+    before = test_client.get(
+        '/v1/search/users?q=Ghost+Searchable', headers=_as(test_client.second_user)
+    )
+    assert before.status_code == 200
+    assert any(u['id'] == target.id for u in before.json()['users'])
+
+    test_client.post(
+        f'/v1/admin/users/{target.id}/disable', headers=_admin(test_client)
+    )
+
+    after = test_client.get(
+        '/v1/search/users?q=Ghost+Searchable', headers=_as(test_client.second_user)
+    )
+    assert after.status_code == 200
+    assert not any(u['id'] == target.id for u in after.json()['users'])

--- a/tests/integration/router_admin_impersonation_test.py
+++ b/tests/integration/router_admin_impersonation_test.py
@@ -1,0 +1,262 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from app.auth.oauth2 import (
+    IMPERSONATION_TOKEN_TYPE,
+    create_access_token,
+    is_impersonation_token,
+)
+from app.db.models import DbAdminAuditLog, DbApiKey, DbImpersonationSession, DbUser
+
+
+def _admin(test_client: TestClient) -> dict:
+    return {'Authorization': f"Bearer {test_client.admin_user.token}"}
+
+
+def _as(user) -> dict:
+    return {'Authorization': f"Bearer {user.token}"}
+
+
+def _start(test_client: TestClient, target, reason: str = 'diagnosing a bug'):
+    return test_client.post(
+        '/v1/admin/impersonation',
+        json={'target_uuid': target.id, 'reason': reason},
+        headers=_admin(test_client),
+    )
+
+
+def _impersonating(test_client: TestClient, target) -> dict:
+    resp = _start(test_client, target)
+    assert resp.status_code == 200, resp.text
+    return {'Authorization': f"Bearer {resp.json()['token']}"}
+
+
+def test_start_returns_a_scoped_token_and_both_parties(test_client: TestClient):
+    resp = _start(test_client, test_client.first_user)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body['target']['id'] == test_client.first_user.id
+    assert body['acting_admin']['id'] == test_client.admin_user.id
+    assert body['session_id']
+    # Expiry is serialized as UTC, same as every other admin datetime.
+    assert body['expires_at'].endswith('Z')
+    # The mint response must never carry a refresh token: an impersonation
+    # session has to die at expiry rather than being renewable.
+    assert 'refresh_token' not in body
+
+
+def test_impersonated_reads_return_the_target_not_the_admin(
+    test_client: TestClient,
+):
+    """
+    ``GET /v1/users/{uuid}`` only serves the caller their own record, so it
+    doubles as an identity probe: under impersonation the TARGET's record
+    must resolve and the acting admin's must not.
+    """
+    headers = _impersonating(test_client, test_client.first_user)
+
+    as_target = test_client.get(
+        f'/v1/users/{test_client.first_user.id}', headers=headers
+    )
+    assert as_target.status_code == 200
+
+    as_admin = test_client.get(
+        f'/v1/users/{test_client.admin_user.id}', headers=headers
+    )
+    assert as_admin.status_code == 403
+
+
+def test_impersonation_cannot_delete_the_target_account(test_client: TestClient):
+    """
+    The bug this whole design exists to prevent.
+
+    ``DELETE /v1/users/{uuid}`` resolves through ``get_current_session_user``,
+    a second decode path. If the identity swap lived in ``get_current_user``
+    instead of the shared resolver, that path would resolve the impersonation
+    token's ``sub`` to the target with no impersonation context, and the
+    endpoint's self-delete branch would fire because the impersonated
+    identity IS the target.
+    """
+    target = test_client.first_user
+    headers = _impersonating(test_client, target)
+    resp = test_client.delete(f'/v1/users/{target.id}', headers=headers)
+    assert resp.status_code == 403
+    db = test_client.test_db_session
+    assert db.query(DbUser).filter(DbUser.id == target.id).first() is not None
+
+
+def test_impersonation_refuses_every_write(test_client: TestClient):
+    headers = _impersonating(test_client, test_client.first_user)
+    writes = (
+        ('post', '/v1/users/me/api-keys', {'name': 'stolen'}),
+        (
+            'put',
+            f'/v1/users/{test_client.first_user.id}',
+            {
+                'display_name': 'Taken Over',
+                'email': 'taken-over@gmail.com',
+                'password': 'hunter22222',
+            },
+        ),
+        ('put', '/v1/users/me/visibility', {'visibility_profile': 'public'}),
+        ('put', '/v1/users/me/preferences', {'theme': 'dark'}),
+    )
+    for method, path, payload in writes:
+        resp = getattr(test_client, method)(path, json=payload, headers=headers)
+        assert resp.status_code == 403, f'{method} {path} was not refused'
+
+    db = test_client.test_db_session
+    owner_pk = (
+        db.query(DbUser).filter(DbUser.id == test_client.first_user.id).first().pk
+    )
+    assert db.query(DbApiKey).filter(DbApiKey.user_id == owner_pk).count() == 0
+
+
+def test_impersonation_cannot_reach_admin_routes(test_client: TestClient):
+    headers = _impersonating(test_client, test_client.first_user)
+    for path in ('/v1/admin/users', '/v1/admin/audit'):
+        assert test_client.get(path, headers=headers).status_code == 403
+
+
+def test_an_api_key_can_never_impersonate(test_client: TestClient):
+    """
+    API keys share the Authorization header with JWTs, so the resolver must
+    never read impersonation claims off one. It cannot: the ``drk_`` branch
+    does not decode a payload at all.
+    """
+    target = test_client.first_user
+    # A live session exists, so if a key could ever be treated as carrying
+    # impersonation this is when it would show.
+    impersonation_headers = _impersonating(test_client, target)
+    probe = f'/v1/users/{target.id}'
+    assert test_client.get(probe, headers=impersonation_headers).status_code == 200
+
+    key_resp = test_client.post(
+        '/v1/users/me/api-keys',
+        json={'name': 'admin cron'},
+        headers=_admin(test_client),
+    )
+    assert key_resp.status_code in (200, 201), key_resp.text
+    secret = key_resp.json()['key']
+    assert secret.startswith('drk_')
+    assert is_impersonation_token(secret) is False
+
+    # A write is the sharpest probe available: the impersonation token is
+    # refused for one, so if the key were ever treated as carrying the live
+    # session it would be refused too. It is not, because the drk_ branch
+    # returns the key's owner without ever decoding a payload.
+    key_headers = {'Authorization': f'Bearer {secret}'}
+    assert (
+        test_client.put(
+            '/v1/users/me/preferences', json={'theme': 'dark'}, headers=key_headers
+        ).status_code
+        == 200
+    )
+    assert (
+        test_client.put(
+            '/v1/users/me/preferences',
+            json={'theme': 'dark'},
+            headers=impersonation_headers,
+        ).status_code
+        == 403
+    )
+
+
+def test_admin_cannot_impersonate_another_admin(test_client: TestClient):
+    db = test_client.test_db_session
+    other = db.query(DbUser).filter(DbUser.id == test_client.first_user.id).first()
+    other.user_group = 'admin'
+    db.commit()
+    resp = _start(test_client, test_client.first_user)
+    assert resp.status_code == 403
+    assert 'admin' in resp.json()['message'].lower()
+
+
+def test_target_promoted_mid_session_stops_being_impersonable(
+    test_client: TestClient,
+):
+    headers = _impersonating(test_client, test_client.first_user)
+    probe = f'/v1/users/{test_client.first_user.id}'
+    assert test_client.get(probe, headers=headers).status_code == 200
+    db = test_client.test_db_session
+    promoted = db.query(DbUser).filter(DbUser.id == test_client.first_user.id).first()
+    promoted.user_group = 'admin'
+    db.commit()
+    assert test_client.get(probe, headers=headers).status_code == 403
+
+
+def test_stopping_kills_the_token_immediately(test_client: TestClient):
+    headers = _impersonating(test_client, test_client.first_user)
+    probe = f'/v1/users/{test_client.first_user.id}'
+    assert test_client.get(probe, headers=headers).status_code == 200
+    stop = test_client.delete('/v1/admin/impersonation', headers=_admin(test_client))
+    assert stop.status_code == 200
+    assert test_client.get(probe, headers=headers).status_code == 403
+
+
+def test_expired_session_is_refused(test_client: TestClient):
+    resp = _start(test_client, test_client.first_user)
+    headers = {'Authorization': f"Bearer {resp.json()['token']}"}
+    db = test_client.test_db_session
+    row = (
+        db.query(DbImpersonationSession)
+        .filter(DbImpersonationSession.id == resp.json()['session_id'])
+        .first()
+    )
+    row.expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+    db.commit()
+    probe = f'/v1/users/{test_client.first_user.id}'
+    assert test_client.get(probe, headers=headers).status_code == 403
+
+
+def test_demoting_the_acting_admin_kills_the_session(test_client: TestClient):
+    headers = _impersonating(test_client, test_client.first_user)
+    db = test_client.test_db_session
+    admin_row = db.query(DbUser).filter(DbUser.id == test_client.admin_user.id).first()
+    admin_row.user_group = 'user'
+    db.commit()
+    probe = f'/v1/users/{test_client.first_user.id}'
+    assert test_client.get(probe, headers=headers).status_code == 403
+
+
+def test_start_and_stop_are_audited(test_client: TestClient):
+    _impersonating(test_client, test_client.first_user)
+    test_client.delete('/v1/admin/impersonation', headers=_admin(test_client))
+    db = test_client.test_db_session
+    actions = {row.action for row in db.query(DbAdminAuditLog).all()}
+    assert 'admin.impersonation.start' in actions
+    assert 'admin.impersonation.stop' in actions
+
+
+def test_a_non_admin_cannot_start_impersonation(test_client: TestClient):
+    resp = test_client.post(
+        '/v1/admin/impersonation',
+        json={'target_uuid': test_client.second_user.id},
+        headers=_as(test_client.first_user),
+    )
+    assert resp.status_code == 403
+
+
+def test_a_forged_impersonation_claim_on_an_ordinary_token_is_refused(
+    test_client: TestClient,
+):
+    """
+    A token whose ``typ`` says impersonation but which names no real session
+    row must not resolve. Signed with the real key, so this proves the check
+    is the session lookup and not merely the signature.
+    """
+    forged = create_access_token(
+        {
+            'sub': test_client.first_user.id,
+            'act': test_client.admin_user.id,
+            'typ': IMPERSONATION_TOKEN_TYPE,
+            'sid': 'no-such-session',
+        }
+    )
+    resp = test_client.get(
+        f'/v1/users/{test_client.first_user.id}',
+        headers={'Authorization': f'Bearer {forged}'},
+    )
+    assert resp.status_code == 403

--- a/tests/integration/router_admin_impersonation_test.py
+++ b/tests/integration/router_admin_impersonation_test.py
@@ -87,7 +87,16 @@ def test_impersonation_cannot_delete_the_target_account(test_client: TestClient)
     assert db.query(DbUser).filter(DbUser.id == target.id).first() is not None
 
 
+WRITE_BLOCK_MESSAGE = 'This view-as session is read-only. End it to act as yourself.'
+
+
 def test_impersonation_refuses_every_write(test_client: TestClient):
+    """
+    Asserting only the status code here would also pass against a build
+    where the feature is completely dead (``_resolve_impersonation``
+    raising 403 unconditionally, before ever reaching the write-block
+    check) - the message is what proves this specific check fired.
+    """
     headers = _impersonating(test_client, test_client.first_user)
     writes = (
         ('post', '/v1/users/me/api-keys', {'name': 'stolen'}),
@@ -106,6 +115,9 @@ def test_impersonation_refuses_every_write(test_client: TestClient):
     for method, path, payload in writes:
         resp = getattr(test_client, method)(path, json=payload, headers=headers)
         assert resp.status_code == 403, f'{method} {path} was not refused'
+        assert (
+            resp.json()['message'] == WRITE_BLOCK_MESSAGE
+        ), f'{method} {path} was refused for the wrong reason: {resp.json()}'
 
     db = test_client.test_db_session
     owner_pk = (
@@ -114,10 +126,52 @@ def test_impersonation_refuses_every_write(test_client: TestClient):
     assert db.query(DbApiKey).filter(DbApiKey.user_id == owner_pk).count() == 0
 
 
+def test_impersonation_refused_writes_are_audited(test_client: TestClient):
+    """
+    A denied *start* was already audited; a denied *write* from an already-
+    live session previously left no trace at all - the more dangerous of
+    the two attempts was the one going unrecorded.
+    """
+    target = test_client.first_user
+    headers = _impersonating(test_client, target)
+    db = test_client.test_db_session
+    before = db.query(DbAdminAuditLog).count()
+
+    resp = test_client.put(
+        '/v1/users/me/preferences', json={'theme': 'dark'}, headers=headers
+    )
+    assert resp.status_code == 403
+
+    db.expire_all()
+    row = db.query(DbAdminAuditLog).order_by(DbAdminAuditLog.pk.desc()).first()
+    assert db.query(DbAdminAuditLog).count() == before + 1
+    assert row.action == 'admin.impersonation.write_blocked'
+    assert row.result == 'denied'
+    assert row.status_code == 403
+    # The acting admin, not the target whose identity the token swapped in -
+    # the same attribution rule as the admin.access denial below.
+    assert row.actor_user_pk == test_client.admin_user.pk
+    assert row.target_user_pk == target.pk
+
+
 def test_impersonation_cannot_reach_admin_routes(test_client: TestClient):
+    """
+    The two GETs alone would pass under a plain non-admin identity too -
+    ``require_admin`` refuses those regardless of impersonation, so they
+    only prove the swap resolved to a non-admin, not that impersonation
+    itself is blocked from the admin surface. ``DELETE /v1/admin/
+    impersonation`` is the case that actually distinguishes them: it is a
+    write, so the read-only rule has to refuse it before ``require_admin``
+    is ever reached - and it is exactly the route a compromised or
+    careless impersonation token would want to reach, to end (or interfere
+    with) a session that is not its own.
+    """
     headers = _impersonating(test_client, test_client.first_user)
     for path in ('/v1/admin/users', '/v1/admin/audit'):
         assert test_client.get(path, headers=headers).status_code == 403
+    stop_resp = test_client.delete('/v1/admin/impersonation', headers=headers)
+    assert stop_resp.status_code == 403
+    assert stop_resp.json()['message'] == WRITE_BLOCK_MESSAGE
 
 
 def test_an_api_key_can_never_impersonate(test_client: TestClient):
@@ -165,13 +219,20 @@ def test_an_api_key_can_never_impersonate(test_client: TestClient):
 
 
 def test_admin_cannot_impersonate_another_admin(test_client: TestClient):
+    """
+    ``'admin' in message.lower()`` would also pass against
+    ``require_admin``'s own 'Admin privileges required' - not a message
+    this endpoint could even produce here, since the caller already IS an
+    admin, but a weak enough assertion to miss the swap. Assert the exact,
+    specific refusal instead.
+    """
     db = test_client.test_db_session
     other = db.query(DbUser).filter(DbUser.id == test_client.first_user.id).first()
     other.user_group = 'admin'
     db.commit()
     resp = _start(test_client, test_client.first_user)
     assert resp.status_code == 403
-    assert 'admin' in resp.json()['message'].lower()
+    assert resp.json()['message'] == 'An admin cannot be impersonated'
 
 
 def test_target_promoted_mid_session_stops_being_impersonable(
@@ -222,12 +283,160 @@ def test_demoting_the_acting_admin_kills_the_session(test_client: TestClient):
 
 
 def test_start_and_stop_are_audited(test_client: TestClient):
-    _impersonating(test_client, test_client.first_user)
+    """
+    Checking only that the action strings exist would also pass with the
+    detail column silently empty - which is exactly the defect this pins:
+    ``session_id``/``reason``/``ended`` were dropped by the redact
+    allowlist until they were added to it, and the commit message claiming
+    ``session_id`` was recorded was wrong.
+    """
+    target = test_client.first_user
+    start_resp = _start(test_client, target, reason='diagnosing a bug')
+    session_id = start_resp.json()['session_id']
     test_client.delete('/v1/admin/impersonation', headers=_admin(test_client))
+
     db = test_client.test_db_session
-    actions = {row.action for row in db.query(DbAdminAuditLog).all()}
-    assert 'admin.impersonation.start' in actions
-    assert 'admin.impersonation.stop' in actions
+    db.expire_all()
+    start_row = (
+        db.query(DbAdminAuditLog)
+        .filter(DbAdminAuditLog.action == 'admin.impersonation.start')
+        .order_by(DbAdminAuditLog.pk.desc())
+        .first()
+    )
+    assert start_row is not None
+    assert start_row.result == 'allowed'
+    assert start_row.target_user_pk == target.pk
+    assert start_row.detail == {
+        'session_id': session_id,
+        'reason': 'diagnosing a bug',
+    }
+
+    stop_row = (
+        db.query(DbAdminAuditLog)
+        .filter(DbAdminAuditLog.action == 'admin.impersonation.stop')
+        .order_by(DbAdminAuditLog.pk.desc())
+        .first()
+    )
+    assert stop_row is not None
+    assert stop_row.result == 'allowed'
+    # One row per ended session names which target it was, so with more
+    # than one live session the trail can still say who was being viewed.
+    assert stop_row.target_user_pk == target.pk
+
+
+def test_stopping_with_nothing_live_still_leaves_a_row(test_client: TestClient):
+    db = test_client.test_db_session
+    before = db.query(DbAdminAuditLog).count()
+    resp = test_client.delete('/v1/admin/impersonation', headers=_admin(test_client))
+    assert resp.status_code == 200
+    assert resp.json() == {'ended': 0}
+
+    db.expire_all()
+    row = (
+        db.query(DbAdminAuditLog)
+        .filter(DbAdminAuditLog.action == 'admin.impersonation.stop')
+        .order_by(DbAdminAuditLog.pk.desc())
+        .first()
+    )
+    assert db.query(DbAdminAuditLog).count() == before + 1
+    assert row.target_user_pk is None
+    assert row.detail == {'ended': 0}
+
+
+def test_a_second_start_leaves_the_first_session_live(test_client: TestClient):
+    first_target = test_client.first_user
+    second_target = test_client.second_user
+    first_headers = _impersonating(test_client, first_target)
+    second_headers = _impersonating(test_client, second_target)
+
+    probe_first = f'/v1/users/{first_target.id}'
+    probe_second = f'/v1/users/{second_target.id}'
+    assert test_client.get(probe_first, headers=first_headers).status_code == 200
+    assert test_client.get(probe_second, headers=second_headers).status_code == 200
+
+    stop = test_client.delete('/v1/admin/impersonation', headers=_admin(test_client))
+    assert stop.status_code == 200
+    assert stop.json() == {'ended': 2}
+    assert test_client.get(probe_first, headers=first_headers).status_code == 403
+    assert test_client.get(probe_second, headers=second_headers).status_code == 403
+
+
+def test_denied_admin_route_while_impersonating_is_attributed_to_the_admin(
+    test_client: TestClient,
+):
+    """
+    The bug: the denial middleware re-decodes the raw token to attribute a
+    request that never reached a handler, and an impersonation token's
+    resolved identity is the swapped-in target - so without the fix, this
+    denial would land on the TARGET's permanent audit record instead of
+    the admin who was actually at the keyboard.
+    """
+    target = test_client.first_user
+    headers = _impersonating(test_client, target)
+    db = test_client.test_db_session
+    before = db.query(DbAdminAuditLog).count()
+
+    resp = test_client.get('/v1/admin/users', headers=headers)
+    assert resp.status_code == 403
+
+    db.expire_all()
+    row = db.query(DbAdminAuditLog).order_by(DbAdminAuditLog.pk.desc()).first()
+    assert db.query(DbAdminAuditLog).count() == before + 1
+    assert row.action == 'admin.access'
+    assert row.result == 'denied'
+    assert row.actor_user_pk == test_client.admin_user.pk
+    assert row.actor_user_pk != target.pk
+    assert row.detail == {'via_impersonation': True}
+
+
+def test_sign_out_ends_a_live_impersonation_session(test_client: TestClient):
+    admin_signin = test_client.post(
+        '/v1/auth/token',
+        files={
+            'username': (None, test_client.admin_user.email),
+            'password': (None, test_client.admin_user.plain_password),
+        },
+    )
+    assert admin_signin.status_code == 200
+    admin_refresh_token = admin_signin.json()['refresh_token']
+
+    headers = _impersonating(test_client, test_client.first_user)
+    probe = f'/v1/users/{test_client.first_user.id}'
+    assert test_client.get(probe, headers=headers).status_code == 200
+
+    logout = test_client.post(
+        '/v1/auth/logout', json={'refresh_token': admin_refresh_token}
+    )
+    assert logout.status_code == 204
+
+    assert test_client.get(probe, headers=headers).status_code == 403
+
+
+def test_get_optional_current_user_under_impersonation_serves_the_target(
+    test_client: TestClient,
+):
+    """
+    ``GET /v1/public/{handle}`` resolves its optional viewer through
+    ``get_optional_current_user``, the one dependency in this file not
+    exercised by the other tests. Now that ``request`` is a required,
+    forwarded parameter there instead of an omitted one, it must not error
+    - and the resolved viewer must be the TARGET (a private profile is
+    visible to its own owner, but not to a stranger), proving the swap
+    reaches this second entry point too, not just ``get_current_user``.
+    """
+    target = test_client.first_user
+    target.handle = 'impersonation-optional-probe'
+    target.visibility_profile = 'private'
+    db = test_client.test_db_session
+    db.commit()
+
+    admin_headers = _admin(test_client)
+    as_admin = test_client.get(f'/v1/public/{target.handle}', headers=admin_headers)
+    assert as_admin.status_code == 404
+
+    headers = _impersonating(test_client, target)
+    as_target = test_client.get(f'/v1/public/{target.handle}', headers=headers)
+    assert as_target.status_code == 200
 
 
 def test_a_non_admin_cannot_start_impersonation(test_client: TestClient):

--- a/tests/integration/router_admin_impersonation_test.py
+++ b/tests/integration/router_admin_impersonation_test.py
@@ -469,3 +469,187 @@ def test_a_forged_impersonation_claim_on_an_ordinary_token_is_refused(
         headers={'Authorization': f'Bearer {forged}'},
     )
     assert resp.status_code == 403
+
+
+def _token_for(test_client, user, test_authenticate_user):
+    return test_authenticate_user(test_client, user.email, user.plain_password)
+
+
+def test_list_impersonation_sessions_is_admin_wide(
+    test_client: TestClient, test_create_admin_user, test_authenticate_user
+):
+    """
+    Scoped to every admin, not just the caller - listed here by an admin
+    who did NOT start the session, matching GET /v1/admin/audit's own
+    whole-trail (not self-scoped) precedent.
+    """
+    other_admin = test_create_admin_user(test_client)[0]
+    other_admin_headers = {
+        'Authorization': f'Bearer {_token_for(test_client, other_admin, test_authenticate_user)}'
+    }
+
+    target = test_client.first_user
+    start_resp = _start(test_client, target)
+    assert start_resp.status_code == 200
+    session_id = start_resp.json()['session_id']
+
+    listing = test_client.get('/v1/admin/impersonation', headers=other_admin_headers)
+    assert listing.status_code == 200
+    sessions = listing.json()['sessions']
+    matching = next(s for s in sessions if s['session_id'] == session_id)
+    assert matching['acting_admin']['id'] == test_client.admin_user.id
+    assert matching['target']['id'] == target.id
+    assert matching['started_at'].endswith('Z')
+    assert matching['expires_at'].endswith('Z')
+    assert 'token' not in matching
+
+
+def test_list_impersonation_sessions_excludes_ended(test_client: TestClient):
+    target = test_client.first_user
+    start_resp = _start(test_client, target)
+    session_id = start_resp.json()['session_id']
+    test_client.delete(
+        f'/v1/admin/impersonation/{session_id}', headers=_admin(test_client)
+    )
+
+    listing = test_client.get('/v1/admin/impersonation', headers=_admin(test_client))
+    assert not any(s['session_id'] == session_id for s in listing.json()['sessions'])
+
+
+def test_list_impersonation_sessions_excludes_expired(test_client: TestClient):
+    target = test_client.first_user
+    start_resp = _start(test_client, target)
+    session_id = start_resp.json()['session_id']
+    db = test_client.test_db_session
+    row = (
+        db.query(DbImpersonationSession)
+        .filter(DbImpersonationSession.id == session_id)
+        .first()
+    )
+    row.expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+    db.commit()
+
+    listing = test_client.get('/v1/admin/impersonation', headers=_admin(test_client))
+    assert not any(s['session_id'] == session_id for s in listing.json()['sessions'])
+
+
+def test_stop_specific_session_ends_only_that_one(test_client: TestClient):
+    first_target = test_client.first_user
+    second_target = test_client.second_user
+    first_headers = _impersonating(test_client, first_target)
+    second_start = _start(test_client, second_target)
+    session_id_two = second_start.json()['session_id']
+    second_headers = {'Authorization': f"Bearer {second_start.json()['token']}"}
+
+    probe_first = f'/v1/users/{first_target.id}'
+    probe_second = f'/v1/users/{second_target.id}'
+    assert test_client.get(probe_first, headers=first_headers).status_code == 200
+    assert test_client.get(probe_second, headers=second_headers).status_code == 200
+
+    stop = test_client.delete(
+        f'/v1/admin/impersonation/{session_id_two}', headers=_admin(test_client)
+    )
+    assert stop.status_code == 200
+    assert stop.json() == {'ended': 1}
+
+    assert test_client.get(probe_first, headers=first_headers).status_code == 200
+    assert test_client.get(probe_second, headers=second_headers).status_code == 403
+
+
+def test_stop_specific_session_is_idempotent(test_client: TestClient):
+    unknown = test_client.delete(
+        '/v1/admin/impersonation/no-such-session', headers=_admin(test_client)
+    )
+    assert unknown.status_code == 200
+    assert unknown.json() == {'ended': 0}
+
+    target = test_client.first_user
+    start_resp = _start(test_client, target)
+    session_id = start_resp.json()['session_id']
+    first_stop = test_client.delete(
+        f'/v1/admin/impersonation/{session_id}', headers=_admin(test_client)
+    )
+    assert first_stop.json() == {'ended': 1}
+    second_stop = test_client.delete(
+        f'/v1/admin/impersonation/{session_id}', headers=_admin(test_client)
+    )
+    assert second_stop.json() == {'ended': 0}
+
+
+def test_stop_specific_session_is_admin_wide(
+    test_client: TestClient, test_create_admin_user, test_authenticate_user
+):
+    """
+    Console oversight, not just self-cleanup: another admin can revoke a
+    session they did not start - the whole point of a listing anyone can
+    act on rather than a "my sessions only" view.
+    """
+    other_admin = test_create_admin_user(test_client)[0]
+    other_admin_headers = {
+        'Authorization': f'Bearer {_token_for(test_client, other_admin, test_authenticate_user)}'
+    }
+
+    target = test_client.first_user
+    start_resp = _start(test_client, target)
+    session_id = start_resp.json()['session_id']
+    imp_headers = {'Authorization': f"Bearer {start_resp.json()['token']}"}
+    probe = f'/v1/users/{target.id}'
+    assert test_client.get(probe, headers=imp_headers).status_code == 200
+
+    stop = test_client.delete(
+        f'/v1/admin/impersonation/{session_id}', headers=other_admin_headers
+    )
+    assert stop.status_code == 200
+    assert stop.json() == {'ended': 1}
+    assert test_client.get(probe, headers=imp_headers).status_code == 403
+
+
+def test_list_and_stop_by_id_are_audited(test_client: TestClient):
+    db = test_client.test_db_session
+    target = test_client.first_user
+    start_resp = _start(test_client, target)
+    session_id = start_resp.json()['session_id']
+
+    test_client.get('/v1/admin/impersonation', headers=_admin(test_client))
+    test_client.delete(
+        f'/v1/admin/impersonation/{session_id}', headers=_admin(test_client)
+    )
+
+    db.expire_all()
+    list_row = (
+        db.query(DbAdminAuditLog)
+        .filter(DbAdminAuditLog.action == 'admin.impersonation.list')
+        .order_by(DbAdminAuditLog.pk.desc())
+        .first()
+    )
+    assert list_row is not None
+    assert list_row.result == 'allowed'
+    assert list_row.detail['live_count'] >= 1
+
+    stop_row = (
+        db.query(DbAdminAuditLog)
+        .filter(DbAdminAuditLog.action == 'admin.impersonation.stop')
+        .order_by(DbAdminAuditLog.pk.desc())
+        .first()
+    )
+    assert stop_row is not None
+    assert stop_row.result == 'allowed'
+    assert stop_row.target_user_pk == target.pk
+    assert stop_row.detail == {'session_id': session_id, 'ended': 1}
+
+
+def test_a_non_admin_cannot_list_or_stop_a_specific_session(test_client: TestClient):
+    target = test_client.first_user
+    start_resp = _start(test_client, target)
+    session_id = start_resp.json()['session_id']
+    headers = _as(test_client.second_user)
+
+    assert (
+        test_client.get('/v1/admin/impersonation', headers=headers).status_code == 403
+    )
+    assert (
+        test_client.delete(
+            f'/v1/admin/impersonation/{session_id}', headers=headers
+        ).status_code
+        == 403
+    )

--- a/tests/integration/router_admin_test.py
+++ b/tests/integration/router_admin_test.py
@@ -56,7 +56,9 @@ def test_admin_denial_is_audited(test_client: TestClient):
     db = test_client.test_db_session
     before = db.query(DbAdminAuditLog).count()
 
-    resp = test_client.get('/v1/admin/users', headers=_as(test_client.first_user))
+    headers = _as(test_client.first_user)
+    headers['X-Forwarded-For'] = '203.0.113.9'
+    resp = test_client.get('/v1/admin/users', headers=headers)
     assert resp.status_code == 403
 
     db.expire_all()
@@ -65,8 +67,36 @@ def test_admin_denial_is_audited(test_client: TestClient):
     row = rows[0]
     assert row.result == 'denied'
     assert row.actor_user_pk == test_client.first_user.pk
+    assert row.actor_user_id == test_client.first_user.id
+    assert row.actor_email == test_client.first_user.email
     assert row.path == '/v1/admin/users'
     assert row.status_code == 403
+    assert row.request_id
+    # Rightmost X-Forwarded-For hop (rate_limit.client_ip's convention), not
+    # the connecting peer - behind Cloud Run/Cloudflare that peer is always
+    # the ingress proxy, never the real caller.
+    assert row.source_ip == '203.0.113.9'
+
+
+def test_admin_anonymous_probe_is_audited(test_client: TestClient):
+    """
+    A 401 (missing/expired token) is a denial too - a prober who never even
+    authenticates is exactly the case an admin surface's audit trail should
+    not go blind on.
+    """
+    db = test_client.test_db_session
+    before = db.query(DbAdminAuditLog).count()
+
+    resp = test_client.get('/v1/admin/users')
+    assert resp.status_code == 401
+
+    db.expire_all()
+    rows = db.query(DbAdminAuditLog).order_by(DbAdminAuditLog.pk.desc()).all()
+    assert len(rows) == before + 1
+    row = rows[0]
+    assert row.result == 'denied'
+    assert row.actor_user_pk is None
+    assert row.status_code == 401
 
 
 def test_admin_search_by_display_name_handle_and_email(test_client: TestClient):
@@ -103,6 +133,15 @@ def test_admin_search_pagination_and_total(test_client: TestClient, test_create_
     test_create_user(test_client, user_count=5)
     db = test_client.test_db_session
     expected_total = db.query(DbUser).count()
+    # Same tiebreaker as the endpoint (created_at desc, pk desc) - a
+    # secondary sort on a non-unique created_at, so this is the one order
+    # the endpoint is allowed to return, not just "an" order.
+    expected_ids = [
+        user.id
+        for user in db.query(DbUser)
+        .order_by(DbUser.created_at.desc(), DbUser.pk.desc())
+        .all()
+    ]
 
     first_page = test_client.get(
         '/v1/admin/users', headers=_admin(test_client), params={'limit': 2, 'offset': 0}
@@ -112,12 +151,12 @@ def test_admin_search_pagination_and_total(test_client: TestClient, test_create_
     assert body['total'] == expected_total
     assert body['limit'] == 2
     assert body['offset'] == 0
-    assert len(body['users']) == 2
+    assert [u['id'] for u in body['users']] == expected_ids[0:2]
 
     second_page = test_client.get(
         '/v1/admin/users', headers=_admin(test_client), params={'limit': 2, 'offset': 2}
     )
-    assert second_page.json()['users'] != first_page.json()['users']
+    assert [u['id'] for u in second_page.json()['users']] == expected_ids[2:4]
 
 
 def test_admin_user_detail_aggregates(test_client: TestClient, test_create_user):
@@ -185,6 +224,7 @@ def test_admin_reads_are_audited(test_client: TestClient):
     assert search_row.result == 'allowed'
     assert search_row.actor_user_pk == test_client.admin_user.pk
     assert search_row.status_code == 200
+    assert search_row.request_id
 
     view_row = (
         db.query(DbAdminAuditLog)
@@ -196,6 +236,9 @@ def test_admin_reads_are_audited(test_client: TestClient):
     assert view_row.target_user_pk == target.pk
     assert view_row.target_email == target.email
     assert view_row.status_code == 200
+    assert view_row.request_id
+    # Same request never reused the search's id - each carries its own.
+    assert view_row.request_id != search_row.request_id
 
 
 def test_admin_datetime_fields_carry_a_utc_designator(test_client: TestClient):
@@ -246,4 +289,34 @@ def test_admin_audit_trail_lists_and_filters(test_client: TestClient):
     assert event['actor']['id'] == test_client.admin_user.id
     assert event['method'] == 'GET'
     assert event['path'] == f'/v1/admin/users/{target.id}'
-    assert event['status_code'] is None or isinstance(event['status_code'], int)
+    assert event['status_code'] == 200
+    assert event['request_id']
+
+
+def test_admin_audit_trail_excludes_its_own_reads_by_default(test_client: TestClient):
+    """
+    Reading the trail is itself audited (``admin.audit.view``), but the
+    default (unfiltered) listing must not include those rows - otherwise
+    paging through the trail during an investigation keeps pushing the
+    events under investigation off page one.
+    """
+    # At least one admin.audit.view row to try to hide.
+    test_client.get('/v1/admin/audit', headers=_admin(test_client))
+
+    default_view = test_client.get('/v1/admin/audit', headers=_admin(test_client))
+    assert default_view.status_code == 200
+    actions = {event['action'] for event in default_view.json()['events']}
+    assert 'admin.audit.view' not in actions
+
+    # Still retrievable when asked for explicitly.
+    filtered_view = test_client.get(
+        '/v1/admin/audit',
+        headers=_admin(test_client),
+        params={'action': 'admin.audit.view'},
+    )
+    assert filtered_view.status_code == 200
+    assert filtered_view.json()['total'] >= 1
+    assert all(
+        event['action'] == 'admin.audit.view'
+        for event in filtered_view.json()['events']
+    )

--- a/tests/integration/router_admin_test.py
+++ b/tests/integration/router_admin_test.py
@@ -184,6 +184,7 @@ def test_admin_reads_are_audited(test_client: TestClient):
     assert search_row is not None
     assert search_row.result == 'allowed'
     assert search_row.actor_user_pk == test_client.admin_user.pk
+    assert search_row.status_code == 200
 
     view_row = (
         db.query(DbAdminAuditLog)
@@ -194,6 +195,36 @@ def test_admin_reads_are_audited(test_client: TestClient):
     assert view_row is not None
     assert view_row.target_user_pk == target.pk
     assert view_row.target_email == target.email
+    assert view_row.status_code == 200
+
+
+def test_admin_datetime_fields_carry_a_utc_designator(test_client: TestClient):
+    """
+    A naive ISO string (no ``Z``/offset) parses as *local* time under
+    ECMAScript, so every JS client would silently shift these by its own
+    UTC offset even though the underlying values are UTC. Assert on the
+    wire string itself, not a round-trip through Python's own datetime
+    parser - that would happily accept the broken naive form too and prove
+    nothing (api#344 review).
+    """
+    list_resp = test_client.get('/v1/admin/users', headers=_admin(test_client))
+    assert list_resp.status_code == 200
+    users = list_resp.json()['users']
+    assert users
+    assert users[0]['created_at'].endswith('Z')
+
+    target = test_client.first_user
+    detail_resp = test_client.get(
+        f'/v1/admin/users/{target.id}', headers=_admin(test_client)
+    )
+    assert detail_resp.status_code == 200
+    assert detail_resp.json()['created_at'].endswith('Z')
+
+    audit_resp = test_client.get('/v1/admin/audit', headers=_admin(test_client))
+    assert audit_resp.status_code == 200
+    events = audit_resp.json()['events']
+    assert events
+    assert events[0]['created_at'].endswith('Z')
 
 
 def test_admin_audit_trail_lists_and_filters(test_client: TestClient):

--- a/tests/integration/router_admin_test.py
+++ b/tests/integration/router_admin_test.py
@@ -1,0 +1,218 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring
+from fastapi.testclient import TestClient
+
+from app.db.models import DbAdminAuditLog, DbFollow, DbFriendship, DbUser
+from app.services.friendships import FriendshipStatus
+from app.services.shelves import SHELVES
+
+ADMIN_PATHS = ('/v1/admin/users', '/v1/admin/audit')
+
+
+def _admin(test_client: TestClient) -> dict:
+    return {'Authorization': f"Bearer {test_client.admin_user.token}"}
+
+
+def _as(user) -> dict:
+    return {'Authorization': f"Bearer {user.token}"}
+
+
+def _track(test_client: TestClient, user_pk: int, category: str, **overrides):
+    """Insert one tracker row for ``user_pk`` in the named shelf's domain."""
+    shelf = next(shelf for shelf in SHELVES if shelf.category == category)
+    db = test_client.test_db_session
+    catalog_row = shelf.catalog_model(
+        title=f"{category} title {overrides.get('rank', 'x')}"
+    )
+    db.add(catalog_row)
+    db.flush()
+    tracker_row = shelf.tracker_model(
+        user_id=user_pk, **{shelf.join_col: catalog_row.pk}, **overrides
+    )
+    db.add(tracker_row)
+    db.commit()
+    return tracker_row
+
+
+def test_admin_routes_require_admin(test_client: TestClient):
+    headers = _as(test_client.first_user)
+    for path in ADMIN_PATHS:
+        resp = test_client.get(path, headers=headers)
+        assert resp.status_code == 403
+        assert resp.json()['message'] == 'Admin privileges required'
+
+    detail_resp = test_client.get(
+        f'/v1/admin/users/{test_client.second_user.id}', headers=headers
+    )
+    assert detail_resp.status_code == 403
+    assert detail_resp.json()['message'] == 'Admin privileges required'
+
+
+def test_admin_routes_reject_anonymous(test_client: TestClient):
+    for path in ADMIN_PATHS:
+        assert test_client.get(path).status_code == 401
+
+
+def test_admin_denial_is_audited(test_client: TestClient):
+    db = test_client.test_db_session
+    before = db.query(DbAdminAuditLog).count()
+
+    resp = test_client.get('/v1/admin/users', headers=_as(test_client.first_user))
+    assert resp.status_code == 403
+
+    db.expire_all()
+    rows = db.query(DbAdminAuditLog).order_by(DbAdminAuditLog.pk.desc()).all()
+    assert len(rows) == before + 1
+    row = rows[0]
+    assert row.result == 'denied'
+    assert row.actor_user_pk == test_client.first_user.pk
+    assert row.path == '/v1/admin/users'
+    assert row.status_code == 403
+
+
+def test_admin_search_by_display_name_handle_and_email(test_client: TestClient):
+    db = test_client.test_db_session
+    target = test_client.first_user
+    target.display_name = 'Charlie Findable'
+    target.handle = 'findable-handle'
+    target.email = 'findable@example.com'
+    db.commit()
+
+    by_name = test_client.get(
+        '/v1/admin/users', headers=_admin(test_client), params={'q': 'charlie find'}
+    )
+    assert by_name.status_code == 200
+    assert target.id in [u['id'] for u in by_name.json()['users']]
+
+    by_handle = test_client.get(
+        '/v1/admin/users', headers=_admin(test_client), params={'q': 'findable-han'}
+    )
+    assert target.id in [u['id'] for u in by_handle.json()['users']]
+
+    by_email = test_client.get(
+        '/v1/admin/users', headers=_admin(test_client), params={'q': 'FINDABLE@EXAMPLE'}
+    )
+    assert target.id in [u['id'] for u in by_email.json()['users']]
+
+    no_match = test_client.get(
+        '/v1/admin/users', headers=_admin(test_client), params={'q': 'no-such-user-xyz'}
+    )
+    assert no_match.json()['users'] == []
+
+
+def test_admin_search_pagination_and_total(test_client: TestClient, test_create_user):
+    test_create_user(test_client, user_count=5)
+    db = test_client.test_db_session
+    expected_total = db.query(DbUser).count()
+
+    first_page = test_client.get(
+        '/v1/admin/users', headers=_admin(test_client), params={'limit': 2, 'offset': 0}
+    )
+    assert first_page.status_code == 200
+    body = first_page.json()
+    assert body['total'] == expected_total
+    assert body['limit'] == 2
+    assert body['offset'] == 0
+    assert len(body['users']) == 2
+
+    second_page = test_client.get(
+        '/v1/admin/users', headers=_admin(test_client), params={'limit': 2, 'offset': 2}
+    )
+    assert second_page.json()['users'] != first_page.json()['users']
+
+
+def test_admin_user_detail_aggregates(test_client: TestClient, test_create_user):
+    friend, follower = test_create_user(test_client, user_count=2)
+    target = test_client.first_user
+
+    _track(test_client, target.pk, 'movies', on_rankings=True, rank=1)
+    _track(test_client, target.pk, 'movies', on_watchlist=True)
+    _track(test_client, target.pk, 'books', on_rankings=True, rank=1)
+
+    db = test_client.test_db_session
+    db.add(
+        DbFriendship(
+            user_low_id=min(target.pk, friend.pk),
+            user_high_id=max(target.pk, friend.pk),
+            requested_by_id=friend.pk,
+            status=FriendshipStatus.ACCEPTED,
+        )
+    )
+    db.add(DbFollow(follower_id=follower.pk, followee_id=target.pk))
+    db.commit()
+
+    resp = test_client.get(f'/v1/admin/users/{target.id}', headers=_admin(test_client))
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body['id'] == target.id
+    assert body['status'] == 'active'
+    assert body['domains']['movies'] == {'ranked': 1, 'watchlist': 1, 'total': 2}
+    assert body['domains']['books'] == {'ranked': 1, 'watchlist': 0, 'total': 1}
+    assert body['domains']['tv'] == {'ranked': 0, 'watchlist': 0, 'total': 0}
+    assert body['domains']['games'] == {'ranked': 0, 'watchlist': 0, 'total': 0}
+    assert body['social'] == {'friends': 1, 'followers': 1, 'following': 0}
+    assert body['visibility']['profile'] == target.visibility_profile
+    assert body['visibility']['share_activity'] == target.share_activity
+
+
+def test_admin_user_detail_not_found(test_client: TestClient):
+    resp = test_client.get('/v1/admin/users/not-a-real-id', headers=_admin(test_client))
+    assert resp.status_code == 404
+
+
+def test_admin_reads_are_audited(test_client: TestClient):
+    db = test_client.test_db_session
+    target = test_client.second_user
+
+    search_resp = test_client.get(
+        '/v1/admin/users', headers=_admin(test_client), params={'q': ''}
+    )
+    assert search_resp.status_code == 200
+
+    detail_resp = test_client.get(
+        f'/v1/admin/users/{target.id}', headers=_admin(test_client)
+    )
+    assert detail_resp.status_code == 200
+
+    db.expire_all()
+    search_row = (
+        db.query(DbAdminAuditLog)
+        .filter(DbAdminAuditLog.action == 'admin.user.search')
+        .order_by(DbAdminAuditLog.pk.desc())
+        .first()
+    )
+    assert search_row is not None
+    assert search_row.result == 'allowed'
+    assert search_row.actor_user_pk == test_client.admin_user.pk
+
+    view_row = (
+        db.query(DbAdminAuditLog)
+        .filter(DbAdminAuditLog.action == 'admin.user.view')
+        .order_by(DbAdminAuditLog.pk.desc())
+        .first()
+    )
+    assert view_row is not None
+    assert view_row.target_user_pk == target.pk
+    assert view_row.target_email == target.email
+
+
+def test_admin_audit_trail_lists_and_filters(test_client: TestClient):
+    target = test_client.second_user
+    test_client.get(f'/v1/admin/users/{target.id}', headers=_admin(test_client))
+
+    resp = test_client.get(
+        '/v1/admin/audit',
+        headers=_admin(test_client),
+        params={'action': 'admin.user.view', 'target': target.email},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body['total'] >= 1
+    event = body['events'][0]
+    assert event['action'] == 'admin.user.view'
+    assert event['result'] == 'allowed'
+    assert event['target']['email'] == target.email
+    assert event['actor']['id'] == test_client.admin_user.id
+    assert event['method'] == 'GET'
+    assert event['path'] == f'/v1/admin/users/{target.id}'
+    assert event['status_code'] is None or isinstance(event['status_code'], int)

--- a/tests/integration/router_admin_test.py
+++ b/tests/integration/router_admin_test.py
@@ -272,7 +272,9 @@ def test_admin_datetime_fields_carry_a_utc_designator(test_client: TestClient):
 
 def test_admin_audit_trail_lists_and_filters(test_client: TestClient):
     target = test_client.second_user
-    test_client.get(f'/v1/admin/users/{target.id}', headers=_admin(test_client))
+    headers = _admin(test_client)
+    headers['X-Forwarded-For'] = '203.0.113.42'
+    test_client.get(f'/v1/admin/users/{target.id}', headers=headers)
 
     resp = test_client.get(
         '/v1/admin/audit',
@@ -291,6 +293,12 @@ def test_admin_audit_trail_lists_and_filters(test_client: TestClient):
     assert event['path'] == f'/v1/admin/users/{target.id}'
     assert event['status_code'] == 200
     assert event['request_id']
+    # Attribution is the point of an audit trail - the console has to be
+    # able to answer "where was this taken from" without a psql session.
+    # user_agent is deliberately not exposed alongside it (too long, wrecks
+    # a table row) - it stays database-only.
+    assert event['source_ip'] == '203.0.113.42'
+    assert 'user_agent' not in event
 
 
 def test_admin_audit_trail_excludes_its_own_reads_by_default(test_client: TestClient):

--- a/tests/integration/router_admin_test.py
+++ b/tests/integration/router_admin_test.py
@@ -1,4 +1,6 @@
 # pylint: disable=missing-module-docstring, missing-function-docstring
+from datetime import datetime, timezone
+
 from fastapi.testclient import TestClient
 
 from app.db.models import DbAdminAuditLog, DbFollow, DbFriendship, DbUser
@@ -159,6 +161,113 @@ def test_admin_search_pagination_and_total(test_client: TestClient, test_create_
     assert [u['id'] for u in second_page.json()['users']] == expected_ids[2:4]
 
 
+def test_admin_search_status_filter(test_client: TestClient, test_create_user):
+    disabled_user = test_create_user(test_client, user_count=1)[0]
+    db = test_client.test_db_session
+    disabled_user.disabled_at = datetime.now(timezone.utc)
+    db.commit()
+
+    active_resp = test_client.get(
+        '/v1/admin/users', headers=_admin(test_client), params={'status': 'active'}
+    )
+    assert active_resp.status_code == 200
+    active_ids = [u['id'] for u in active_resp.json()['users']]
+    assert disabled_user.id not in active_ids
+    assert test_client.first_user.id in active_ids
+
+    disabled_resp = test_client.get(
+        '/v1/admin/users', headers=_admin(test_client), params={'status': 'disabled'}
+    )
+    assert disabled_resp.status_code == 200
+    disabled_body = disabled_resp.json()
+    assert disabled_body['total'] == 1
+    assert [u['id'] for u in disabled_body['users']] == [disabled_user.id]
+    assert disabled_body['users'][0]['status'] == 'disabled'
+
+
+def test_admin_search_sort_by_joined(test_client: TestClient, test_create_user):
+    """
+    Sorting has to be corpus-wide, in SQL, not client-side on the loaded
+    page - a page of 2 sorted client-side would answer "oldest accounts
+    first" correctly for those 2 and silently wrong for everyone else.
+    Proven here by sorting ascending with a limit smaller than the corpus
+    and checking the returned page is still the true oldest-first prefix.
+    """
+    test_create_user(test_client, user_count=5)
+    db = test_client.test_db_session
+    expected_ids = [
+        user.id
+        for user in db.query(DbUser)
+        .order_by(DbUser.created_at.asc(), DbUser.pk.desc())
+        .all()
+    ]
+
+    resp = test_client.get(
+        '/v1/admin/users',
+        headers=_admin(test_client),
+        params={'sort': 'joined', 'direction': 'asc', 'limit': 3},
+    )
+    assert resp.status_code == 200
+    assert [u['id'] for u in resp.json()['users']] == expected_ids[:3]
+
+
+def test_admin_search_sort_by_status(test_client: TestClient, test_create_user):
+    disabled_user = test_create_user(test_client, user_count=1)[0]
+    db = test_client.test_db_session
+    disabled_user.disabled_at = datetime.now(timezone.utc)
+    db.commit()
+
+    resp = test_client.get(
+        '/v1/admin/users',
+        headers=_admin(test_client),
+        params={'sort': 'status', 'direction': 'desc'},
+    )
+    assert resp.status_code == 200
+    users = resp.json()['users']
+    # Disabled (1) sorts before active (0) under direction=desc.
+    assert users[0]['id'] == disabled_user.id
+    assert users[0]['status'] == 'disabled'
+
+
+def test_admin_search_sort_by_tracked_total(test_client: TestClient, test_create_user):
+    heavy_user, light_user = test_create_user(test_client, user_count=2)
+    _track(test_client, heavy_user.pk, 'movies', on_rankings=True, rank=1)
+    _track(test_client, heavy_user.pk, 'books', on_watchlist=True)
+    _track(test_client, light_user.pk, 'movies', on_watchlist=True)
+
+    resp = test_client.get(
+        '/v1/admin/users',
+        headers=_admin(test_client),
+        params={'sort': 'tracked_total', 'direction': 'desc', 'limit': 2},
+    )
+    assert resp.status_code == 200
+    users = resp.json()['users']
+    assert users[0]['id'] == heavy_user.id
+    assert users[0]['tracked_total'] == 2
+    assert users[1]['id'] == light_user.id
+    assert users[1]['tracked_total'] == 1
+
+
+def test_admin_search_sort_by_last_tracked(test_client: TestClient, test_create_user):
+    older_user, newer_user = test_create_user(test_client, user_count=2)
+    older_row = _track(test_client, older_user.pk, 'movies', on_watchlist=True)
+    newer_row = _track(test_client, newer_user.pk, 'movies', on_watchlist=True)
+    db = test_client.test_db_session
+    older_row.updated_at = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    newer_row.updated_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    db.commit()
+
+    resp = test_client.get(
+        '/v1/admin/users',
+        headers=_admin(test_client),
+        params={'sort': 'last_tracked', 'direction': 'desc', 'limit': 2},
+    )
+    assert resp.status_code == 200
+    users = resp.json()['users']
+    assert users[0]['id'] == newer_user.id
+    assert users[1]['id'] == older_user.id
+
+
 def test_admin_user_detail_aggregates(test_client: TestClient, test_create_user):
     friend, follower = test_create_user(test_client, user_count=2)
     target = test_client.first_user
@@ -299,6 +408,56 @@ def test_admin_audit_trail_lists_and_filters(test_client: TestClient):
     # a table row) - it stays database-only.
     assert event['source_ip'] == '203.0.113.42'
     assert 'user_agent' not in event
+
+
+def test_admin_audit_target_filter_accepts_a_handle(test_client: TestClient):
+    """
+    The console's audit table renders the TARGET column as a handle, so
+    the natural motion is to read one there and paste it into the filter.
+    Before this, that produced a confident "no events match" for a target
+    with 30 real rows (api#341 review) - only email/id resolved.
+    """
+    target = test_client.second_user
+    target.handle = 'audit-target-handle'
+    test_client.test_db_session.commit()
+    test_client.get(f'/v1/admin/users/{target.id}', headers=_admin(test_client))
+
+    resp = test_client.get(
+        '/v1/admin/audit',
+        headers=_admin(test_client),
+        params={'action': 'admin.user.view', 'target': 'audit-target-handle'},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body['total'] >= 1
+    assert body['events'][0]['target']['id'] == target.id
+
+
+def test_admin_audit_actor_and_target_filters_combine(test_client: TestClient):
+    """
+    Both filters join DbUser - via distinct aliases, since joining the same
+    unaliased table twice for one query is invalid SQL. Exercising both
+    together is what would have caught a regression to a bare (unaliased)
+    second join.
+    """
+    target = test_client.second_user
+    test_client.get(f'/v1/admin/users/{target.id}', headers=_admin(test_client))
+
+    resp = test_client.get(
+        '/v1/admin/audit',
+        headers=_admin(test_client),
+        params={
+            'actor': test_client.admin_user.handle,
+            'target': target.email,
+            'action': 'admin.user.view',
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body['total'] >= 1
+    event = body['events'][0]
+    assert event['actor']['id'] == test_client.admin_user.id
+    assert event['target']['id'] == target.id
 
 
 def test_admin_audit_trail_excludes_its_own_reads_by_default(test_client: TestClient):

--- a/tests/integration/router_user_test.py
+++ b/tests/integration/router_user_test.py
@@ -209,9 +209,10 @@ def test_api_user_cant_get_all_users(
     assert list_response.status_code == 403
     response_data = list_response.json()
     assert response_data['success'] is False
-    assert (
-        response_data['message'] == 'User does not have permission to view all users.'
-    )
+    # Routed through the shared require_admin dependency (#344) rather than
+    # its own bespoke message, so every admin-only route in the API answers
+    # a non-admin the same way.
+    assert response_data['message'] == 'Admin privileges required'
 
 
 def test_api_admin_update_user(

--- a/tests/integration/router_visibility_viewer_test.py
+++ b/tests/integration/router_visibility_viewer_test.py
@@ -122,12 +122,13 @@ def _fingerprint(response) -> tuple:
     Everything a caller can observe, minus what varies run to run.
 
     ``Server-Timing`` is a duration and ``Date`` a clock reading; both differ
-    between any two responses, including two identical ones.
+    between any two responses, including two identical ones. ``X-Request-Id``
+    (#344) is a fresh id minted per request for the same reason.
     """
     headers = {
         key: value
         for key, value in response.headers.items()
-        if key.lower() not in ('server-timing', 'date')
+        if key.lower() not in ('server-timing', 'date', 'x-request-id')
     }
     return response.status_code, response.json(), headers
 

--- a/tests/unit/seed_dev_test.py
+++ b/tests/unit/seed_dev_test.py
@@ -262,9 +262,9 @@ def test_seed_cast_creates_fixed_users_and_relationships(test_client):
     result = seed_dev._seed_cast(session, target)
     session.commit()
 
-    assert result['cast_users'] == 6
+    assert result['cast_users'] == 7
     # target 8 canon + friend 8 + follower 2 + followee 1 + public 3
-    # + private 6 + stranger 4 non-canon.
+    # + private 6 + stranger 4 non-canon + admin-two 0.
     assert result['ranked_rows'] == 32
 
     friend = _cast_user(session, 'friend@example.com')
@@ -301,6 +301,34 @@ def test_seed_cast_creates_fixed_users_and_relationships(test_client):
     assert public_user.visibility_profile == 'public'
     assert private_user.visibility_profile == 'private'
     assert stranger.visibility_profile == 'public'
+
+
+def test_seed_cast_admin_two_is_a_second_admin(test_client):
+    """
+    Dev otherwise seeds exactly one admin (the seed admin from
+    ADMIN_EMAIL), which made #341's "an admin cannot impersonate or
+    disable another admin" provable only by unit test - never
+    demonstrable in the console. admin-two exists to fix that; it has no
+    friend/follow relationship to the target and ranks nothing, unlike the
+    other six cast members.
+    """
+    session = test_client.test_db_session
+    target = test_client.first_user
+
+    seed_dev._seed_cast(session, target)
+    session.commit()
+
+    admin_two = _cast_user(session, 'admin-two@gmail.com')
+    assert admin_two.user_group == 'admin'
+    assert admin_two.handle == 'admin-two'
+    assert Hash.verify(admin_two.password, seed_dev._CAST_PASSWORD)
+    assert db_friendship.friendship_between(session, target.pk, admin_two.pk) is None
+    assert db_follow.find(session, admin_two.pk, target.pk) is None
+    assert db_follow.find(session, target.pk, admin_two.pk) is None
+    assert (
+        session.query(DbUserMovie).filter(DbUserMovie.user_id == admin_two.pk).count()
+        == 0
+    )
 
 
 def test_seed_cast_ranks_the_canon_movies(test_client):
@@ -406,12 +434,12 @@ def test_seed_cast_is_idempotent(test_client):
     second = seed_dev._seed_cast(session, target)
     session.commit()
 
-    assert second == {'cast_users': 6, 'ranked_rows': 0}
+    assert second == {'cast_users': 7, 'ranked_rows': 0}
     assert (
         session.query(DbUser)
         .filter(DbUser.email.in_([s['email'] for s in seed_dev._CAST_USERS]))
         .count()
-        == 6
+        == 7
     )
     assert session.query(DbFriendship).count() == 1
     assert session.query(DbFollow).count() == 2


### PR DESCRIPTION
## Summary

- The admin surface had exactly one primitive, `require_admin`, and nothing else: no admin router, no audit trail, no way to disable an account, no way to see the app as a user. This adds all four, plus the foundations the later reports work will sit on.
- **Directory and aggregates.** `GET /v1/admin/users` searches display name, handle and email with pagination, a total, sorting (joined, last tracked, tracked total, status) and a status filter. `GET /v1/admin/users/{uuid}` returns per-domain ranked/watchlist counts, the full visibility block and friend/follower counts. Sorting is correlated subqueries over the whole corpus, not the fetched page, so it cannot lie about rows it has not loaded.
- **Gating is router-level**, `dependencies=[Depends(require_admin)]`, not per-route. A route added here later cannot ship ungated by someone forgetting a decorator. The ad-hoc inline admin checks in `router/v1/user.py` are folded onto the same `is_admin()` predicate so there is one idiom instead of two.
- **Append-only audit trail** for every admin action, including denials, with actor, target (denormalized so the row survives the target's deletion), request id, method, path, status, and the real client IP via the existing `client_ip()` rather than the ingress proxy. `detail` is an allowlist, so a secret cannot reach a row by being added upstream.
- **Disable is enforced where it actually matters.** The check lives in both credential resolvers, not at sign-in: access JWTs are stateless with no jti, so a live one keeps working for its full TTL unless the resolver checks on every use. Disabling also revokes every refresh-token family and deletes every API key in one transaction, and per product decision D2 a disabled user disappears from public profiles, comparison, activity, friends, follows and search. Returns 403, not 401, so the web BFF does not loop on refresh.
- **Impersonation is read-only, with no override path.** The "act on their behalf" criterion was cut from #341 during planning, so the write block is a blanket denial rather than a gate with an escape hatch, which is a materially smaller thing to get right.
- **The identity swap sits inside `_user_from_access_token`, not `get_current_user`.** That placement is the security story: `get_current_session_user` is a second, independent decode path, and swapping one level up would leave it resolving an impersonation token's `sub` to the target with no impersonation context, reaching the self-delete branch of `DELETE /v1/users/{uuid}`. Sitting below the `drk_` branch also means an API key can never carry impersonation, which matters because keys share the Authorization header and the MCP server and crons hold long-lived ones.
- A dedicated short-lived JWT plus an `impersonation_sessions` row checked per request. **No refresh token is ever minted**, so expiry is a hard stop rather than a renewable alternate login. Sign-out ends live sessions. Every request re-checks that the acting admin is still an admin and not disabled, and that the target has not been promoted to admin.
- **What does not change:** no existing route's behavior, response shape or permissions, apart from `get_all_users` now returning the shared "Admin privileges required" message instead of a bespoke one. Impersonation is inert unless an admin explicitly starts a session.

## Test plan

- [x] `pytest` - **1040 passed, 0 failed**, up from 969 on main. New files: `tests/integration/router_admin_test.py` and `tests/integration/router_admin_impersonation_test.py`.
- [x] The case this design exists to prevent: an impersonation token cannot delete the target account via `DELETE /v1/users/{uuid}`, asserted directly rather than inferred.
- [x] Impersonation cannot mint or delete an API key, change an email or password, reach any `/v1/admin` route, or nest. An API key cannot impersonate. Admin-on-admin refused at mint and re-checked per request.
- [x] Disable: a token issued **before** the disable stops working immediately, fresh sign-in is refused, API keys and refresh tokens are dead, re-enable restores sign-in.
- [x] Migrations applied to real Postgres with existing data (23 users), including a full `downgrade`/`upgrade` round trip with no data loss. The suite runs on SQLite via `create_all`, so the migration path was verified separately against the dev database.
- [x] Verified against the local dev stack, not just tests: impersonated `private-user`, whose profile 404s for everyone else, and their private tier resolved while every write returned 403 and the token died the moment the session was stopped. Disable/enable driven end to end with a throwaway account. Audit rows confirmed to name the acting admin (not the impersonated victim) on a denied admin request, with `via_impersonation: true`.
- [x] Audit `target` filter verified to return the same 32 events for a handle and an email, having previously returned 0 for the handle its own column displays.
- [x] `pylint` 10.00/10, `black` clean, `openapi-spec-validator` clean, `openapi.json` regenerated.

## Checklist

- [x] Branch named `feat/…`, `fix/…`, or `chore/…`
- [x] New module has a test file in this PR (see CLAUDE.md, Testing)
- [x] Per-domain change checked against the other three domains (movies/TV/books/games): aggregates iterate the `SHELVES` registry with no per-shelf branching, and the detail test asserts all four
- [x] CI green (lint + tests)
- [x] No secrets committed
- [x] Docs updated: `docs/dev-cast.md` gains the second seeded admin, which is what makes "an admin cannot impersonate another admin" demonstrable rather than only unit-tested

## Notes for review

`openapi.json` carries a large diff. The committed file was stale independently of this work and predates the em dash scrub; regenerating it was the only way to give the web branch a correct spec to build against.

Deliberately out of scope, worth their own issues: no rate limiter on `/v1/admin/*`, so a looping non-admin can write unbounded audit rows into a table with no retention policy; `q` is not escaped for LIKE metacharacters, so `a_b` also matches `axb`; and the API-wide naive-datetime serialization is fixed only for the admin schemas here, not everywhere.

Closes #344. Closes #341.
