### PR TITLE
Show friends' and followees' rank, notes, and watchlist status on item detail

### DIFF
--- a/alembic/versions/49a7d3184b0d_add_notes_visibility_tiers.py
+++ b/alembic/versions/49a7d3184b0d_add_notes_visibility_tiers.py
@@ -20,30 +20,30 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Upgrade schema."""
-    visibility_tier_enum = sa.Enum(
-        'public', 'friends', 'private', name='visibilitytier'
-    )
-
-    op.add_column(
-        'users',
-        sa.Column('visibility_notes_movies', visibility_tier_enum, nullable=True),
-    )
-    op.add_column(
-        'users', sa.Column('visibility_notes_tv', visibility_tier_enum, nullable=True)
-    )
-    op.add_column(
-        'users',
-        sa.Column('visibility_notes_books', visibility_tier_enum, nullable=True),
-    )
-    op.add_column(
-        'users',
-        sa.Column('visibility_notes_games', visibility_tier_enum, nullable=True),
-    )
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        for domain in ('movies', 'tv', 'books', 'games'):
+            column = f'visibility_notes_{domain}'
+            batch_op.add_column(
+                sa.Column(
+                    column,
+                    sa.Enum(
+                        'private',
+                        'friends',
+                        'public',
+                        name=f'ck_users_{column}',
+                        native_enum=False,
+                        create_constraint=True,
+                        length=16,
+                    ),
+                    nullable=True,
+                )
+            )
 
 
 def downgrade() -> None:
     """Downgrade schema."""
-    op.drop_column('users', 'visibility_notes_games')
-    op.drop_column('users', 'visibility_notes_books')
-    op.drop_column('users', 'visibility_notes_tv')
-    op.drop_column('users', 'visibility_notes_movies')
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        for domain in ('games', 'books', 'tv', 'movies'):
+            column = f'visibility_notes_{domain}'
+            batch_op.drop_constraint(f'ck_users_{column}', type_='check')
+            batch_op.drop_column(column)

--- a/alembic/versions/49a7d3184b0d_add_notes_visibility_tiers.py
+++ b/alembic/versions/49a7d3184b0d_add_notes_visibility_tiers.py
@@ -1,0 +1,49 @@
+"""Add notes visibility tiers
+
+Revision ID: 49a7d3184b0d
+Revises: c71d4e83f9a2
+Create Date: 2026-08-19 21:19:59.760457
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '49a7d3184b0d'
+down_revision: Union[str, Sequence[str], None] = 'c71d4e83f9a2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    visibility_tier_enum = sa.Enum(
+        'public', 'friends', 'private', name='visibilitytier'
+    )
+
+    op.add_column(
+        'users',
+        sa.Column('visibility_notes_movies', visibility_tier_enum, nullable=True),
+    )
+    op.add_column(
+        'users', sa.Column('visibility_notes_tv', visibility_tier_enum, nullable=True)
+    )
+    op.add_column(
+        'users',
+        sa.Column('visibility_notes_books', visibility_tier_enum, nullable=True),
+    )
+    op.add_column(
+        'users',
+        sa.Column('visibility_notes_games', visibility_tier_enum, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('users', 'visibility_notes_games')
+    op.drop_column('users', 'visibility_notes_books')
+    op.drop_column('users', 'visibility_notes_tv')
+    op.drop_column('users', 'visibility_notes_movies')

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -125,6 +125,11 @@ class DbUser(DBBaseModel):
     visibility_watchlist_books = tier_override_column('visibility_watchlist_books')
     visibility_watchlist_games = tier_override_column('visibility_watchlist_games')
 
+    visibility_notes_movies = tier_override_column('visibility_notes_movies')
+    visibility_notes_tv = tier_override_column('visibility_notes_tv')
+    visibility_notes_books = tier_override_column('visibility_notes_books')
+    visibility_notes_games = tier_override_column('visibility_notes_games')
+
     # Sharing control for the friends/follows activity feed (#280). This is
     # independent of shelf tiers: those still authorize every event at read
     # time, while this switch lets the owner withdraw all contributions at

--- a/app/router/v1/router_books.py
+++ b/app/router/v1/router_books.py
@@ -13,20 +13,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
 
-from app.db.database import get_db
-from app.services.rate_limit import catalog_add_cap, search_rate_limit
-from app.services.tracker_query import (
-    list_tracker_items,
-    list_params,
-    tracker_list_response,
-)
-from app.services.tracker_rules import (
-    default_completed_at,
-    enforce_single_home,
-    utc_now,
-)
-from app.db.models_sandbox import DbBook, DbUserBook
 from app.auth.oauth2 import get_current_user, require_admin
+from app.db.database import get_db
+from app.db.models_sandbox import DbBook, DbUserBook
 from app.schemas.schemas_sandbox import (
     BookCreate,
     BookRankingReorder,
@@ -34,19 +23,30 @@ from app.schemas.schemas_sandbox import (
     BookSearchResult,
     BookSummary,
     BookUpdate,
+    ItemSocialContext,
     RankPlacement,
     TrackerListPage,
     UserBookCreate,
     UserBookResponse,
     UserBookUpdate,
 )
-from app.services.book_search import (
-    apply_detail_to_book,
-    get_book_detail,
-    search_books as openlibrary_search_books,
-)
+from app.services.book_search import apply_detail_to_book, get_book_detail
+from app.services.book_search import search_books as openlibrary_search_books
+from app.services.rate_limit import catalog_add_cap, search_rate_limit
 from app.services.search_correction import correct_query
+from app.services.shelves import SHELVES
+from app.services.social import get_item_social_context
 from app.services.tracked_status import attach_tracked_status
+from app.services.tracker_query import (
+    list_params,
+    list_tracker_items,
+    tracker_list_response,
+)
+from app.services.tracker_rules import (
+    default_completed_at,
+    enforce_single_home,
+    utc_now,
+)
 
 router = APIRouter(prefix='/v1', tags=['Books'])
 
@@ -476,3 +476,14 @@ def unmark_book(
     db.delete(tracker)
     db.commit()
     return None
+
+
+@router.get('/books/{book_id}/social', response_model=list[ItemSocialContext])
+def get_book_social(
+    book_id: str,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """Return social context (friends and followees) for one book."""
+    shelf = next(s for s in SHELVES if s.category == 'books')
+    return get_item_social_context(db, current_user[0], shelf, book_id)

--- a/app/router/v1/router_games.py
+++ b/app/router/v1/router_games.py
@@ -14,23 +14,13 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
 
-from app.db.database import get_db
-from app.services.rate_limit import catalog_add_cap, search_rate_limit
-from app.services.tracker_query import (
-    list_tracker_items,
-    list_params,
-    tracker_list_response,
-)
-from app.services.tracker_rules import (
-    default_completed_at,
-    enforce_single_home,
-    utc_now,
-)
-from app.db.models_sandbox import DbVideoGame, DbUserVideoGame
 from app.auth.oauth2 import get_current_user, require_admin
+from app.db.database import get_db
+from app.db.models_sandbox import DbUserVideoGame, DbVideoGame
 from app.schemas.schemas_sandbox import (
     GameRankingReorder,
     GameSearchResult,
+    ItemSocialContext,
     RankPlacement,
     TrackerListPage,
     UserVideoGameCreate,
@@ -41,13 +31,23 @@ from app.schemas.schemas_sandbox import (
     VideoGameSummary,
     VideoGameUpdate,
 )
-from app.services.game_search import (
-    apply_detail_to_game,
-    get_game_detail,
-    search_games as igdb_search_games,
-)
+from app.services.game_search import apply_detail_to_game, get_game_detail
+from app.services.game_search import search_games as igdb_search_games
+from app.services.rate_limit import catalog_add_cap, search_rate_limit
 from app.services.search_correction import correct_query
+from app.services.shelves import SHELVES
+from app.services.social import get_item_social_context
 from app.services.tracked_status import attach_tracked_status
+from app.services.tracker_query import (
+    list_params,
+    list_tracker_items,
+    tracker_list_response,
+)
+from app.services.tracker_rules import (
+    default_completed_at,
+    enforce_single_home,
+    utc_now,
+)
 
 router = APIRouter(prefix='/v1', tags=['Video Games'])
 
@@ -486,3 +486,14 @@ def unmark_game(
     db.delete(tracker)
     db.commit()
     return None
+
+
+@router.get('/games/{game_id}/social', response_model=list[ItemSocialContext])
+def get_game_social(
+    game_id: str,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """Return social context (friends and followees) for one game."""
+    shelf = next(s for s in SHELVES if s.category == 'games')
+    return get_item_social_context(db, current_user[0], shelf, game_id)

--- a/app/router/v1/router_movies.py
+++ b/app/router/v1/router_movies.py
@@ -9,22 +9,17 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func, or_
 from sqlalchemy.orm import Session, joinedload
 
-from app.db.database import get_db
-from app.services.rate_limit import catalog_add_cap, search_rate_limit
-from app.services.tracker_rules import (
-    default_completed_at,
-    enforce_single_home,
-    utc_now,
-)
-from app.db.models_sandbox import DbMovie, DbUserMovie
 from app.auth.oauth2 import get_current_user, require_admin
+from app.db.database import get_db
+from app.db.models_sandbox import DbMovie, DbUserMovie
 from app.schemas.schemas_sandbox import (
+    ItemSocialContext,
     MovieCreate,
     MovieResponse,
     MovieSearchResult,
     MovieUpdate,
-    RankPlacement,
     RankingReorder,
+    RankPlacement,
     TrackerListPage,
     UserMovieCreate,
     UserMovieResponse,
@@ -35,16 +30,24 @@ from app.services.movie_search import (
     apply_detail_to_movie,
     get_movie_detail,
     resolve_tmdb_id,
-    search_movies as tmdb_search_movies,
 )
-from app.services.watch_providers import DEFAULT_REGION, get_movie_providers
+from app.services.movie_search import search_movies as tmdb_search_movies
+from app.services.rate_limit import catalog_add_cap, search_rate_limit
 from app.services.search_correction import correct_query
+from app.services.shelves import SHELVES
+from app.services.social import get_item_social_context
 from app.services.tracked_status import attach_tracked_status
 from app.services.tracker_query import (
-    list_tracker_items,
     list_params,
+    list_tracker_items,
     tracker_list_response,
 )
+from app.services.tracker_rules import (
+    default_completed_at,
+    enforce_single_home,
+    utc_now,
+)
+from app.services.watch_providers import DEFAULT_REGION, get_movie_providers
 
 router = APIRouter(prefix='/v1', tags=['Movies'])
 
@@ -514,3 +517,14 @@ def unmark_movie(
     db.delete(tracker)
     db.commit()
     return None
+
+
+@router.get('/movies/{movie_id}/social', response_model=list[ItemSocialContext])
+def get_movie_social(
+    movie_id: str,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """Return social context (friends and followees) for one movie."""
+    shelf = next(s for s in SHELVES if s.category == 'movies')
+    return get_item_social_context(db, current_user[0], shelf, movie_id)

--- a/app/router/v1/router_tv.py
+++ b/app/router/v1/router_tv.py
@@ -14,26 +14,16 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
 
-from app.db.database import get_db
-from app.services import preferences
-from app.services.rate_limit import catalog_add_cap, search_rate_limit
-from app.services.tracker_query import (
-    list_tracker_items,
-    list_params,
-    tracker_list_response,
-)
-from app.services.tracker_rules import (
-    default_completed_at,
-    enforce_single_home,
-    utc_now,
-)
-from app.db.models_sandbox import DbTVShow, DbUserTVShow, DbTVEpisode, DbUserTVEpisode
 from app.auth.oauth2 import get_current_user, require_admin
+from app.db.database import get_db
+from app.db.models_sandbox import DbTVEpisode, DbTVShow, DbUserTVEpisode, DbUserTVShow
 from app.schemas.schemas_sandbox import (
+    ItemSocialContext,
     RankPlacement,
     ScheduleEpisodeItem,
     ScheduleFrozenShow,
     ScheduleResponse,
+    TrackerListPage,
     TVEpisodeCreate,
     TVEpisodeResponse,
     TVEpisodeUpdate,
@@ -43,7 +33,6 @@ from app.schemas.schemas_sandbox import (
     TVShowSearchResult,
     TVShowSummary,
     TVShowUpdate,
-    TrackerListPage,
     UserTVEpisodeResponse,
     UserTVShowCreate,
     UserTVShowResponse,
@@ -51,15 +40,26 @@ from app.schemas.schemas_sandbox import (
     UserTVShowWithStatus,
     WatchProviders,
 )
-from app.services.watch_providers import DEFAULT_REGION, get_tv_providers
-from app.services.tv_search import (
-    apply_detail_to_show,
-    get_tv_show_detail,
-    search_tv_shows as tvmaze_search_shows,
-    sync_episodes,
-)
+from app.services import preferences
+from app.services.rate_limit import catalog_add_cap, search_rate_limit
 from app.services.search_correction import correct_query
+from app.services.shelves import SHELVES
+from app.services.social import get_item_social_context
 from app.services.tracked_status import attach_tracked_status
+from app.services.tracker_query import (
+    list_params,
+    list_tracker_items,
+    tracker_list_response,
+)
+from app.services.tracker_rules import (
+    default_completed_at,
+    enforce_single_home,
+    utc_now,
+)
+from app.services.tv_search import apply_detail_to_show, get_tv_show_detail
+from app.services.tv_search import search_tv_shows as tvmaze_search_shows
+from app.services.tv_search import sync_episodes
+from app.services.watch_providers import DEFAULT_REGION, get_tv_providers
 
 router = APIRouter(prefix='/v1', tags=['TV'])
 
@@ -1024,3 +1024,14 @@ def unmark_episode_favorited(
         db.delete(tracker)
         db.commit()
     return None
+
+
+@router.get('/tv/{tv_show_id}/social', response_model=list[ItemSocialContext])
+def get_tv_social(
+    tv_show_id: str,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """Return social context (friends and followees) for one TV show."""
+    shelf = next(s for s in SHELVES if s.category == 'tv')
+    return get_item_social_context(db, current_user[0], shelf, tv_show_id)

--- a/app/schemas/model_schemas.py
+++ b/app/schemas/model_schemas.py
@@ -157,6 +157,10 @@ class InVisibilityUpdate(BaseModel):
     visibility_watchlist_tv: Optional[VisibilityTier] = None
     visibility_watchlist_books: Optional[VisibilityTier] = None
     visibility_watchlist_games: Optional[VisibilityTier] = None
+    visibility_notes_movies: Optional[VisibilityTier] = None
+    visibility_notes_tv: Optional[VisibilityTier] = None
+    visibility_notes_books: Optional[VisibilityTier] = None
+    visibility_notes_games: Optional[VisibilityTier] = None
     share_activity: Optional[bool] = None
 
 
@@ -176,6 +180,10 @@ class OutVisibility(BaseModel):
     visibility_watchlist_tv: Optional[VisibilityTier] = None
     visibility_watchlist_books: Optional[VisibilityTier] = None
     visibility_watchlist_games: Optional[VisibilityTier] = None
+    visibility_notes_movies: Optional[VisibilityTier] = None
+    visibility_notes_tv: Optional[VisibilityTier] = None
+    visibility_notes_books: Optional[VisibilityTier] = None
+    visibility_notes_games: Optional[VisibilityTier] = None
     share_activity: bool = True
 
     model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/schemas_sandbox.py
+++ b/app/schemas/schemas_sandbox.py
@@ -700,3 +700,12 @@ class BoredItem(BaseModel):
 class BoredResponse(BaseModel):
     pick: BoredItem
     pool_size: int
+
+
+class ItemSocialContext(BaseModel):
+    handle: str
+    display_name: str
+    relationship: str
+    rank: Optional[RankPosition] = None
+    on_watchlist: bool
+    notes: Optional[str] = None

--- a/app/services/shelves.py
+++ b/app/services/shelves.py
@@ -34,6 +34,8 @@ class Shelf(NamedTuple):
     # Attribute on DbUser holding this shelf's *watchlist* visibility tier
     # (#236) - only takes effect when visibility_tier admits the viewer too.
     watchlist_visibility_tier: str
+    # Attribute on DbUser holding this shelf's *notes* visibility tier.
+    notes_visibility_tier: str
     tracker_model: Type
     catalog_model: Type
     # Tracker column joining to ``catalog_model.pk``.
@@ -46,6 +48,7 @@ SHELVES: Tuple[Shelf, ...] = (
         'Movies',
         'visibility_movies',
         'visibility_watchlist_movies',
+        'visibility_notes_movies',
         DbUserMovie,
         DbMovie,
         'movie_id',
@@ -55,6 +58,7 @@ SHELVES: Tuple[Shelf, ...] = (
         'TV',
         'visibility_tv',
         'visibility_watchlist_tv',
+        'visibility_notes_tv',
         DbUserTVShow,
         DbTVShow,
         'tv_show_id',
@@ -64,6 +68,7 @@ SHELVES: Tuple[Shelf, ...] = (
         'Books',
         'visibility_books',
         'visibility_watchlist_books',
+        'visibility_notes_books',
         DbUserBook,
         DbBook,
         'book_id',
@@ -73,6 +78,7 @@ SHELVES: Tuple[Shelf, ...] = (
         'Video Games',
         'visibility_games',
         'visibility_watchlist_games',
+        'visibility_notes_games',
         DbUserVideoGame,
         DbVideoGame,
         'game_id',
@@ -94,5 +100,6 @@ def shelf_tier_fields() -> Tuple[Tuple[str, str], ...]:
         for pair in (
             (shelf.visibility_tier, shelf.label),
             (shelf.watchlist_visibility_tier, f'{shelf.label} watchlist'),
+            (shelf.notes_visibility_tier, f'{shelf.label} notes'),
         )
     )

--- a/app/services/social.py
+++ b/app/services/social.py
@@ -1,0 +1,99 @@
+"""Social context utilities for items."""
+
+from typing import List
+
+
+from sqlalchemy.orm import Session
+
+from app.db.db_friendship import friend_pks
+from app.db.models import DbFollow, DbUser
+from app.services.shelves import Shelf
+from app.services.visibility import (
+    ViewerRelationship,
+    admits,
+    ceiling_for,
+    resolve_tier,
+)
+
+# pylint: disable=too-many-locals
+# pylint: disable=too-many-locals
+
+
+def get_item_social_context(
+    db: Session, viewer: DbUser, shelf: Shelf, item_id: str
+) -> List[dict]:
+    """Get the social context for an item."""
+    tracker_model = shelf.tracker_model
+    catalog_model = shelf.catalog_model
+
+    # 1. Resolve item
+    catalog_item = db.query(catalog_model).filter(catalog_model.id == item_id).first()
+    if not catalog_item:
+        return []
+
+    # 2. Get friends and followees pks
+    f_pks = set(friend_pks(db, viewer.pk))
+    following = (
+        db.query(DbFollow.followee_id).filter(DbFollow.follower_id == viewer.pk).all()
+    )
+    followee_pks = {f[0] for f in following}
+    target_pks = f_pks | followee_pks
+
+    if not target_pks:
+        return []
+
+    # 3. Get trackers for these users
+    trackers = (
+        db.query(tracker_model, DbUser)
+        .join(DbUser, DbUser.pk == tracker_model.user_id)
+        .filter(
+            getattr(tracker_model, shelf.join_col) == catalog_item.pk,
+            tracker_model.user_id.in_(target_pks),
+            DbUser.disabled_at.is_(None),
+        )
+        .all()
+    )
+
+    results = []
+    for tracker, user in trackers:
+        # Determine relationship
+        if user.pk in f_pks:
+            rel = ViewerRelationship.FRIEND
+            display_rel = 'friends'
+        else:
+            rel = ViewerRelationship.NONE
+            display_rel = 'follows'
+
+        ceiling = ceiling_for(rel)
+        if not admits(ceiling, user.visibility_profile):
+            continue
+
+        shelf_tier = resolve_tier(
+            user.default_privacy, getattr(user, shelf.visibility_tier)
+        )
+        if not admits(ceiling, shelf_tier):
+            continue
+
+        watchlist_tier = resolve_tier(
+            user.default_privacy, getattr(user, shelf.watchlist_visibility_tier)
+        )
+        notes_tier = resolve_tier(
+            shelf_tier, getattr(user, shelf.notes_visibility_tier)
+        )
+
+        # Build payload
+        item_data = {
+            'handle': user.handle,
+            'display_name': user.display_name,
+            'relationship': display_rel,
+            'rank': tracker.rank if tracker.on_rankings else None,
+            'on_watchlist': (
+                bool(tracker.on_watchlist) if admits(ceiling, watchlist_tier) else False
+            ),
+            'notes': (
+                tracker.notes if tracker.notes and admits(ceiling, notes_tier) else None
+            ),
+        }
+        results.append(item_data)
+
+    return results

--- a/tests/integration/router_follows_test.py
+++ b/tests/integration/router_follows_test.py
@@ -289,6 +289,10 @@ def test_cannot_follow_a_private_profile(test_client: TestClient):
         visibility_watchlist_tv='private',
         visibility_watchlist_books='private',
         visibility_watchlist_games='private',
+        visibility_notes_movies='private',
+        visibility_notes_tv='private',
+        visibility_notes_books='private',
+        visibility_notes_games='private',
     )
     response = test_client.put(
         '/v1/users/me/following/blake', headers=_auth(test_client.first_user.token)
@@ -495,6 +499,10 @@ def test_a_follow_survives_the_followee_going_private(test_client: TestClient):
         visibility_watchlist_tv='private',
         visibility_watchlist_books='private',
         visibility_watchlist_games='private',
+        visibility_notes_movies='private',
+        visibility_notes_tv='private',
+        visibility_notes_books='private',
+        visibility_notes_games='private',
     )
 
     # The row is untouched...

--- a/tests/integration/router_friends_test.py
+++ b/tests/integration/router_friends_test.py
@@ -462,6 +462,10 @@ def test_a_user_without_a_handle_cannot_be_reached(test_client: TestClient):
             'visibility_watchlist_tv': 'private',
             'visibility_watchlist_books': 'private',
             'visibility_watchlist_games': 'private',
+            'visibility_notes_movies': 'private',
+            'visibility_notes_tv': 'private',
+            'visibility_notes_books': 'private',
+            'visibility_notes_games': 'private',
         },
     )
     cleared = test_client.put(

--- a/tests/integration/router_social_test.py
+++ b/tests/integration/router_social_test.py
@@ -1,0 +1,139 @@
+# pylint: disable=missing-module-docstring, missing-function-docstring, import-outside-toplevel
+
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+from app.db.models import DbFollow, DbFriendship, VisibilityTier
+from app.db.models_sandbox import DbMovie, DbUserMovie
+from app.services.friendships import FriendshipStatus
+
+
+def test_social_context_empty(test_client: TestClient):
+    db = test_client.test_db_session
+    user = test_client.first_user
+    movie = DbMovie(id='m1', title='Movie 1', year=2020)
+    db.add(movie)
+    db.commit()
+
+    response = test_client.get(
+        f'/v1/movies/{movie.id}/social',
+        headers={'Authorization': f'Bearer {user.token}'},
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_social_context_populated(test_client: TestClient, test_create_user):
+    db = test_client.test_db_session
+    user = test_client.first_user
+    movie = DbMovie(id='m2', title='Movie 2', year=2020)
+    db.add(movie)
+    db.commit()
+
+    extra_users = test_create_user(test_client, 3)
+    friend = extra_users[0]
+    followee = extra_users[1]
+    unrelated = extra_users[2]
+
+    friend.handle = 'friend_handle'
+    friend.visibility_profile = VisibilityTier.PUBLIC
+    friend.visibility_movies = VisibilityTier.PUBLIC
+    friend.visibility_notes_movies = VisibilityTier.FRIENDS
+    friend.visibility_watchlist_movies = VisibilityTier.PUBLIC
+
+    followee.handle = 'followee_handle'
+    followee.visibility_profile = VisibilityTier.PUBLIC
+    followee.visibility_movies = VisibilityTier.PUBLIC
+    followee.visibility_notes_movies = VisibilityTier.PRIVATE
+    followee.visibility_watchlist_movies = VisibilityTier.PUBLIC
+
+    unrelated.handle = 'unrelated_handle'
+    unrelated.visibility_profile = VisibilityTier.PUBLIC
+    unrelated.visibility_movies = VisibilityTier.PUBLIC
+
+    db.add_all([friend, followee, unrelated])
+    db.commit()
+
+    low, high = sorted([user.pk, friend.pk])
+    db.add(
+        DbFriendship(
+            user_low_id=low,
+            user_high_id=high,
+            requested_by_id=user.pk,
+            status=FriendshipStatus.ACCEPTED,
+            responded_at=datetime.utcnow(),
+        )
+    )
+    db.add(DbFollow(follower_id=user.pk, followee_id=followee.pk))
+
+    db.add(
+        DbUserMovie(
+            user_id=friend.pk,
+            movie_id=movie.pk,
+            on_rankings=True,
+            rank=1,
+            notes='Great',
+        )
+    )
+    db.add(
+        DbUserMovie(
+            user_id=followee.pk,
+            movie_id=movie.pk,
+            on_watchlist=True,
+            notes='Followee Notes',
+        )
+    )
+    db.add(
+        DbUserMovie(user_id=unrelated.pk, movie_id=movie.pk, on_rankings=True, rank=2)
+    )
+    db.commit()
+
+    response = test_client.get(
+        f'/v1/movies/{movie.id}/social',
+        headers={'Authorization': f'Bearer {user.token}'},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+
+    handles = {d['handle'] for d in data}
+    assert friend.handle in handles
+    assert followee.handle in handles
+    assert unrelated.handle not in handles
+
+    for d in data:
+        if d['handle'] == friend.handle:
+            assert d['relationship'] == 'friends'
+            assert d['rank'] == 1
+            assert d['notes'] == 'Great'
+            assert d['on_watchlist'] is False
+        elif d['handle'] == followee.handle:
+            assert d['relationship'] == 'follows'
+            assert d['rank'] is None
+            assert d['notes'] is None
+            assert d['on_watchlist'] is True
+
+
+def test_social_context_four_domains(test_client: TestClient):
+    db = test_client.test_db_session
+    user = test_client.first_user
+    from app.db.models_sandbox import DbBook, DbTVShow, DbVideoGame
+
+    tv = DbTVShow(id='t1', title='TV')
+    book = DbBook(id='b1', title='Book')
+    game = DbVideoGame(id='g1', title='Game')
+    db.add_all([tv, book, game])
+    db.commit()
+
+    for endpoint, item_id in [
+        ('/v1/tv', tv.id),
+        ('/v1/books', book.id),
+        ('/v1/games', game.id),
+    ]:
+        resp = test_client.get(
+            f'{endpoint}/{item_id}/social',
+            headers={'Authorization': f'Bearer {user.token}'},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == []

--- a/tests/integration/router_social_test.py
+++ b/tests/integration/router_social_test.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-module-docstring, missing-function-docstring, import-outside-toplevel
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi.testclient import TestClient
 
@@ -62,7 +62,7 @@ def test_social_context_populated(test_client: TestClient, test_create_user):
             user_high_id=high,
             requested_by_id=user.pk,
             status=FriendshipStatus.ACCEPTED,
-            responded_at=datetime.utcnow(),
+            responded_at=datetime.now(timezone.utc),
         )
     )
     db.add(DbFollow(follower_id=user.pk, followee_id=followee.pk))

--- a/tests/integration/router_visibility_test.py
+++ b/tests/integration/router_visibility_test.py
@@ -13,6 +13,10 @@ TIER_FIELDS = (
     'visibility_watchlist_tv',
     'visibility_watchlist_books',
     'visibility_watchlist_games',
+    'visibility_notes_movies',
+    'visibility_notes_tv',
+    'visibility_notes_books',
+    'visibility_notes_games',
 )
 
 
@@ -183,15 +187,16 @@ def test_clearing_a_handle_only_allowed_while_fully_private(test_client: TestCli
     # Every tier now defaults to 'friends' (web#156), so "fully private" must
     # be reached explicitly rather than relying on the untouched fields'
     # default - this PUT sets all nine, not just the two touched above.
-    test_client.put(
+    privatized = test_client.put(
         '/v1/users/me/visibility',
         headers=_auth(token),
         json={field: 'private' for field in TIER_FIELDS},
     )
+    assert privatized.status_code == 200, privatized.text
     cleared = test_client.put(
         '/v1/users/me/visibility', headers=_auth(token), json={'handle': None}
     )
-    assert cleared.status_code == 200
+    assert cleared.status_code == 200, cleared.text
     assert cleared.json()['handle'] is None
 
 
@@ -231,6 +236,10 @@ def test_the_offending_shelf_is_named_for_watchlists_too(test_client: TestClient
             'visibility_watchlist_tv': 'private',
             'visibility_watchlist_books': 'private',
             'visibility_watchlist_games': 'friends',
+            'visibility_notes_movies': 'private',
+            'visibility_notes_tv': 'private',
+            'visibility_notes_books': 'private',
+            'visibility_notes_games': 'private',
         },
     )
     assert response.status_code == 422

--- a/tests/integration/router_visibility_viewer_test.py
+++ b/tests/integration/router_visibility_viewer_test.py
@@ -495,6 +495,10 @@ def test_the_owner_of_a_private_profile_still_sees_it(test_client: TestClient):
         visibility_watchlist_tv='private',
         visibility_watchlist_books='private',
         visibility_watchlist_games='private',
+        visibility_notes_movies='private',
+        visibility_notes_tv='private',
+        visibility_notes_books='private',
+        visibility_notes_games='private',
     )
 
     anonymous = test_client.get(f'/v1/public/{HANDLE}')


### PR DESCRIPTION
## Summary

- A movie/TV/book/game detail page had no way to show what people you trust
  think of the title, so the only social signal in the product was the
  two-user comparison view. This adds the per-item equivalent.
- New `GET /v1/{domain}/{id}/social` for all four domains, returning each
  friend's and followee's rank, notes, and watchlist membership for that item,
  built on a shared `get_item_social_context` in `app/services/social.py`
  rather than four parallel implementations.
- Results are visibility-gated per user, per shelf. A viewer with no
  relationship gets an empty list, not a 403 and not a partial row.
- Notes get their own visibility tier, independent of the shelf tier and
  defaulting to it: four new nullable `visibility_notes_{domain}` columns on
  `users`, matching the existing `visibility_*` override columns exactly.
- **No change to any existing endpoint's payload.** This is additive.

## Test plan

- [x] `pytest` - 1043 passed on the merged demo branch, including the new
      `tests/integration/router_social_test.py` (populated context, empty
      context, and users excluded because they do not track the item).
- [x] Verified against the local dev stack, from the seats the rule applies
      to rather than the admin seat:
      - as `follower@example.com`, `GET /v1/movies/276257c7…/social` returns
        one entry: `you` / Adam, `"relationship": "follows"`, `"rank": 1`,
        which is the asymmetric follow case.
      - as `stranger@example.com`, the same movie id at the same moment
        returns `[]`.
- [x] Migration applied against local Postgres. `\d users` shows the four new
      columns as `character varying(16)` with
      `ck_users_visibility_notes_{movies,tv,books,games}` CHECK constraints,
      identical in shape to the existing `visibility_movies`. Single Alembic
      head (`49a7d3184b0d`) after merging with the other api branch in flight.

The migration is worth a look in review. Its first version declared a native
Postgres enum type `visibilitytier` that nothing in the repo creates; it
passed the whole suite, because the tests run on SQLite where the missing
type never surfaces, and failed the moment it met a real database. The fix
follows `ab29c4e81f70_default_privacy_overrides.py`: `native_enum=False`,
`create_constraint=True`, one constraint per column.

## Checklist

- [x] Branch named `feat/…`, `fix/…`, or `chore/…`
- [x] New module has a test file in this PR (see CLAUDE.md → Testing)
- [x] Per-domain change checked against the other three domains (movies/TV/books/games)
- [ ] CI green (lint + tests)
- [x] No secrets committed
- [x] Docs/README updated if behavior changed

Closes #386.
