### PR TITLE
Add outgoing friend-request state to profile and comparison payloads

### DIFF
--- a/app/router/v1/router_comparison.py
+++ b/app/router/v1/router_comparison.py
@@ -74,7 +74,7 @@ def compare_with_user(
     """Return the four domain comparisons visible to this viewer."""
     viewer = current_user[0]
     target, relationship, ceiling = _target_access(db, viewer, handle)
-    friend_request_state = outgoing_friend_request_state(
+    friend_request_state, outgoing_request_id = outgoing_friend_request_state(
         db, target, viewer, relationship
     )
     return {
@@ -82,6 +82,7 @@ def compare_with_user(
         'display_name': target.display_name,
         'relationship': relationship.value,
         'friend_request_state': friend_request_state,
+        'outgoing_request_id': outgoing_request_id,
         'domains': [
             compare_shelf(db, viewer, target, shelf, ceiling) for shelf in SHELVES
         ],

--- a/app/router/v1/router_visibility.py
+++ b/app/router/v1/router_visibility.py
@@ -503,7 +503,9 @@ def public_profile(  # pylint: disable=too-many-arguments, too-many-positional-a
         relationship is ViewerRelationship.NONE
         or relationship is ViewerRelationship.FRIEND
     ) and is_following(db, viewer.pk, user.pk)
-    friend_request_state = outgoing_friend_request_state(db, user, viewer, relationship)
+    friend_request_state, outgoing_request_id = outgoing_friend_request_state(
+        db, user, viewer, relationship
+    )
 
     payload = {
         'handle': user.handle,
@@ -512,6 +514,7 @@ def public_profile(  # pylint: disable=too-many-arguments, too-many-positional-a
             'relationship': relationship.value,
             'following': following,
             'friend_request_state': friend_request_state,
+            'outgoing_request_id': outgoing_request_id,
         },
         'shelves': shelves,
         'total_ranked': sum(s['ranked_count'] for s in shelves),

--- a/app/services/profile_access.py
+++ b/app/services/profile_access.py
@@ -1,6 +1,6 @@
 """Relationship resolution shared by viewer-aware profile surfaces."""
 
-from typing import Optional
+from typing import Optional, Tuple
 
 from sqlalchemy.orm import Session
 
@@ -28,17 +28,20 @@ def outgoing_friend_request_state(
     owner: DbUser,
     viewer: Optional[DbUser],
     relationship: ViewerRelationship,
-) -> str:
-    """The request state the viewer's friend button should render."""
+) -> Tuple[str, Optional[str]]:
+    """
+    The request state the viewer's friend button should render,
+    and the id of the viewer's pending outgoing request if there is one.
+    """
     if relationship is ViewerRelationship.FRIEND:
-        return 'friends'
+        return 'friends', None
     if viewer is None or relationship is not ViewerRelationship.NONE:
-        return 'none'
+        return 'none', None
     friendship = friendship_between(db, viewer.pk, owner.pk)
     if (
         friendship is not None
         and friendship.status is FriendshipStatus.PENDING
         and friendship.requested_by_id == viewer.pk
     ):
-        return 'pending'
-    return 'none'
+        return 'pending', friendship.id
+    return 'none', None

--- a/tests/integration/router_comparison_test.py
+++ b/tests/integration/router_comparison_test.py
@@ -145,6 +145,12 @@ def test_comparison_reports_a_viewers_outgoing_pending_request(test_client: Test
     )
     assert sent.status_code == 202, sent.text
 
+    requests = test_client.get(
+        '/v1/users/me/friends/requests',
+        headers=_auth(test_client.second_user.token),
+    )
+    req_id = requests.json()['outgoing'][0]['id']
+
     response = test_client.get(
         '/v1/users/me/comparison/brandon',
         headers=_auth(test_client.second_user.token),
@@ -152,6 +158,7 @@ def test_comparison_reports_a_viewers_outgoing_pending_request(test_client: Test
     assert response.status_code == 200, response.text
     assert response.json()['relationship'] == 'none'
     assert response.json()['friend_request_state'] == 'pending'
+    assert response.json()['outgoing_request_id'] == req_id
 
 
 def test_private_profile_and_unknown_handle_are_the_same_404(test_client: TestClient):

--- a/tests/integration/router_follows_test.py
+++ b/tests/integration/router_follows_test.py
@@ -416,16 +416,19 @@ def test_a_follower_sees_exactly_what_a_stranger_sees(
         'relationship': 'none',
         'following': True,
         'friend_request_state': 'none',
+        'outgoing_request_id': None,
     }
     assert stranger_view.json()['viewer'] == {
         'relationship': 'none',
         'following': False,
         'friend_request_state': 'none',
+        'outgoing_request_id': None,
     }
     assert anonymous_view.json()['viewer'] == {
         'relationship': 'anonymous',
         'following': False,
         'friend_request_state': 'none',
+        'outgoing_request_id': None,
     }
 
     # The friends-only shelf and its content never reach any of the three.

--- a/tests/integration/router_visibility_viewer_test.py
+++ b/tests/integration/router_visibility_viewer_test.py
@@ -172,6 +172,7 @@ def test_anonymous_sees_only_public_shelves(profile: TestClient):
         'relationship': 'anonymous',
         'following': False,
         'friend_request_state': 'none',
+        'outgoing_request_id': None,
     }
 
 
@@ -185,6 +186,7 @@ def test_a_friend_additionally_sees_friends_shelves(profile: TestClient):
         'relationship': 'friend',
         'following': False,
         'friend_request_state': 'friends',
+        'outgoing_request_id': None,
     }
 
 
@@ -198,6 +200,7 @@ def test_a_non_friend_gets_the_anonymous_response(profile: TestClient, stranger_
         'relationship': 'none',
         'following': False,
         'friend_request_state': 'none',
+        'outgoing_request_id': None,
     }
     assert {k: v for k, v in stranger.items() if k != 'viewer'} == {
         k: v for k, v in anonymous.items() if k != 'viewer'
@@ -214,6 +217,7 @@ def test_the_owner_sees_every_shelf_including_private(profile: TestClient):
         'relationship': 'self',
         'following': False,
         'friend_request_state': 'none',
+        'outgoing_request_id': None,
     }
 
 
@@ -379,6 +383,7 @@ def test_nothing_visible_returns_200_when_profile_tier_admits_you(
         'relationship': 'friend',
         'following': False,
         'friend_request_state': 'friends',
+        'outgoing_request_id': None,
     }
 
     # Querying a specific unadmitted shelf still returns 404.
@@ -428,12 +433,19 @@ def test_profile_reports_a_viewers_outgoing_pending_request(test_client: TestCli
     )
     assert sent.status_code == 202, sent.text
 
+    requests = test_client.get(
+        '/v1/users/me/friends/requests',
+        headers=_auth(viewer_token),
+    )
+    req_id = requests.json()['outgoing'][0]['id']
+
     response = test_client.get(f'/v1/public/{HANDLE}', headers=_auth(viewer_token))
     assert response.status_code == 200, response.text
     assert response.json()['viewer'] == {
         'relationship': 'none',
         'following': False,
         'friend_request_state': 'pending',
+        'outgoing_request_id': req_id,
     }
 
 
@@ -493,6 +505,7 @@ def test_the_owner_of_a_private_profile_still_sees_it(test_client: TestClient):
         'relationship': 'self',
         'following': False,
         'friend_request_state': 'none',
+        'outgoing_request_id': None,
     }
 
 
@@ -515,6 +528,7 @@ def test_bad_credentials_are_rejected_rather_than_ignored(profile: TestClient, t
             'relationship': 'anonymous',
             'following': False,
             'friend_request_state': 'none',
+            'outgoing_request_id': None,
         }
     else:
         assert response.status_code == 401


### PR DESCRIPTION
## Summary

- A profile or comparison page could not tell whether the viewer already had
  a friend request pending, so `FriendRequestButton` had to discover it from
  the browser after the server had already rendered the page.
- Adds `viewer.friend_request_state` (`friends` / `pending` / `none`) and
  `viewer.outgoing_request_id` to the public profile payload, and the same two
  fields at the root of the comparison payload.
- Both are computed by `outgoing_friend_request_state` *after* every access
  decision has been made, so neither can widen what a caller is served. A
  viewer who may not know a request exists does not receive its id.
- The id, not just the status, is the point: cancelling calls
  `DELETE /v1/users/me/friends/requests/{id}` and has to name the request.
  It is `friendship.id`, the same value `_out_request` already returns from
  the pending-requests list.
- **No change to any existing field.** Additive only.
- Consumed by ALeonard9/druthers-web#241, which deletes the client-side
  fetch this replaces.

## Test plan

- [x] `pytest` - 1043 passed on the merged demo branch. New cases in
      `router_visibility_viewer_test.py` and `router_comparison_test.py`
      assert the id is present and correct for a viewer with a pending
      outgoing request, `None` when there is none, and withheld from viewers
      the existing gating already withholds `friend_request_state` from.
- [x] Verified against the local dev stack as `follower@example.com`:
      `GET /v1/public/public-user` returned
      `{'relationship': 'none', 'following': False,
      'friend_request_state': 'none', 'outgoing_request_id': None}`; after
      sending a request, the same call returned `'pending'` with
      `'outgoing_request_id': 'cc6ba2ed-7850-49d5-9b64-881d460bf069'`.
      `GET /v1/users/me/comparison/public-user` returned the identical id at
      its root.
- [x] Verified in the browser that web#241 renders from these fields with no
      fetch on mount.

Note for review: an earlier version of this work reached `main` inside
PR #387, which listed six unrelated issues in its `Closes` line and closed
this issue without implementing the id. This branch was rebased onto that
main; git dropped the duplicated commit as "already upstream", so the diff
here is only the id.

## Checklist

- [x] Branch named `feat/…`, `fix/…`, or `chore/…`
- [x] New module has a test file in this PR (see CLAUDE.md → Testing)
- [x] Per-domain change checked against the other three domains (movies/TV/books/games)
- [ ] CI green (lint + tests)
- [x] No secrets committed
- [x] Docs/README updated if behavior changed

Closes #357.
