### PR TITLE
Add admin reports and stats

### DIFF
--- a/alembic/versions/f342a9b7c1d0_product_events.py
+++ b/alembic/versions/f342a9b7c1d0_product_events.py
@@ -11,7 +11,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision: str = 'f342a9b7c1d0'
-down_revision: Union[str, Sequence[str], None] = 'c71d4e83f9a2'
+down_revision: Union[str, Sequence[str], None] = '49a7d3184b0d'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/f342a9b7c1d0_product_events.py
+++ b/alembic/versions/f342a9b7c1d0_product_events.py
@@ -1,0 +1,62 @@
+"""Add privacy-minimal product event instrumentation.
+
+Revision ID: f342a9b7c1d0
+Revises: c71d4e83f9a2
+Create Date: 2026-08-20 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'f342a9b7c1d0'
+down_revision: Union[str, Sequence[str], None] = 'c71d4e83f9a2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'product_events',
+        sa.Column('pk', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('id', sa.String(), nullable=True),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('event_type', sa.String(length=64), nullable=False),
+        sa.Column('payload', sa.JSON(), nullable=False),
+        sa.Column('occurred_at', sa.DateTime(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['users.pk'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('pk'),
+    )
+    op.create_index(
+        op.f('ix_product_events_pk'), 'product_events', ['pk'], unique=False
+    )
+    op.create_index(op.f('ix_product_events_id'), 'product_events', ['id'], unique=True)
+    op.create_index(
+        op.f('ix_product_events_user_id'), 'product_events', ['user_id'], unique=False
+    )
+    op.create_index(
+        op.f('ix_product_events_event_type'),
+        'product_events',
+        ['event_type'],
+        unique=False,
+    )
+    op.create_index(
+        op.f('ix_product_events_occurred_at'),
+        'product_events',
+        ['occurred_at'],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_product_events_occurred_at'), table_name='product_events')
+    op.drop_index(op.f('ix_product_events_event_type'), table_name='product_events')
+    op.drop_index(op.f('ix_product_events_user_id'), table_name='product_events')
+    op.drop_index(op.f('ix_product_events_id'), table_name='product_events')
+    op.drop_index(op.f('ix_product_events_pk'), table_name='product_events')
+    op.drop_table('product_events')

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -246,6 +246,31 @@ class DbApiKey(DBBaseModel):
     )
 
 
+class DbProductEvent(DBBaseModel):
+    """Privacy-minimal product instrumentation used by admin reports (#342)."""
+
+    __tablename__ = 'product_events'
+
+    user_id = Column(
+        Integer,
+        ForeignKey('users.pk', ondelete='CASCADE'),
+        nullable=False,
+        index=True,
+    )
+    event_type = Column(String(length=64), nullable=False, index=True)
+    payload = Column(JSON, nullable=False, default=dict)
+    occurred_at = Column(
+        DateTime,
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        index=True,
+    )
+
+    user = relationship(
+        'DbUser', backref=backref('product_events', cascade='all, delete-orphan')
+    )
+
+
 class DbRefreshToken(DBBaseModel):
     """
     Long-lived, revocable browser-session credential (#246).

--- a/app/router/v1/router_admin.py
+++ b/app/router/v1/router_admin.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-function-docstring
+# pylint: disable=missing-function-docstring, too-many-lines
 """
 Admin user directory (#344): search, per-user aggregates, and the audit
 trail those actions leave.
@@ -14,11 +14,14 @@ request, so it costs no extra query.
 Impersonation and reports are later increments - not built here.
 """
 
-from datetime import datetime, timedelta, timezone
+import csv
+import io
+from collections import Counter, defaultdict
+from datetime import date, datetime, timedelta, timezone
 from functools import reduce
 from typing import Literal, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from sqlalchemy import and_, case, func, or_, select
 from sqlalchemy.orm import Session, aliased
 
@@ -38,6 +41,7 @@ from app.db.models import (
     DbAdminAuditLog,
     DbApiKey,
     DbImpersonationSession,
+    DbProductEvent,
     DbUser,
 )
 from app.schemas.schemas_admin import (
@@ -52,6 +56,7 @@ from app.schemas.schemas_admin import (
     OutAdminUserListResponse,
     OutAdminUserSummary,
     OutAdminVisibility,
+    OutAdminReportResponse,
     OutImpersonationLiveSession,
     OutImpersonationParty,
     OutImpersonationSession,
@@ -69,6 +74,19 @@ router = APIRouter(
 
 MAX_PAGE_SIZE = 200
 DEFAULT_PAGE_SIZE = 50
+
+REPORT_NAMES = (
+    'signups',
+    'active_users',
+    'tracking_volume',
+    'top_titles',
+    'top_users',
+    'engagement_by_tier',
+    'activation',
+    'retention',
+    'conversion',
+)
+FUNNEL_REPORTS = {'activation', 'retention', 'conversion'}
 
 
 def _clamp_page(limit: int, offset: int) -> tuple[int, int]:
@@ -616,6 +634,321 @@ def list_audit(  # pylint: disable=too-many-arguments, too-many-positional-argum
             for row in rows
         ],
     )
+
+
+def _as_date(value: datetime) -> date:
+    return value.date()
+
+
+def _period(value: date, bucket: str) -> date:
+    if bucket == 'week':
+        return value - timedelta(days=value.weekday())
+    if bucket == 'month':
+        return value.replace(day=1)
+    return value
+
+
+def _periods(start: date, end: date, bucket: str) -> list[date]:
+    periods = []
+    current = _period(start, bucket)
+    last = _period(end, bucket)
+    while current <= last:
+        periods.append(current)
+        if bucket == 'day':
+            current += timedelta(days=1)
+        elif bucket == 'week':
+            current += timedelta(days=7)
+        elif current.month == 12:
+            current = current.replace(year=current.year + 1, month=1)
+        else:
+            current = current.replace(month=current.month + 1)
+    return periods
+
+
+def _in_range(value: datetime, start: date, end: date) -> bool:
+    return start <= _as_date(value) <= end
+
+
+def _report_csv(payload: dict) -> str:
+    output = io.StringIO()
+    writer = csv.writer(output)
+    if payload.get('rows') is not None:
+        writer.writerow(['label', 'count', 'domain'])
+        for row in payload['rows']:
+            writer.writerow([row['label'], row['count'], row.get('domain', '')])
+    else:
+        keys = sorted({key for point in payload['series'] for key in point['values']})
+        writer.writerow(['period', *keys])
+        for point in payload['series']:
+            writer.writerow(
+                [point['period'], *[point['values'].get(key, '') for key in keys]]
+            )
+    return output.getvalue()
+
+
+def _event_rows(db: Session) -> list[DbProductEvent]:
+    return db.query(DbProductEvent).order_by(DbProductEvent.occurred_at).all()
+
+
+# pylint: disable=too-many-locals
+def _funnel_report(
+    report: str, events: list[DbProductEvent], start: date, end: date, bucket: str
+) -> dict:
+    events_by_user: dict[int, list[DbProductEvent]] = defaultdict(list)
+    for event in events:
+        events_by_user[event.user_id].append(event)
+    signups = [event for event in events if event.event_type == 'signup_completed']
+    cohorts: dict[date, list[DbProductEvent]] = defaultdict(list)
+    for signup in signups:
+        if _in_range(signup.occurred_at, start, end):
+            cohorts[_period(_as_date(signup.occurred_at), bucket)].append(signup)
+
+    series = []
+    for period in _periods(start, end, bucket):
+        cohort = cohorts[period]
+        cohort_size = len(cohort)
+        values: dict[str, int] = {'cohort_size': cohort_size}
+        if report in ('activation', 'conversion'):
+            activated = 0
+            for signup in cohort:
+                kinds = {
+                    event.event_type
+                    for event in events_by_user[signup.user_id]
+                    if event.occurred_at >= signup.occurred_at
+                }
+                if 'fifth_item_ranked' in kinds and (
+                    'profile_completed' in kinds or 'first_share' in kinds
+                ):
+                    activated += 1
+            if report == 'activation':
+                values['activated'] = activated
+            else:
+                values['signup_to_activation'] = activated
+                shares = [
+                    event
+                    for event in events
+                    if event.event_type == 'first_share'
+                    and _period(_as_date(event.occurred_at), bucket) == period
+                ]
+                share_ids = {
+                    str(event.payload.get('share_id'))
+                    for event in shares
+                    if event.payload.get('share_id') is not None
+                }
+                referred_signups = sum(
+                    1
+                    for signup_event in signups
+                    if str(signup_event.payload.get('share_id')) in share_ids
+                )
+                values['share_cohort_size'] = len(shares)
+                values['share_to_signup'] = referred_signups
+        if report == 'retention':
+            returned_d7 = 0
+            returned_d28 = 0
+            for signup in cohort:
+                returned = {
+                    _as_date(event.occurred_at)
+                    for event in events_by_user[signup.user_id]
+                    if event.event_type == 'returning_session'
+                }
+                signup_date = _as_date(signup.occurred_at)
+                returned_d7 += any(
+                    signup_date + timedelta(days=7)
+                    <= item
+                    <= signup_date + timedelta(days=13)
+                    for item in returned
+                )
+                returned_d28 += any(
+                    signup_date + timedelta(days=28)
+                    <= item
+                    <= signup_date + timedelta(days=34)
+                    for item in returned
+                )
+            values['retained_d7'] = returned_d7
+            values['retained_d28'] = returned_d28
+        series.append({'period': period.isoformat(), 'values': values})
+    totals = {'cohort_size': sum(point['values']['cohort_size'] for point in series)}
+    for key in {key for point in series for key in point['values']} - {'cohort_size'}:
+        totals[key] = sum(point['values'].get(key, 0) for point in series)
+    return {'series': series, 'totals': totals}
+
+
+@router.get('/reports/{report}', response_model=OutAdminReportResponse)
+def get_report(  # pylint: disable=too-many-arguments, too-many-locals, too-many-branches, too-many-positional-arguments, too-many-statements, redefined-builtin
+    report: str,
+    request: Request,
+    from_date: Optional[date] = Query(default=None, alias='from'),
+    to: Optional[date] = None,
+    bucket: Literal['day', 'week', 'month'] = 'day',
+    format: Optional[Literal['csv']] = None,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
+    """Product-health report data, with one stable chart/table envelope."""
+    if report not in REPORT_NAMES:
+        raise HTTPException(status_code=404, detail='Unknown report')
+    end = to or datetime.now(timezone.utc).date()
+    start = from_date or end - timedelta(days=29)
+    if start > end:
+        raise HTTPException(status_code=422, detail='from must not be after to')
+    periods = _periods(start, end, bucket)
+    payload: dict = {
+        'report': report,
+        'bucket': bucket,
+        'from': start.isoformat(),
+        'to': end.isoformat(),
+        'series': [],
+        'totals': {},
+    }
+
+    if report == 'signups':
+        users = db.query(DbUser).all()
+        cumulative = sum(1 for user in users if _as_date(user.created_at) < start)
+        counts = Counter(
+            _period(_as_date(user.created_at), bucket)
+            for user in users
+            if _in_range(user.created_at, start, end)
+        )
+        for period in periods:
+            count = counts[period]
+            cumulative += count
+            payload['series'].append(
+                {
+                    'period': period.isoformat(),
+                    'values': {'count': count, 'cumulative': cumulative},
+                }
+            )
+        payload['totals'] = {'count': sum(counts.values())}
+    elif report == 'active_users':
+        activity: dict[date, set[int]] = defaultdict(set)
+        all_activity: list[tuple[date, int]] = []
+        for shelf in SHELVES:
+            for user_id, updated_at in db.query(
+                shelf.tracker_model.user_id, shelf.tracker_model.updated_at
+            ):
+                activity[_period(_as_date(updated_at), bucket)].add(user_id)
+                all_activity.append((_as_date(updated_at), user_id))
+        for period in periods:
+            period_end = period + timedelta(
+                days=6 if bucket == 'week' else 30 if bucket == 'month' else 0
+            )
+            dau = len(activity[period])
+            wau = len(
+                {
+                    user_id
+                    for day, user_id in all_activity
+                    if period_end - timedelta(days=6) <= day <= period_end
+                }
+            )
+            payload['series'].append(
+                {'period': period.isoformat(), 'values': {'dau': dau, 'wau': wau}}
+            )
+        payload['totals'] = {
+            'dau': sum(item['values']['dau'] for item in payload['series'])
+        }
+    elif report in ('tracking_volume', 'top_titles', 'top_users'):
+        volume: dict[date, dict[str, Counter]] = defaultdict(
+            lambda: defaultdict(Counter)
+        )
+        title_counts: Counter = Counter()
+        user_counts: Counter = Counter()
+        for shelf in SHELVES:
+            tracker = shelf.tracker_model
+            catalog = shelf.catalog_model
+            rows = (
+                db.query(tracker, catalog.title)
+                .join(catalog, getattr(tracker, shelf.join_col) == catalog.pk)
+                .all()
+            )
+            for row, title in rows:
+                if not _in_range(row.created_at, start, end):
+                    continue
+                period = _period(_as_date(row.created_at), bucket)
+                if row.on_rankings or row.on_watchlist:
+                    volume[period][shelf.category]['tracked'] += 1
+                    title_counts[(shelf.category, title)] += 1
+                    user_counts[row.user_id] += 1
+                if row.on_rankings:
+                    volume[period][shelf.category]['ranked'] += 1
+                if row.on_watchlist:
+                    volume[period][shelf.category]['watchlisted'] += 1
+        if report == 'tracking_volume':
+            for period in periods:
+                values = {}
+                for shelf in SHELVES:
+                    counts = volume[period][shelf.category]
+                    values[f'{shelf.category}_tracked'] = counts['tracked']
+                    values[f'{shelf.category}_ranked'] = counts['ranked']
+                    values[f'{shelf.category}_watchlisted'] = counts['watchlisted']
+                payload['series'].append(
+                    {'period': period.isoformat(), 'values': values}
+                )
+            payload['totals'] = (
+                {
+                    key: sum(point['values'][key] for point in payload['series'])
+                    for key in payload['series'][0]['values']
+                }
+                if payload['series']
+                else {}
+            )
+        elif report == 'top_titles':
+            payload['rows'] = [
+                {'label': title, 'domain': domain, 'count': count}
+                for (domain, title), count in title_counts.most_common(20)
+            ]
+            payload['totals'] = {'count': sum(title_counts.values())}
+        else:
+            users = {
+                user.pk: user
+                for user in db.query(DbUser).filter(DbUser.pk.in_(user_counts)).all()
+            }
+            payload['rows'] = [
+                {
+                    'label': users[user_pk].handle or users[user_pk].display_name,
+                    'count': count,
+                }
+                for user_pk, count in user_counts.most_common(20)
+            ]
+            payload['totals'] = {'count': sum(user_counts.values())}
+    elif report == 'engagement_by_tier':
+        tiers: dict[date, Counter] = defaultdict(Counter)
+        for user in db.query(DbUser).all():
+            if _in_range(user.created_at, start, end):
+                tiers[_period(_as_date(user.created_at), bucket)][
+                    user.default_privacy or 'private'
+                ] += 1
+        for period in periods:
+            values = {
+                tier: tiers[period][tier] for tier in ('private', 'friends', 'public')
+            }
+            payload['series'].append({'period': period.isoformat(), 'values': values})
+        payload['totals'] = {
+            tier: sum(item['values'][tier] for item in payload['series'])
+            for tier in ('private', 'friends', 'public')
+        }
+    else:
+        events = _event_rows(db)
+        instrumented = any(_in_range(event.occurred_at, start, end) for event in events)
+        payload['instrumented'] = instrumented
+        if instrumented:
+            payload.update(_funnel_report(report, events, start, end, bucket))
+
+    admin_audit.record(
+        request,
+        actor=current_user[0],
+        action='admin.reports.view',
+        result=AdminAuditResult.ALLOWED,
+        status_code=200,
+        detail={
+            'report': report,
+            'from': start.isoformat(),
+            'to': end.isoformat(),
+            'bucket': bucket,
+        },
+    )
+    if format == 'csv':
+        return Response(content=_report_csv(payload), media_type='text/csv')
+    return payload
 
 
 @router.get('/impersonation', response_model=OutImpersonationSessionList)

--- a/app/schemas/schemas_admin.py
+++ b/app/schemas/schemas_admin.py
@@ -8,9 +8,9 @@ response model.
 """
 
 from datetime import datetime, timezone
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional
 
-from pydantic import BaseModel, ConfigDict, PlainSerializer
+from pydantic import BaseModel, ConfigDict, Field, PlainSerializer
 
 from app.services.visibility import VisibilityTier
 
@@ -212,3 +212,33 @@ class OutImpersonationSessionList(BaseModel):
     """``GET /v1/admin/impersonation``."""
 
     sessions: list[OutImpersonationLiveSession]
+
+
+class OutAdminReportPoint(BaseModel):
+    """One dated report bucket, with report-specific values."""
+
+    period: str
+    values: dict[str, Any]
+
+
+class OutAdminReportRow(BaseModel):
+    """One unbucketed ranked report row."""
+
+    label: str
+    count: int
+    domain: Optional[str] = None
+
+
+class OutAdminReportResponse(BaseModel):
+    """Shared envelope for every ``GET /v1/admin/reports/{report}``."""
+
+    report: str
+    bucket: str
+    from_: str = Field(alias='from')
+    to: str
+    series: list[OutAdminReportPoint]
+    totals: dict[str, Any]
+    rows: Optional[list[OutAdminReportRow]] = None
+    instrumented: Optional[bool] = None
+
+    model_config = ConfigDict(populate_by_name=True)

--- a/app/services/admin_audit.py
+++ b/app/services/admin_audit.py
@@ -48,6 +48,10 @@ ALLOWED_DETAIL_FIELDS = frozenset(
         'ended',
         'via_impersonation',
         'live_count',
+        'report',
+        'from',
+        'to',
+        'bucket',
     }
 )
 

--- a/tests/integration/router_admin_reports_test.py
+++ b/tests/integration/router_admin_reports_test.py
@@ -1,0 +1,230 @@
+# pylint: disable=missing-function-docstring
+"""Behaviour tests for the admin product-health report contract (#342)."""
+
+from datetime import datetime, timedelta, timezone
+
+from app.db.models import DbProductEvent
+from app.services.shelves import SHELVES
+
+
+def _admin(test_client):
+    return {'Authorization': f'Bearer {test_client.admin_user.token}'}
+
+
+def _event(db, user_id, event_type, occurred_at, payload=None):
+    db.add(
+        DbProductEvent(
+            user_id=user_id,
+            event_type=event_type,
+            payload=payload or {},
+            occurred_at=occurred_at,
+        )
+    )
+
+
+def test_reports_are_admin_only_and_signups_have_cumulative_csv(test_client):
+    db = test_client.test_db_session
+    first = test_client.first_user
+    second = test_client.second_user
+    first.created_at = datetime(2026, 8, 10, tzinfo=timezone.utc)
+    second.created_at = datetime(2026, 8, 11, tzinfo=timezone.utc)
+    db.commit()
+
+    denied = test_client.get('/v1/admin/reports/signups')
+    assert denied.status_code == 401
+    response = test_client.get(
+        '/v1/admin/reports/signups',
+        headers=_admin(test_client),
+        params={'from': '2026-08-10', 'to': '2026-08-11'},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body['report'] == 'signups'
+    assert body['series'] == [
+        {'period': '2026-08-10', 'values': {'count': 1, 'cumulative': 1}},
+        {'period': '2026-08-11', 'values': {'count': 1, 'cumulative': 2}},
+    ]
+    assert body['totals'] == {'count': 2}
+
+    csv_response = test_client.get(
+        '/v1/admin/reports/signups',
+        headers=_admin(test_client),
+        params={'from': '2026-08-10', 'to': '2026-08-11', 'format': 'csv'},
+    )
+    assert csv_response.headers['content-type'].startswith('text/csv')
+    assert '2026-08-11,1,2' in csv_response.text
+
+
+def test_tracking_volume_counts_each_shelf(test_client):
+    db = test_client.test_db_session
+    timestamp = datetime(2026, 8, 10, tzinfo=timezone.utc)
+    for shelf in SHELVES:
+        catalog = shelf.catalog_model(title=f'{shelf.category} report title')
+        db.add(catalog)
+        db.flush()
+        tracker = shelf.tracker_model(
+            user_id=test_client.first_user.pk,
+            **{shelf.join_col: catalog.pk},
+            on_rankings=True,
+            on_watchlist=True,
+            created_at=timestamp,
+        )
+        db.add(tracker)
+    db.commit()
+
+    response = test_client.get(
+        '/v1/admin/reports/tracking_volume',
+        headers=_admin(test_client),
+        params={'from': '2026-08-10', 'to': '2026-08-10'},
+    )
+    assert response.status_code == 200
+    values = response.json()['series'][0]['values']
+    for shelf in SHELVES:
+        assert values[f'{shelf.category}_tracked'] == 1
+        assert values[f'{shelf.category}_ranked'] == 1
+        assert values[f'{shelf.category}_watchlisted'] == 1
+
+
+def test_funnel_reports_distinguish_empty_instrumentation_and_retention(test_client):
+    db = test_client.test_db_session
+    start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    empty = test_client.get(
+        '/v1/admin/reports/retention',
+        headers=_admin(test_client),
+        params={'from': '2026-07-01', 'to': '2026-07-01'},
+    )
+    assert empty.json()['instrumented'] is False
+    assert empty.json()['series'] == []
+
+    _event(db, test_client.first_user.pk, 'signup_completed', start)
+    _event(
+        db, test_client.first_user.pk, 'fifth_item_ranked', start + timedelta(days=1)
+    )
+    _event(
+        db, test_client.first_user.pk, 'profile_completed', start + timedelta(days=1)
+    )
+    _event(
+        db, test_client.first_user.pk, 'returning_session', start + timedelta(days=8)
+    )
+    _event(
+        db, test_client.first_user.pk, 'returning_session', start + timedelta(days=30)
+    )
+    db.commit()
+
+    retention = test_client.get(
+        '/v1/admin/reports/retention',
+        headers=_admin(test_client),
+        params={'from': '2026-07-01', 'to': '2026-07-01'},
+    )
+    values = retention.json()['series'][0]['values']
+    assert retention.json()['instrumented'] is True
+    assert values == {'cohort_size': 1, 'retained_d7': 1, 'retained_d28': 1}
+
+    activation = test_client.get(
+        '/v1/admin/reports/activation',
+        headers=_admin(test_client),
+        params={'from': '2026-07-01', 'to': '2026-07-01'},
+    )
+    assert activation.json()['series'][0]['values'] == {
+        'cohort_size': 1,
+        'activated': 1,
+    }
+
+
+def test_top_users_uses_the_tracked_user_label(test_client):
+    db = test_client.test_db_session
+    user = test_client.first_user
+    user.handle = 'reporter'
+    db.commit()
+    timestamp = datetime(2026, 8, 10, tzinfo=timezone.utc)
+    shelf = SHELVES[0]
+    catalog = shelf.catalog_model(title='Counted movie')
+    db.add(catalog)
+    db.flush()
+    db.add(
+        shelf.tracker_model(
+            user_id=user.pk,
+            **{shelf.join_col: catalog.pk},
+            on_rankings=True,
+            created_at=timestamp,
+        )
+    )
+    db.commit()
+    response = test_client.get(
+        '/v1/admin/reports/top_users',
+        headers=_admin(test_client),
+        params={'from': '2026-08-10', 'to': '2026-08-10'},
+    )
+    assert response.json()['series'] == []
+    assert response.json()['rows'] == [
+        {'label': 'reporter', 'count': 1, 'domain': None}
+    ]
+
+
+def test_remaining_reports_expose_real_aggregate_values(test_client):
+    db = test_client.test_db_session
+    user = test_client.first_user
+    user.created_at = datetime(2026, 8, 10, tzinfo=timezone.utc)
+    user.default_privacy = 'public'
+    shelf = SHELVES[0]
+    catalog = shelf.catalog_model(title='Popular movie')
+    db.add(catalog)
+    db.flush()
+    db.add(
+        shelf.tracker_model(
+            user_id=user.pk,
+            **{shelf.join_col: catalog.pk},
+            on_rankings=True,
+            created_at=datetime(2026, 8, 10, tzinfo=timezone.utc),
+            updated_at=datetime(2026, 8, 10, tzinfo=timezone.utc),
+        )
+    )
+    _event(
+        db,
+        user.pk,
+        'first_share',
+        datetime(2026, 8, 10, tzinfo=timezone.utc),
+        {'share_id': 'share-1'},
+    )
+    _event(
+        db,
+        test_client.second_user.pk,
+        'signup_completed',
+        datetime(2026, 8, 10, tzinfo=timezone.utc),
+        {'share_id': 'share-1'},
+    )
+    db.commit()
+    params = {'from': '2026-08-10', 'to': '2026-08-10'}
+
+    active = test_client.get(
+        '/v1/admin/reports/active_users', headers=_admin(test_client), params=params
+    )
+    assert active.json()['series'][0]['values'] == {'dau': 1, 'wau': 1}
+
+    titles = test_client.get(
+        '/v1/admin/reports/top_titles', headers=_admin(test_client), params=params
+    )
+    assert titles.json()['rows'] == [
+        {'label': 'Popular movie', 'count': 1, 'domain': 'movies'}
+    ]
+
+    engagement = test_client.get(
+        '/v1/admin/reports/engagement_by_tier',
+        headers=_admin(test_client),
+        params=params,
+    )
+    assert engagement.json()['series'][0]['values'] == {
+        'private': 0,
+        'friends': 0,
+        'public': 1,
+    }
+
+    conversion = test_client.get(
+        '/v1/admin/reports/conversion', headers=_admin(test_client), params=params
+    )
+    assert conversion.json()['series'][0]['values'] == {
+        'cohort_size': 1,
+        'signup_to_activation': 0,
+        'share_cohort_size': 1,
+        'share_to_signup': 1,
+    }


### PR DESCRIPTION
## Summary

- Product health was invisible without ad-hoc SQL, and the funnel metrics
  defined in ALeonard9/druthers-infra#41 had nowhere to live: no table, no
  endpoints, no page.
- Adds `GET /v1/admin/reports/{report}` covering nine reports behind one
  envelope: `signups`, `active_users`, `tracking_volume`, `top_titles`,
  `top_users`, `engagement_by_tier`, `activation`, `retention`, `conversion`.
  Admin-gated with the rest of `router_admin.py`; an unknown report is a 404.
- Adds the `product_events` migration, so the funnel reports have a table to
  read even before anything writes to it.
- **Every report is a series by cohort period, never an all-time scalar.** A
  lifetime ratio cannot show a trend, and for signup-to-activation it
  actively misleads: new signups enter the denominator at once but cannot
  reach the numerator for days, so the number falls while you grow.
- **Funnel reports send the numerator and the denominator, never a
  percentage.** The client renders "5 of 14" rather than "36%", which is the
  honest reading when a cohort is 14 people.
- **`instrumented: false`** when `product_events` holds nothing for the
  range. Without it, an uninstrumented funnel renders 0% and reads as "nobody
  converts" instead of "we have not started measuring." Those two states are
  identical on a chart.
- `?format=csv` returns the same data on the same route, so the export and
  the chart cannot disagree about what a report contains.
- Ranked reports (`top_titles`, `top_users`) carry `rows` and an empty
  `series`; they are tables, not charts.

## Test plan

- [x] `pytest` - 1048 passed, including the new
      `tests/integration/router_admin_reports_test.py`.
- [x] Re-run with `-W error::DeprecationWarning`, which is how CI runs it -
      1048 passed. #390 failed CI on exactly this, passing locally as a plain
      warning.
- [x] Verified against the local dev stack with the web companion
      (ALeonard9/druthers-web#251) rendering it: sign-ups 8, DAU 7 / WAU 7,
      movies tracked 294, most-tracked titles led by Interstellar at 6,
      most-active users led by `you` at 407.
- [x] Funnel reports returned `instrumented: false` and the page showed
      "Not instrumented yet" rather than 0%, with `product_events` present
      and empty.
- [x] Migration applied against local Postgres; single Alembic head.

**Alembic ordering.** `f342a9b7c1d0` now chains behind `49a7d3184b0d` from
#390. Both were written against the same parent while in flight, so each was
single-headed alone and main would have had two heads once both merged,
breaking the next `alembic upgrade head`. #390 is on main, so this follows it.

## Checklist

- [x] Branch named `feat/…`, `fix/…`, or `chore/…`
- [x] New module has a test file in this PR (see CLAUDE.md → Testing)
- [x] Per-domain change checked against the other three domains (movies/TV/books/games)
- [ ] CI green (lint + tests)
- [x] No secrets committed
- [x] Docs/README updated if behavior changed

Closes #342.
