### PR TITLE
Search holds a DB connection across provider calls, and upstream 4xx is reported as 502

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -28,6 +28,12 @@ class Settings(BaseSettings):
     lz: Optional[str] = None
     log_level: str = 'INFO'
     time_zone: str = 'America/New_York'
+    # Cloud Run admits 80 requests per instance. AnyIO runs at most 40 sync
+    # callables concurrently, while the 20-connection DB pool is reserved for
+    # short auth and result-decoration phases, never provider waits.
+    cloud_run_container_concurrency: int = 80
+    sync_thread_limit: int = 40
+    search_handler_timeout_seconds: float = 20.0
     # Baked in at image build time (see Dockerfile ARG/ENV GIT_SHA). Lets a
     # running container be checked against the working tree instead of
     # silently serving a stale build (api#232).
@@ -40,9 +46,9 @@ class Settings(BaseSettings):
     postgres_host: Optional[str] = None
     postgres_connection_port: str = '5432'
     postgres_db: str = 'druthers'
-    # SQLAlchemy's default pool is 5 + 10 overflow. One page render fans out
-    # several concurrent API calls, so the default silently serialises the
-    # tail of a render behind the pool. Sized here instead of implied.
+    # Twenty total connections support the brief DB phases of up to 40 active
+    # sync callables. Search closes its session during provider I/O, so the
+    # pool is not expected to match Cloud Run's 80 admitted requests.
     db_pool_size: int = 10
     db_max_overflow: int = 10
     db_pool_timeout: int = 10

--- a/app/router/v1/router_books.py
+++ b/app/router/v1/router_books.py
@@ -12,6 +12,7 @@ from typing import List, Optional, Union
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
+from starlette.concurrency import run_in_threadpool
 
 from app.auth.oauth2 import get_current_user, require_admin
 from app.db.database import get_db
@@ -34,6 +35,7 @@ from app.services.book_search import apply_detail_to_book, get_book_detail
 from app.services.book_search import search_books as openlibrary_search_books
 from app.services.rate_limit import catalog_add_cap, search_rate_limit
 from app.services.search_correction import correct_query
+from app.services.search_policy import run_search_provider, search_with_correction
 from app.services.shelves import SHELVES
 from app.services.social import get_item_social_context
 from app.services.tracked_status import attach_tracked_status
@@ -76,17 +78,17 @@ def get_all_books(  # pylint: disable=too-many-arguments, too-many-positional-ar
     response_model=List[BookSearchResult],
     dependencies=[Depends(search_rate_limit)],
 )
-def search_books_endpoint(
+async def search_books_endpoint(
     q: str,
     db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
 ):
-    results = openlibrary_search_books(q)
-    if not results:
-        corrected = correct_query(q)
-        if corrected:
-            results = openlibrary_search_books(corrected)
-    return attach_tracked_status(db, current_user[0].pk, results, 'books')
+    user_pk = current_user[0].pk
+    db.close()
+    results = await run_search_provider(
+        search_with_correction, openlibrary_search_books, correct_query, q
+    )
+    return await run_in_threadpool(attach_tracked_status, db, user_pk, results, 'books')
 
 
 @router.post(

--- a/app/router/v1/router_games.py
+++ b/app/router/v1/router_games.py
@@ -13,6 +13,7 @@ from typing import List, Optional, Union
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
+from starlette.concurrency import run_in_threadpool
 
 from app.auth.oauth2 import get_current_user, require_admin
 from app.db.database import get_db
@@ -35,6 +36,7 @@ from app.services.game_search import apply_detail_to_game, get_game_detail
 from app.services.game_search import search_games as igdb_search_games
 from app.services.rate_limit import catalog_add_cap, search_rate_limit
 from app.services.search_correction import correct_query
+from app.services.search_policy import run_search_provider, search_with_correction
 from app.services.shelves import SHELVES
 from app.services.social import get_item_social_context
 from app.services.tracked_status import attach_tracked_status
@@ -73,17 +75,17 @@ def get_all_games(
     response_model=List[GameSearchResult],
     dependencies=[Depends(search_rate_limit)],
 )
-def search_games_endpoint(
+async def search_games_endpoint(
     q: str,
     db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
 ):
-    results = igdb_search_games(q)
-    if not results:
-        corrected = correct_query(q)
-        if corrected:
-            results = igdb_search_games(corrected)
-    return attach_tracked_status(db, current_user[0].pk, results, 'games')
+    user_pk = current_user[0].pk
+    db.close()
+    results = await run_search_provider(
+        search_with_correction, igdb_search_games, correct_query, q
+    )
+    return await run_in_threadpool(attach_tracked_status, db, user_pk, results, 'games')
 
 
 @router.post(

--- a/app/router/v1/router_movies.py
+++ b/app/router/v1/router_movies.py
@@ -8,6 +8,7 @@ from typing import List, Optional, Union
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func, or_
 from sqlalchemy.orm import Session, joinedload
+from starlette.concurrency import run_in_threadpool
 
 from app.auth.oauth2 import get_current_user, require_admin
 from app.db.database import get_db
@@ -34,6 +35,7 @@ from app.services.movie_search import (
 from app.services.movie_search import search_movies as tmdb_search_movies
 from app.services.rate_limit import catalog_add_cap, search_rate_limit
 from app.services.search_correction import correct_query
+from app.services.search_policy import run_search_provider, search_with_correction
 from app.services.shelves import SHELVES
 from app.services.social import get_item_social_context
 from app.services.tracked_status import attach_tracked_status
@@ -89,17 +91,19 @@ def get_all_movies(
     response_model=List[MovieSearchResult],
     dependencies=[Depends(search_rate_limit)],
 )
-def search_movies_endpoint(
+async def search_movies_endpoint(
     q: str,
     db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
 ):
-    results = tmdb_search_movies(q)
-    if not results:
-        corrected = correct_query(q)
-        if corrected:
-            results = tmdb_search_movies(corrected)
-    return attach_tracked_status(db, current_user[0].pk, results, 'movies')
+    user_pk = current_user[0].pk
+    db.close()
+    results = await run_search_provider(
+        search_with_correction, tmdb_search_movies, correct_query, q
+    )
+    return await run_in_threadpool(
+        attach_tracked_status, db, user_pk, results, 'movies'
+    )
 
 
 @router.post(

--- a/app/router/v1/router_search.py
+++ b/app/router/v1/router_search.py
@@ -26,7 +26,10 @@ from app.services.book_search import search_books
 from app.services.game_search import search_games
 from app.services.movie_search import search_movies
 from app.services.search_correction import correct_query
-from app.services.search_policy import MIN_SEARCH_QUERY_LENGTH, run_search_provider
+from app.services.search_policy import (
+    MIN_CORRECTION_QUERY_LENGTH,
+    run_search_provider,
+)
 from app.services.search_ranking import rank_and_cap
 from app.services.tracked_status import attach_tracked_status
 from app.services.tv_search import search_tv_shows
@@ -72,7 +75,7 @@ def _global_provider_search(q: str):
     # Some providers fuzzy-match and some don't, so retry only the domains
     # that came back empty with a spell-corrected query.
     empty = [name for name, hits in results.items() if not hits]
-    if empty and len(q.strip()) >= MIN_SEARCH_QUERY_LENGTH:
+    if empty and len(q.strip()) >= MIN_CORRECTION_QUERY_LENGTH:
         respelled = correct_query(q)
         if respelled:
             retried = _fan_out(respelled, only=empty)

--- a/app/router/v1/router_search.py
+++ b/app/router/v1/router_search.py
@@ -13,6 +13,7 @@ from typing import Callable, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
+from starlette.concurrency import run_in_threadpool
 
 from app.auth.oauth2 import get_current_user
 from app.db.database import get_db
@@ -25,6 +26,7 @@ from app.services.book_search import search_books
 from app.services.game_search import search_games
 from app.services.movie_search import search_movies
 from app.services.search_correction import correct_query
+from app.services.search_policy import MIN_SEARCH_QUERY_LENGTH, run_search_provider
 from app.services.search_ranking import rank_and_cap
 from app.services.tracked_status import attach_tracked_status
 from app.services.tv_search import search_tv_shows
@@ -60,16 +62,8 @@ def _fan_out(q: str, only: Optional[List[str]] = None) -> Dict[str, List[dict]]:
         return {name: future.result() for name, future in futures.items()}
 
 
-@router.get(
-    '/search',
-    response_model=GlobalSearchResponse,
-    dependencies=[Depends(search_rate_limit)],
-)
-def global_search(
-    q: str,
-    db: Session = Depends(get_db),
-    current_user: list = Depends(get_current_user),
-):
+def _global_provider_search(q: str):
+    """Run both provider rounds and ranking under one search deadline."""
     results = _fan_out(q)
     corrected = None
     # Track which query actually produced each domain's hits, so ranking
@@ -78,7 +72,7 @@ def global_search(
     # Some providers fuzzy-match and some don't, so retry only the domains
     # that came back empty with a spell-corrected query.
     empty = [name for name, hits in results.items() if not hits]
-    if empty:
+    if empty and len(q.strip()) >= MIN_SEARCH_QUERY_LENGTH:
         respelled = correct_query(q)
         if respelled:
             retried = _fan_out(respelled, only=empty)
@@ -95,9 +89,24 @@ def global_search(
         domain: rank_and_cap(query_by_domain[domain], hits)
         for domain, hits in results.items()
     }
+    return results, corrected
+
+
+@router.get(
+    '/search',
+    response_model=GlobalSearchResponse,
+    dependencies=[Depends(search_rate_limit)],
+)
+async def global_search(
+    q: str,
+    db: Session = Depends(get_db),
+    current_user: list = Depends(get_current_user),
+):
     user_pk = current_user[0].pk
+    db.close()
+    results, corrected = await run_search_provider(_global_provider_search, q)
     for domain, hits in results.items():
-        attach_tracked_status(db, user_pk, hits, domain)
+        await run_in_threadpool(attach_tracked_status, db, user_pk, hits, domain)
     return GlobalSearchResponse(query=q, corrected=corrected, **results)
 
 

--- a/app/router/v1/router_tv.py
+++ b/app/router/v1/router_tv.py
@@ -13,6 +13,7 @@ from typing import List, Optional, Union
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
+from starlette.concurrency import run_in_threadpool
 
 from app.auth.oauth2 import get_current_user, require_admin
 from app.db.database import get_db
@@ -43,6 +44,7 @@ from app.schemas.schemas_sandbox import (
 from app.services import preferences
 from app.services.rate_limit import catalog_add_cap, search_rate_limit
 from app.services.search_correction import correct_query
+from app.services.search_policy import run_search_provider, search_with_correction
 from app.services.shelves import SHELVES
 from app.services.social import get_item_social_context
 from app.services.tracked_status import attach_tracked_status
@@ -116,17 +118,19 @@ def get_all_tv_shows(  # pylint: disable=too-many-arguments, too-many-positional
     response_model=List[TVShowSearchResult],
     dependencies=[Depends(search_rate_limit)],
 )
-def search_tv_shows_endpoint(
+async def search_tv_shows_endpoint(
     q: str,
     db: Session = Depends(get_db),
     current_user: list = Depends(get_current_user),
 ):
-    results = tvmaze_search_shows(q)
-    if not results:
-        corrected = correct_query(q)
-        if corrected:
-            results = tvmaze_search_shows(corrected)
-    return attach_tracked_status(db, current_user[0].pk, results, 'tv_shows')
+    user_pk = current_user[0].pk
+    db.close()
+    results = await run_search_provider(
+        search_with_correction, tvmaze_search_shows, correct_query, q
+    )
+    return await run_in_threadpool(
+        attach_tracked_status, db, user_pk, results, 'tv_shows'
+    )
 
 
 @router.post(

--- a/app/run.py
+++ b/app/run.py
@@ -7,8 +7,10 @@ import json
 import os
 import time
 import uuid
+from contextlib import asynccontextmanager
 
 import uvicorn
+import anyio.to_thread
 from fastapi import FastAPI, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
@@ -50,6 +52,22 @@ from .utils.exceptions import (
 )
 
 settings = get_settings()
+
+
+@asynccontextmanager
+async def lifespan(_app):
+    """Configure per-instance concurrency on the server's event loop."""
+    anyio.to_thread.current_default_thread_limiter().total_tokens = (
+        settings.sync_thread_limit
+    )
+    logger.info(
+        'Instance capacity: %d Cloud Run requests, %d sync workers, '
+        '%d database connections',
+        settings.cloud_run_container_concurrency,
+        settings.sync_thread_limit,
+        settings.db_pool_size + settings.db_max_overflow,
+    )
+    yield
 
 
 def _is_mutable_user_read(method: str, path: str) -> bool:
@@ -119,6 +137,7 @@ app = FastAPI(
         'name': 'GPL-3.0',
         'url': 'https://www.gnu.org/licenses/gpl-3.0.html',
     },
+    lifespan=lifespan,
 )
 
 

--- a/app/services/book_search.py
+++ b/app/services/book_search.py
@@ -23,6 +23,7 @@ from fastapi import HTTPException, status
 
 from app.config import get_settings
 from app.log.logging_config import logger
+from app.services.search_policy import is_bad_query_error, normalized_search_query
 
 OPENLIBRARY_URL = 'https://openlibrary.org'
 COVERS_URL = 'https://covers.openlibrary.org'
@@ -329,6 +330,15 @@ def _search_by_isbn(isbn: str) -> List[dict]:
         )
         response.raise_for_status()
         payload = response.json()
+    except requests.HTTPError as exc:
+        if is_bad_query_error(exc):
+            logger.info('Open Library rejected ISBN search %r: %s', isbn, exc)
+            return []
+        logger.error('Open Library ISBN lookup failed for %r: %s', isbn, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Upstream book search failed',
+        ) from exc
     except (requests.RequestException, ValueError) as exc:
         logger.error('Open Library ISBN lookup failed for %r: %s', isbn, exc)
         raise HTTPException(
@@ -376,19 +386,16 @@ def search_books(query: str) -> List[dict]:
     Search Open Library for books matching ``query``.
 
     Returns a list of normalized dicts (``isbn``, ``title``, ``authors``,
-    ``year``, ``poster_url``). Raises 400 on an empty query and 502 when the
-    upstream call fails.
+    ``year``, ``poster_url``). Queries shorter than three characters and
+    provider query rejections return ``[]``; upstream failures raise 502.
 
     When ``query`` looks like an ISBN (10 or 13 digits, optionally
     hyphenated), it's resolved directly via Open Library's ISBN lookup
     instead of a title search.
     """
-    query = (query or '').strip()
-    if not query:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail='Search query must not be empty',
-        )
+    query = normalized_search_query(query, 'Book')
+    if query is None:
+        return []
 
     normalized_isbn = re.sub(r'[-\s]', '', query)
     if _ISBN_RE.match(normalized_isbn):
@@ -411,6 +418,15 @@ def search_books(query: str) -> List[dict]:
         )
         response.raise_for_status()
         payload = response.json()
+    except requests.HTTPError as exc:
+        if is_bad_query_error(exc):
+            logger.info('Open Library rejected book search query %r: %s', query, exc)
+            return []
+        logger.error('Open Library search failed for %r: %s', query, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Upstream book search failed',
+        ) from exc
     except (requests.RequestException, ValueError) as exc:
         logger.error('Open Library search failed for %r: %s', query, exc)
         raise HTTPException(

--- a/app/services/book_search.py
+++ b/app/services/book_search.py
@@ -386,8 +386,9 @@ def search_books(query: str) -> List[dict]:
     Search Open Library for books matching ``query``.
 
     Returns a list of normalized dicts (``isbn``, ``title``, ``authors``,
-    ``year``, ``poster_url``). Queries shorter than three characters and
-    provider query rejections return ``[]``; upstream failures raise 502.
+    ``year``, ``poster_url``). Queries shorter than three characters, which
+    Open Library rejects with a 422, and provider query rejections return
+    ``[]``; upstream failures raise 502.
 
     When ``query`` looks like an ISBN (10 or 13 digits, optionally
     hyphenated), it's resolved directly via Open Library's ISBN lookup

--- a/app/services/game_search.py
+++ b/app/services/game_search.py
@@ -21,6 +21,7 @@ from fastapi import HTTPException, status
 
 from app.config import get_settings
 from app.log.logging_config import logger
+from app.services.search_policy import is_bad_query_error, normalized_search_query
 
 TWITCH_OAUTH_URL = 'https://id.twitch.tv/oauth2/token'
 IGDB_URL = 'https://api.igdb.com/v4'
@@ -153,6 +154,15 @@ def _search_games_by_id(igdb_id: int) -> List[dict]:
             'games',
             f'fields {_SEARCH_FIELDS}; where id = {igdb_id};',
         )
+    except requests.HTTPError as exc:
+        if is_bad_query_error(exc):
+            logger.info('IGDB rejected game id query %s: %s', igdb_id, exc)
+            return []
+        logger.error('IGDB id lookup failed for %s: %s', igdb_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Upstream game search failed',
+        ) from exc
     except (requests.RequestException, ValueError) as exc:
         logger.error('IGDB id lookup failed for %s: %s', igdb_id, exc)
         raise HTTPException(
@@ -172,15 +182,13 @@ def search_games(query: str) -> List[dict]:
     A bare-numeric query is treated as an IGDB id and resolved directly via
     ``where id = <id>`` instead of a fuzzy title search. Returns a list of
     normalized dicts (``igdb``, ``title``, ``year``, ``platforms``,
-    ``poster_url``). Raises 400 on an empty query, 503 when unconfigured,
-    and 502 when the upstream call fails.
+    ``poster_url``). Queries shorter than three characters and provider query
+    rejections return ``[]``; unconfigured search raises 503 and upstream
+    failures raise 502.
     """
-    query = (query or '').strip()
-    if not query:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail='Search query must not be empty',
-        )
+    query = normalized_search_query(query, 'Game')
+    if query is None:
+        return []
 
     if query.isdigit():
         return _search_games_by_id(int(query))
@@ -195,6 +203,15 @@ def search_games(query: str) -> List[dict]:
             'platforms.abbreviation,cover.image_id,total_rating_count; '
             'limit 20;',
         )
+    except requests.HTTPError as exc:
+        if is_bad_query_error(exc):
+            logger.info('IGDB rejected game search query %r: %s', query, exc)
+            return []
+        logger.error('IGDB search failed for %r: %s', query, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Upstream game search failed',
+        ) from exc
     except (requests.RequestException, ValueError) as exc:
         # HTTPExceptions from _igdb_query (503 unconfigured / 502 auth)
         # propagate untouched - they aren't caught here.

--- a/app/services/game_search.py
+++ b/app/services/game_search.py
@@ -182,8 +182,8 @@ def search_games(query: str) -> List[dict]:
     A bare-numeric query is treated as an IGDB id and resolved directly via
     ``where id = <id>`` instead of a fuzzy title search. Returns a list of
     normalized dicts (``igdb``, ``title``, ``year``, ``platforms``,
-    ``poster_url``). Queries shorter than three characters and provider query
-    rejections return ``[]``; unconfigured search raises 503 and upstream
+    ``poster_url``). Queries below IGDB's one-character floor and provider
+    query rejections return ``[]``; unconfigured search raises 503 and upstream
     failures raise 502.
     """
     query = normalized_search_query(query, 'Game')

--- a/app/services/movie_search.py
+++ b/app/services/movie_search.py
@@ -28,6 +28,7 @@ from fastapi import HTTPException, status
 
 from app.log.logging_config import logger
 from app.services import tmdb
+from app.services.search_policy import normalized_search_query
 
 _IMDB_ID_RE = re.compile(r'^tt\d+$', re.IGNORECASE)
 
@@ -77,12 +78,16 @@ def _search_by_imdb_id(imdb_id: str) -> List[dict]:
     result into the same search-hit shape title matches produce. Returns ``[]``
     when the id doesn't resolve, mirroring title search's "not found".
     """
-    payload = tmdb.try_request(f'/find/{imdb_id}', {'external_source': 'imdb_id'})
-    if payload is None:
+    try:
+        payload = tmdb.request(f'/find/{imdb_id}', {'external_source': 'imdb_id'})
+    except tmdb.TmdbBadQuery as exc:
+        logger.info('TMDB rejected movie id query %r: %s', imdb_id, exc)
+        return []
+    except (tmdb.TmdbUnconfigured, tmdb.TmdbError) as exc:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail='Upstream movie search failed',
-        )
+        ) from exc
     results = payload.get('movie_results') or []
     if not results:
         return []
@@ -102,14 +107,12 @@ def search_movies(query: str) -> List[dict]:
 
     Returns a list of normalized dicts (``tmdb``, ``imdb``, ``title``,
     ``year``, ``poster_url``, ``type``, ``popularity``). Raises 503 when the
-    API key is not configured and 502 when the upstream call fails.
+    API key is not configured and 502 when the upstream call fails. Queries
+    shorter than three characters and provider query rejections return ``[]``.
     """
-    query = (query or '').strip()
-    if not query:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail='Search query must not be empty',
-        )
+    query = normalized_search_query(query, 'Movie')
+    if query is None:
+        return []
 
     if not tmdb.is_configured():
         raise HTTPException(
@@ -129,6 +132,9 @@ def search_movies(query: str) -> List[dict]:
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail='Movie search is not configured (TMDB_API_KEY missing)',
         ) from exc
+    except tmdb.TmdbBadQuery as exc:
+        logger.info('TMDB rejected movie search query %r: %s', query, exc)
+        return []
     except tmdb.TmdbError as exc:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,

--- a/app/services/movie_search.py
+++ b/app/services/movie_search.py
@@ -108,7 +108,8 @@ def search_movies(query: str) -> List[dict]:
     Returns a list of normalized dicts (``tmdb``, ``imdb``, ``title``,
     ``year``, ``poster_url``, ``type``, ``popularity``). Raises 503 when the
     API key is not configured and 502 when the upstream call fails. Queries
-    shorter than three characters and provider query rejections return ``[]``.
+    below TMDB's one-character floor and provider query rejections return
+    ``[]``.
     """
     query = normalized_search_query(query, 'Movie')
     if query is None:

--- a/app/services/rate_limit.py
+++ b/app/services/rate_limit.py
@@ -9,13 +9,19 @@ meter a distributed fleet. Enforcement is on in deployed environments
 defaults are generous enough that a human never notices them.
 """
 
+import hashlib
 import threading
 import time
 from collections import defaultdict, deque
 
 from fastapi import Depends, HTTPException, Request, status
 
-from app.auth.oauth2 import get_current_user
+from app.auth.oauth2 import (
+    API_KEY_PREFIX,
+    decode_token_payload_best_effort,
+    get_current_user,
+    oauth2_scheme,
+)
 from app.config import get_settings
 
 _lock = threading.Lock()
@@ -133,12 +139,22 @@ def refresh_rate_limit(user) -> None:
         _reject('token refreshes', AUTH_WINDOW_SECONDS)
 
 
-def search_rate_limit(current_user: list = Depends(get_current_user)) -> None:
-    """Per-user cap on external search-proxy calls (they burn API quotas)."""
+def _search_credential_key(token: str) -> str:
+    """Stable limiter key derived without checking out a DB connection."""
+    if not token.startswith(API_KEY_PREFIX):
+        payload = decode_token_payload_best_effort(token)
+        if payload and payload.get('sub'):
+            return str(payload['sub'])
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def search_rate_limit(token: str = Depends(oauth2_scheme)) -> None:
+    """Per-credential search cap that runs before database authentication."""
     if not _enforced():
         return
     limit = get_settings().rate_limit_search
-    if not _allow(f'search:{current_user[0].pk}', limit, SEARCH_WINDOW_SECONDS):
+    key = _search_credential_key(token)
+    if not _allow(f'search:{key}', limit, SEARCH_WINDOW_SECONDS):
         _reject('searches', SEARCH_WINDOW_SECONDS)
 
 

--- a/app/services/search_policy.py
+++ b/app/services/search_policy.py
@@ -1,0 +1,67 @@
+"""Shared input and upstream-response policy for catalog searches."""
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
+from typing import Optional
+
+import requests
+from fastapi import HTTPException, status
+
+from app.config import get_settings
+from app.log.logging_config import logger
+
+MIN_SEARCH_QUERY_LENGTH = 3
+_OPERATOR_HTTP_STATUSES = frozenset({401, 403, 429})
+_executor = ThreadPoolExecutor(
+    max_workers=get_settings().sync_thread_limit,
+    thread_name_prefix='catalog-search',
+)
+
+
+async def run_search_provider(function, *args, **kwargs):
+    """Run bounded provider work and abandon its future at the request deadline."""
+    future = _executor.submit(partial(function, *args, **kwargs))
+    try:
+        return await asyncio.wait_for(
+            asyncio.wrap_future(future),
+            timeout=get_settings().search_handler_timeout_seconds,
+        )
+    except TimeoutError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail='Search timed out, please try again',
+        ) from exc
+
+
+def search_with_correction(provider, corrector, query: str):
+    """Run one provider and its optional correction retry as one bounded job."""
+    results = provider(query)
+    if not results and len(query.strip()) >= MIN_SEARCH_QUERY_LENGTH:
+        corrected = corrector(query)
+        if corrected:
+            results = provider(corrected)
+    return results
+
+
+def normalized_search_query(query: str, domain: str) -> Optional[str]:
+    """Normalize a query, returning ``None`` for an expected short prefix."""
+    normalized = (query or '').strip()
+    if len(normalized) < MIN_SEARCH_QUERY_LENGTH:
+        logger.debug(
+            '%s search skipped query shorter than %d characters',
+            domain,
+            MIN_SEARCH_QUERY_LENGTH,
+        )
+        return None
+    return normalized
+
+
+def is_bad_query_error(exc: requests.HTTPError) -> bool:
+    """Whether an HTTP error represents caller input rather than availability."""
+    response = exc.response
+    return bool(
+        response is not None
+        and 400 <= response.status_code < 500
+        and response.status_code not in _OPERATOR_HTTP_STATUSES
+    )

--- a/app/services/search_policy.py
+++ b/app/services/search_policy.py
@@ -11,7 +11,27 @@ from fastapi import HTTPException, status
 from app.config import get_settings
 from app.log.logging_config import logger
 
-MIN_SEARCH_QUERY_LENGTH = 3
+# Each provider's own floor, probed directly on 2026-08-20 (api#398). These are
+# observed provider limits, not a product preference, so changing one should
+# follow a re-probe rather than a judgement call. TMDB, TVMaze and IGDB all
+# serve one-character queries; Open Library answers 422 for anything under
+# three characters, sometimes as a dropped TLS connection rather than a clean
+# status. Flooring all four to Open Library's limit silently lost every
+# two-letter title (Go, Up, It, Us) in the other three domains.
+MIN_QUERY_LENGTH_BY_DOMAIN = {
+    'Movie': 1,
+    'TV': 1,
+    'Game': 1,
+    'Book': 3,
+}
+# For a domain not listed above, so a newly added domain fails closed rather
+# than sending a provider prefixes it may reject.
+DEFAULT_MIN_QUERY_LENGTH = 3
+# Whether a spelling correction is worth a round trip is a different question
+# from what a provider will accept. A one or two character string has no
+# meaningful correction, so this stays at three even where the provider floor
+# is one.
+MIN_CORRECTION_QUERY_LENGTH = 3
 _OPERATOR_HTTP_STATUSES = frozenset({401, 403, 429})
 _executor = ThreadPoolExecutor(
     max_workers=get_settings().sync_thread_limit,
@@ -37,21 +57,27 @@ async def run_search_provider(function, *args, **kwargs):
 def search_with_correction(provider, corrector, query: str):
     """Run one provider and its optional correction retry as one bounded job."""
     results = provider(query)
-    if not results and len(query.strip()) >= MIN_SEARCH_QUERY_LENGTH:
+    if not results and len(query.strip()) >= MIN_CORRECTION_QUERY_LENGTH:
         corrected = corrector(query)
         if corrected:
             results = provider(corrected)
     return results
 
 
+def min_query_length(domain: str) -> int:
+    """The shortest query this domain's provider will accept."""
+    return MIN_QUERY_LENGTH_BY_DOMAIN.get(domain, DEFAULT_MIN_QUERY_LENGTH)
+
+
 def normalized_search_query(query: str, domain: str) -> Optional[str]:
     """Normalize a query, returning ``None`` for an expected short prefix."""
     normalized = (query or '').strip()
-    if len(normalized) < MIN_SEARCH_QUERY_LENGTH:
+    minimum = min_query_length(domain)
+    if len(normalized) < minimum:
         logger.debug(
             '%s search skipped query shorter than %d characters',
             domain,
-            MIN_SEARCH_QUERY_LENGTH,
+            minimum,
         )
         return None
     return normalized

--- a/app/services/tmdb.py
+++ b/app/services/tmdb.py
@@ -26,6 +26,7 @@ import requests
 
 from app.config import get_settings
 from app.log.logging_config import logger
+from app.services.search_policy import is_bad_query_error
 
 TMDB_URL = 'https://api.themoviedb.org/3'
 IMAGE_BASE = 'https://image.tmdb.org/t/p'
@@ -49,6 +50,10 @@ class TmdbUnconfigured(RuntimeError):
 
 class TmdbError(RuntimeError):
     """TMDB was unreachable or returned an unusable response."""
+
+
+class TmdbBadQuery(TmdbError):
+    """TMDB rejected caller input with a non-authentication 4xx response."""
 
 
 def is_configured() -> bool:
@@ -124,6 +129,11 @@ def request(path: str, params: Optional[dict] = None) -> dict:
                 continue
             response.raise_for_status()
             return response.json()
+        except requests.HTTPError as exc:
+            if is_bad_query_error(exc):
+                raise TmdbBadQuery(f'TMDB rejected query for {path}') from exc
+            last_exc = exc
+            break
         except (requests.RequestException, ValueError) as exc:
             # A non-retryable status (404), a decode error, or a transport
             # failure - all terminal, since retryable statuses are handled

--- a/app/services/tv_search.py
+++ b/app/services/tv_search.py
@@ -17,6 +17,7 @@ import requests
 from fastapi import HTTPException, status
 
 from app.log.logging_config import logger
+from app.services.search_policy import is_bad_query_error, normalized_search_query
 
 TVMAZE_URL = 'https://api.tvmaze.com'
 REQUEST_TIMEOUT = 10
@@ -95,6 +96,15 @@ def _lookup_show(params: dict) -> List[dict]:
             return []
         response.raise_for_status()
         payload = response.json()
+    except requests.HTTPError as exc:
+        if is_bad_query_error(exc):
+            logger.info('TVMaze rejected TV id query %r: %s', params, exc)
+            return []
+        logger.error('TVMaze lookup failed for %r: %s', params, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Upstream TV search failed',
+        ) from exc
     except (requests.RequestException, ValueError) as exc:
         logger.error('TVMaze lookup failed for %r: %s', params, exc)
         raise HTTPException(
@@ -118,15 +128,13 @@ def search_tv_shows(query: str) -> List[dict]:
     queries are unaffected.
 
     Returns a list of normalized dicts (``tvmaze``, ``imdb``, ``title``,
-    ``year``, ``status``, ``network``, ``poster_url``). Raises 400 on an
-    empty query and 502 when the upstream call fails.
+    ``year``, ``status``, ``network``, ``poster_url``). Queries shorter than
+    three characters and provider query rejections return ``[]``; upstream
+    failures raise 502.
     """
-    query = (query or '').strip()
-    if not query:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail='Search query must not be empty',
-        )
+    query = normalized_search_query(query, 'TV')
+    if query is None:
+        return []
 
     if _IMDB_ID_RE.fullmatch(query):
         return _lookup_show({'imdb': query.lower()})
@@ -143,6 +151,15 @@ def search_tv_shows(query: str) -> List[dict]:
         )
         response.raise_for_status()
         payload = response.json()
+    except requests.HTTPError as exc:
+        if is_bad_query_error(exc):
+            logger.info('TVMaze rejected TV search query %r: %s', query, exc)
+            return []
+        logger.error('TVMaze search failed for %r: %s', query, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Upstream TV search failed',
+        ) from exc
     except (requests.RequestException, ValueError) as exc:
         logger.error('TVMaze search failed for %r: %s', query, exc)
         raise HTTPException(

--- a/docs/search-capacity.md
+++ b/docs/search-capacity.md
@@ -1,0 +1,21 @@
+# Search capacity
+
+One Cloud Run instance admits 80 concurrent HTTP requests. The application
+declares that deployment value, sets AnyIO's synchronous worker limit to 40,
+and sets SQLAlchemy's pool to 10 persistent plus 10 overflow connections in
+`app/config.py`.
+
+Those numbers describe three different phases, so they do not need to be
+equal. An instance can accept 80 requests and run 40 blocking search jobs on
+the bounded catalog-search executor while serving short authentication and
+tracked-status queries from 20 database connections. A single-domain job
+makes one provider call; a global search job fans out to four provider threads.
+Catalog search handlers close their session before calling TMDB, TVMaze, Open
+Library, or IGDB, including the spelling-correction retry, then reacquire a
+connection only to decorate returned hits. The other 40 admitted requests can
+wait for a search worker without also waiting on or occupying Postgres.
+
+Cloud Run's `containerConcurrency` remains deployment configuration owned by
+`druthers-infra`. Keep it at 80 unless the sync worker limit and this capacity
+model are changed with it. Every catalog search request has a 20-second total
+handler deadline, far below Cloud Run's 300-second request timeout.

--- a/tests/integration/rate_limit_test.py
+++ b/tests/integration/rate_limit_test.py
@@ -8,6 +8,8 @@ from unittest.mock import patch
 from fastapi.testclient import TestClient
 
 from app.config import Settings
+from app.db.database import get_db
+from app.run import app
 from app.services import rate_limit
 
 ENABLED = {'env': 'github', 'rate_limits_enabled': True}
@@ -113,14 +115,34 @@ def test_search_is_rate_limited_per_user(
     for _ in range(2):
         assert (
             test_client.get(
-                '/v1/movies/search?q=x', headers=_auth(test_client)
+                '/v1/movies/search?q=matrix', headers=_auth(test_client)
             ).status_code
             == 200
         )
     assert (
-        test_client.get('/v1/movies/search?q=x', headers=_auth(test_client)).status_code
+        test_client.get(
+            '/v1/movies/search?q=matrix', headers=_auth(test_client)
+        ).status_code
         == 429
     )
+    rate_limit.reset()
+
+
+@patch('app.services.rate_limit.get_settings')
+def test_search_limit_rejects_before_requesting_a_db_session(
+    mock_settings, test_client: TestClient
+):
+    """An exhausted search bucket rejects before auth asks Postgres for a row."""
+    rate_limit.reset()
+    mock_settings.return_value = Settings(**ENABLED, rate_limit_search=0)
+
+    def forbidden_db_dependency():
+        raise AssertionError('rate limiter requested a database session')
+
+    app.dependency_overrides[get_db] = forbidden_db_dependency
+    response = test_client.get('/v1/movies/search?q=matrix', headers=_auth(test_client))
+
+    assert response.status_code == 429
     rate_limit.reset()
 
 

--- a/tests/integration/router_movies_test.py
+++ b/tests/integration/router_movies_test.py
@@ -1,9 +1,19 @@
 # pylint: disable=missing-module-docstring, missing-function-docstring
+import asyncio
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import QueuePool
 
 from app.config import Settings
+from app.router.v1 import router_movies
+from app.run import settings as app_settings
 from app.services import watch_providers
 
 
@@ -503,3 +513,90 @@ def test_movie_watch_providers_requires_auth(test_client: TestClient):
 
     response = test_client.get(f"/v1/movies/{movie_id}/watch-providers")
     assert response.status_code == 401
+
+
+@patch('app.router.v1.router_movies.attach_tracked_status')
+@patch('app.router.v1.router_movies.tmdb_search_movies')
+def test_search_releases_db_connection_before_provider(mock_search, mock_attach):
+    db = MagicMock()
+    user = SimpleNamespace(pk=7)
+
+    def provider(_query):
+        db.close.assert_called_once_with()
+        return [{'tmdb': 1, 'title': 'Matrix'}]
+
+    expected = [{'tmdb': 1, 'title': 'Matrix'}]
+    mock_search.side_effect = provider
+    mock_attach.side_effect = lambda _db, _pk, results, _domain: results
+
+    results = asyncio.run(router_movies.search_movies_endpoint('matrix', db, [user]))
+
+    assert results[0]['title'] == 'Matrix'
+    mock_attach.assert_called_once_with(db, 7, expected, 'movies')
+
+
+@patch('app.router.v1.router_movies.correct_query', return_value=None)
+def test_concurrent_searches_above_pool_capacity_do_not_time_out(
+    _correct_query,
+):
+    pool_capacity = app_settings.db_pool_size + app_settings.db_max_overflow
+    request_count = pool_capacity + 4
+    engine = create_engine(
+        'sqlite://',
+        connect_args={'check_same_thread': False},
+        poolclass=QueuePool,
+        pool_size=app_settings.db_pool_size,
+        max_overflow=app_settings.db_max_overflow,
+        pool_timeout=0.2,
+    )
+    sessions = sessionmaker(bind=engine)
+    provider_barrier = threading.Barrier(request_count)
+    provider_release = threading.Barrier(request_count)
+
+    def provider(_query):
+        provider_barrier.wait(timeout=5)
+        assert engine.pool.checkedout() == 0
+        provider_release.wait(timeout=5)
+        return [{'tmdb': 1, 'title': 'Matrix'}]
+
+    def attach_status(db, _user_pk, results, _domain):
+        db.execute(text('SELECT 1'))
+        return results
+
+    def search_request():
+        db = sessions()
+        try:
+            db.execute(text('SELECT 1'))
+            return asyncio.run(
+                router_movies.search_movies_endpoint(
+                    'matrix', db, [SimpleNamespace(pk=7)]
+                )
+            )
+        finally:
+            db.close()
+
+    with (
+        patch.object(router_movies, 'tmdb_search_movies', side_effect=provider),
+        patch.object(router_movies, 'attach_tracked_status', side_effect=attach_status),
+        ThreadPoolExecutor(max_workers=request_count) as pool,
+    ):
+        futures = [pool.submit(search_request) for _ in range(request_count)]
+        results = [future.result(timeout=10) for future in futures]
+
+    assert all(result[0]['title'] == 'Matrix' for result in results)
+    engine.dispose()
+
+
+@patch('app.router.v1.router_movies.tmdb_search_movies')
+def test_search_handler_timeout_returns_clear_504(mock_search, test_client):
+    mock_search.side_effect = lambda _query: time.sleep(0.5) or []
+    headers = {'Authorization': f'Bearer {test_client.first_user.token}'}
+
+    started = time.monotonic()
+    with patch.object(app_settings, 'search_handler_timeout_seconds', 0.05):
+        response = test_client.get('/v1/movies/search?q=matrix', headers=headers)
+    elapsed = time.monotonic() - started
+
+    assert response.status_code == 504
+    assert response.json()['message'] == 'Search timed out, please try again'
+    assert elapsed < 0.25

--- a/tests/unit/book_search_test.py
+++ b/tests/unit/book_search_test.py
@@ -666,6 +666,10 @@ def test_google_books_request_carries_no_user_agent(mock_get, mock_settings):
 
 @patch('app.services.book_search.requests.get')
 def test_search_books_short_query_returns_empty_without_http(mock_get):
+    # Books keeps the three-character floor: Open Library answers 422 for
+    # anything shorter (probed 2026-08-20, api#398). This is the one domain
+    # where a two-letter title cannot be searched, and it is the provider's
+    # limit, not ours.
     assert not book_search.search_books('Go')
     mock_get.assert_not_called()
 

--- a/tests/unit/book_search_test.py
+++ b/tests/unit/book_search_test.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
+from fastapi import HTTPException
 
 from app.services import book_search
 
@@ -661,3 +662,31 @@ def test_google_books_request_carries_no_user_agent(mock_get, mock_settings):
     book_search.get_book_detail_by_googleid('_An-CAAAQBAJ')
 
     assert 'headers' not in mock_get.call_args.kwargs
+
+
+@patch('app.services.book_search.requests.get')
+def test_search_books_short_query_returns_empty_without_http(mock_get):
+    assert not book_search.search_books('Go')
+    mock_get.assert_not_called()
+
+
+@pytest.mark.parametrize('status_code', [422, 404])
+@patch('app.services.book_search.requests.get')
+def test_search_books_bad_query_4xx_returns_empty(mock_get, status_code):
+    response = MagicMock(status_code=status_code)
+    response.raise_for_status.side_effect = requests.HTTPError(response=response)
+    mock_get.return_value = response
+
+    assert not book_search.search_books('Warthunder')
+
+
+@pytest.mark.parametrize('status_code', [500, 401, 403])
+@patch('app.services.book_search.requests.get')
+def test_search_books_operator_http_error_returns_502(mock_get, status_code):
+    response = MagicMock(status_code=status_code)
+    response.raise_for_status.side_effect = requests.HTTPError(response=response)
+    mock_get.return_value = response
+
+    with pytest.raises(HTTPException) as exc:
+        book_search.search_books('Warthunder')
+    assert exc.value.status_code == 502

--- a/tests/unit/game_search_test.py
+++ b/tests/unit/game_search_test.py
@@ -278,3 +278,91 @@ def test_get_time_to_beat_no_community_data_returns_none(mock_post, mock_setting
 
     assert game_search.get_time_to_beat(1234) is None
     _reset_token_cache()
+
+
+@patch('app.services.game_search.requests.post')
+def test_search_games_short_query_returns_empty_without_http(mock_post):
+    assert not game_search.search_games('Go')
+    mock_post.assert_not_called()
+
+
+@pytest.mark.parametrize('status_code', [422, 404])
+@patch('app.services.game_search.get_settings')
+@patch('app.services.game_search.requests.post')
+def test_search_games_bad_query_4xx_returns_empty(
+    mock_post, mock_settings, status_code
+):
+    _reset_token_cache()
+    mock_settings.return_value = Settings(
+        twitch_client_id='cid', twitch_client_secret='secret', env='github'
+    )
+    token_response = MagicMock()
+    token_response.raise_for_status.return_value = None
+    token_response.json.return_value = {'access_token': 'tok', 'expires_in': 5000000}
+    query_response = MagicMock(status_code=status_code)
+    query_response.raise_for_status.side_effect = game_search.requests.HTTPError(
+        response=query_response
+    )
+    mock_post.side_effect = [token_response, query_response]
+
+    assert not game_search.search_games('Zelda')
+    _reset_token_cache()
+
+
+@pytest.mark.parametrize('status_code', [500, 403])
+@patch('app.services.game_search.get_settings')
+@patch('app.services.game_search.requests.post')
+def test_search_games_operator_http_error_returns_502(
+    mock_post, mock_settings, status_code
+):
+    _reset_token_cache()
+    mock_settings.return_value = Settings(
+        twitch_client_id='cid', twitch_client_secret='secret', env='github'
+    )
+    token_response = MagicMock()
+    token_response.raise_for_status.return_value = None
+    token_response.json.return_value = {'access_token': 'tok', 'expires_in': 5000000}
+    query_response = MagicMock(status_code=status_code)
+    query_response.raise_for_status.side_effect = game_search.requests.HTTPError(
+        response=query_response
+    )
+    mock_post.side_effect = [token_response, query_response]
+
+    with pytest.raises(HTTPException) as exc:
+        game_search.search_games('Zelda')
+    assert exc.value.status_code == 502
+    _reset_token_cache()
+
+
+@patch('app.services.game_search.get_settings')
+@patch('app.services.game_search.requests.post')
+def test_search_games_repeated_401_returns_502(mock_post, mock_settings):
+    _reset_token_cache()
+    mock_settings.return_value = Settings(
+        twitch_client_id='cid', twitch_client_secret='secret', env='github'
+    )
+
+    def token_response(value):
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {'access_token': value, 'expires_in': 5000000}
+        return response
+
+    def unauthorized_response():
+        response = MagicMock(status_code=401)
+        response.raise_for_status.side_effect = game_search.requests.HTTPError(
+            response=response
+        )
+        return response
+
+    mock_post.side_effect = [
+        token_response('first'),
+        unauthorized_response(),
+        token_response('second'),
+        unauthorized_response(),
+    ]
+
+    with pytest.raises(HTTPException) as exc:
+        game_search.search_games('Zelda')
+    assert exc.value.status_code == 502
+    _reset_token_cache()

--- a/tests/unit/game_search_test.py
+++ b/tests/unit/game_search_test.py
@@ -280,9 +280,30 @@ def test_get_time_to_beat_no_community_data_returns_none(mock_post, mock_setting
     _reset_token_cache()
 
 
+@patch('app.services.game_search.get_settings')
 @patch('app.services.game_search.requests.post')
-def test_search_games_short_query_returns_empty_without_http(mock_post):
+def test_search_games_reaches_igdb_for_a_two_character_query(mock_post, mock_settings):
+    # IGDB serves one-character queries (probed 2026-08-20, api#398).
+    _reset_token_cache()
+    mock_settings.return_value = Settings(
+        twitch_client_id='cid', twitch_client_secret='secret', env='github'
+    )
+    token_resp = MagicMock()
+    token_resp.raise_for_status.return_value = None
+    token_resp.json.return_value = {'access_token': 'tok', 'expires_in': 5000000}
+    games_resp = MagicMock()
+    games_resp.raise_for_status.return_value = None
+    games_resp.json.return_value = []
+    mock_post.side_effect = [token_resp, games_resp]
+
     assert not game_search.search_games('Go')
+    assert mock_post.call_count == 2
+    _reset_token_cache()
+
+
+@patch('app.services.game_search.requests.post')
+def test_search_games_empty_query_returns_empty_without_http(mock_post):
+    assert not game_search.search_games('   ')
     mock_post.assert_not_called()
 
 

--- a/tests/unit/movie_search_test.py
+++ b/tests/unit/movie_search_test.py
@@ -227,9 +227,20 @@ def test_search_movies_unconfigured_returns_503(mock_settings):
     assert exc.value.status_code == 503
 
 
+@patch('app.services.tmdb.get_settings')
 @patch('app.services.tmdb.requests.get')
-def test_search_movies_short_query_returns_empty_without_http(mock_get):
+def test_search_movies_reaches_tmdb_for_a_two_character_query(mock_get, mock_settings):
+    # TMDB serves one-character queries (probed 2026-08-20, api#398), so a
+    # two-letter title like Go must actually reach it.
+    mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+    mock_get.return_value = _response({'results': []})
     assert movie_search.search_movies('Go') == []
+    mock_get.assert_called()
+
+
+@patch('app.services.tmdb.requests.get')
+def test_search_movies_empty_query_returns_empty_without_http(mock_get):
+    assert movie_search.search_movies('   ') == []
     mock_get.assert_not_called()
 
 

--- a/tests/unit/movie_search_test.py
+++ b/tests/unit/movie_search_test.py
@@ -227,12 +227,40 @@ def test_search_movies_unconfigured_returns_503(mock_settings):
     assert exc.value.status_code == 503
 
 
+@patch('app.services.tmdb.requests.get')
+def test_search_movies_short_query_returns_empty_without_http(mock_get):
+    assert movie_search.search_movies('Go') == []
+    mock_get.assert_not_called()
+
+
+@pytest.mark.parametrize('status_code', [422, 404])
 @patch('app.services.tmdb.get_settings')
-def test_search_movies_empty_query_returns_400(mock_settings):
+@patch('app.services.tmdb.requests.get')
+def test_search_movies_bad_query_4xx_returns_empty(
+    mock_get, mock_settings, status_code
+):
     mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+    response = _response({}, status_code=status_code)
+    response.raise_for_status.side_effect = tmdb.requests.HTTPError(response=response)
+    mock_get.return_value = response
+
+    assert movie_search.search_movies('Titanic') == []
+
+
+@pytest.mark.parametrize('status_code', [500, 401, 403])
+@patch('app.services.tmdb.get_settings')
+@patch('app.services.tmdb.requests.get')
+def test_search_movies_operator_http_error_returns_502(
+    mock_get, mock_settings, status_code
+):
+    mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+    response = _response({}, status_code=status_code)
+    response.raise_for_status.side_effect = tmdb.requests.HTTPError(response=response)
+    mock_get.return_value = response
+
     with pytest.raises(HTTPException) as exc:
-        movie_search.search_movies('   ')
-    assert exc.value.status_code == 400
+        movie_search.search_movies('Titanic')
+    assert exc.value.status_code == 502
 
 
 @patch('app.services.tmdb.time.sleep')

--- a/tests/unit/search_policy_test.py
+++ b/tests/unit/search_policy_test.py
@@ -11,7 +11,9 @@ from fastapi import HTTPException
 
 from app.config import get_settings
 from app.services.search_policy import (
+    MIN_QUERY_LENGTH_BY_DOMAIN,
     is_bad_query_error,
+    min_query_length,
     normalized_search_query,
     run_search_provider,
 )
@@ -21,9 +23,26 @@ def _http_error(status_code: int) -> requests.HTTPError:
     return requests.HTTPError(response=MagicMock(status_code=status_code))
 
 
-def test_query_policy_normalizes_and_rejects_short_prefixes():
+def test_query_policy_normalizes_and_trims():
     assert normalized_search_query('  matrix  ', 'Movie') == 'matrix'
-    assert normalized_search_query('Go', 'Movie') is None
+
+
+def test_query_floor_follows_each_provider_not_the_strictest():
+    # Probed 2026-08-20 (api#398): TMDB, TVMaze and IGDB all serve
+    # one-character queries; Open Library rejects anything under three.
+    # Asserting the domains differ is the point, so a future change that
+    # flattens them back to one shared floor fails here.
+    assert normalized_search_query('Go', 'Movie') == 'Go'
+    assert normalized_search_query('Go', 'TV') == 'Go'
+    assert normalized_search_query('Go', 'Game') == 'Go'
+    assert normalized_search_query('Go', 'Book') is None
+
+    searchable = {d for d in MIN_QUERY_LENGTH_BY_DOMAIN if min_query_length(d) <= 2}
+    assert searchable == {'Movie', 'TV', 'Game'}
+
+
+def test_unknown_domain_fails_closed_to_the_conservative_floor():
+    assert normalized_search_query('Go', 'Podcast') is None
 
 
 def test_bad_query_policy_keeps_auth_rate_and_server_failures_loud():

--- a/tests/unit/search_policy_test.py
+++ b/tests/unit/search_policy_test.py
@@ -1,0 +1,55 @@
+"""Tests for shared catalog search input and upstream HTTP policy."""
+
+# pylint: disable=missing-function-docstring
+
+import asyncio
+import threading
+from unittest.mock import MagicMock
+
+import requests
+from fastapi import HTTPException
+
+from app.config import get_settings
+from app.services.search_policy import (
+    is_bad_query_error,
+    normalized_search_query,
+    run_search_provider,
+)
+
+
+def _http_error(status_code: int) -> requests.HTTPError:
+    return requests.HTTPError(response=MagicMock(status_code=status_code))
+
+
+def test_query_policy_normalizes_and_rejects_short_prefixes():
+    assert normalized_search_query('  matrix  ', 'Movie') == 'matrix'
+    assert normalized_search_query('Go', 'Movie') is None
+
+
+def test_bad_query_policy_keeps_auth_rate_and_server_failures_loud():
+    assert is_bad_query_error(_http_error(422))
+    assert not is_bad_query_error(_http_error(401))
+    assert not is_bad_query_error(_http_error(403))
+    assert not is_bad_query_error(_http_error(429))
+    assert not is_bad_query_error(_http_error(500))
+
+
+def test_provider_future_can_be_abandoned_at_request_deadline():
+    release = threading.Event()
+
+    async def run():
+        await run_search_provider(release.wait)
+
+    settings = get_settings()
+    original_timeout = settings.search_handler_timeout_seconds
+    settings.search_handler_timeout_seconds = 0.01
+    try:
+        try:
+            asyncio.run(run())
+        except HTTPException as exc:
+            assert exc.status_code == 504
+        else:
+            raise AssertionError('provider future did not honor cancellation')
+    finally:
+        settings.search_handler_timeout_seconds = original_timeout
+        release.set()

--- a/tests/unit/tv_search_test.py
+++ b/tests/unit/tv_search_test.py
@@ -249,8 +249,19 @@ def test_search_tv_shows_ordinary_title_query_unaffected(mock_get):
 
 
 @patch('app.services.tv_search.requests.get')
-def test_search_tv_shows_short_query_returns_empty_without_http(mock_get):
+def test_search_tv_shows_reaches_tvmaze_for_a_two_character_query(mock_get):
+    # TVMaze serves one-character queries (probed 2026-08-20, api#398).
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = []
+    mock_get.return_value = resp
     assert not tv_search.search_tv_shows('Go')
+    mock_get.assert_called()
+
+
+@patch('app.services.tv_search.requests.get')
+def test_search_tv_shows_empty_query_returns_empty_without_http(mock_get):
+    assert not tv_search.search_tv_shows('   ')
     mock_get.assert_not_called()
 
 

--- a/tests/unit/tv_search_test.py
+++ b/tests/unit/tv_search_test.py
@@ -2,6 +2,9 @@
 # pylint: disable=protected-access, missing-class-docstring
 from unittest.mock import MagicMock, patch
 
+import pytest
+from fastapi import HTTPException
+
 from app.services import tv_search
 
 
@@ -243,3 +246,35 @@ def test_search_tv_shows_ordinary_title_query_unaffected(mock_get):
         headers=tv_search.TVMAZE_HEADERS,
     )
     assert results[0]['title'] == 'Severance'
+
+
+@patch('app.services.tv_search.requests.get')
+def test_search_tv_shows_short_query_returns_empty_without_http(mock_get):
+    assert not tv_search.search_tv_shows('Go')
+    mock_get.assert_not_called()
+
+
+@pytest.mark.parametrize('status_code', [422, 404])
+@patch('app.services.tv_search.requests.get')
+def test_search_tv_shows_bad_query_4xx_returns_empty(mock_get, status_code):
+    response = MagicMock(status_code=status_code)
+    response.raise_for_status.side_effect = tv_search.requests.HTTPError(
+        response=response
+    )
+    mock_get.return_value = response
+
+    assert not tv_search.search_tv_shows('Severance')
+
+
+@pytest.mark.parametrize('status_code', [500, 401, 403])
+@patch('app.services.tv_search.requests.get')
+def test_search_tv_shows_operator_http_error_returns_502(mock_get, status_code):
+    response = MagicMock(status_code=status_code)
+    response.raise_for_status.side_effect = tv_search.requests.HTTPError(
+        response=response
+    )
+    mock_get.return_value = response
+
+    with pytest.raises(HTTPException) as exc:
+        tv_search.search_tv_shows('Severance')
+    assert exc.value.status_code == 502


### PR DESCRIPTION
## Summary

- Search authentication left the request-scoped SQLAlchemy session checked out
  while TMDB, TVMaze, Open Library and IGDB ran. FastAPI caches a dependency per
  request, so the auth lookup and the handler shared one session and `get_db`
  only closed it after the handler returned. A connection was therefore held,
  doing no database work, for the entire provider wait. Under ~20 concurrent
  searches the 10+10 pool was exhausted and requests failed on
  `db_pool_timeout`. All four domain handlers and global search now capture the
  user id, close the session before provider work, and reacquire only to attach
  tracked status.
- Provider work runs on a bounded 40-worker executor. The initial lookup and the
  spelling-correction retry share one 20 second deadline, so the retry can no
  longer double the hold time, and a timeout returns 504 instead of running to
  Cloud Run's 300 second ceiling. Prod had served this path at 138 seconds.
- The search rate limiter depended on `get_current_user`, so it had to consume a
  database connection before it could reject anything. A load shedder that first
  consumes the resource it protects cannot shed load. It now derives its key from
  a verified JWT subject or a hashed API-key credential and rejects with 429
  before requesting a session.
- Upstream 4xx was flattened into 502. `raise_for_status()` raises for 4xx and
  5xx alike, so "your query is malformed" was reported as "the gateway failed",
  which is a different claim and the wrong one. Query-related 4xx now resolves to
  an empty list below ERROR level. 401, 403 and 429 stay loud, because those mean
  our credentials or quota are wrong, not the query.
- Minimum query length is per-domain, taken from each provider's own probed
  behavior rather than the strictest one. This corrects a defect caught at demo:
  a single floor of 3 made every two-letter title (Go, Up, It, Us) unsearchable
  in three domains that never had the limit.
- `app/config.py` and `docs/search-capacity.md` now declare the 80 admitted Cloud
  Run requests, 40 search workers and 20 pooled connections, and explain why
  those numbers differ. The model depends on provider waits holding no
  connection.
- Not changed: `db_pool_size` stays at 10+10. Raising it treats the symptom and
  hides the defect. The live Cloud Run `containerConcurrency` also stays as-is;
  it is owned by druthers-infra#40, and this repo now declares the expected value
  so the two can be reconciled there.

### Provider floors, probed rather than chosen

Probed directly from the dev container on 2026-08-20, two independent trials,
identical results:

| Domain | Provider | `U` (1) | `Go` (2) | `Mat` (3) | Floor |
|---|---|---|---|---|---|
| Movies | TMDB | 20 results | 20 | 20 | 1 |
| TV | TVMaze | 10 results | 10 | 10 | 1 |
| Games | IGDB | 4 results | 5 | 4 | 1 |
| Books | Open Library | HTTP 422 | 422 | HTTP 200 | 3 |

Only Open Library has a real minimum. Its refusal sometimes arrives as a dropped
TLS connection rather than a clean 422, but it correlates perfectly with length
and never with the query text. The alert-noise this guard was partly meant to
address is already handled by the 4xx classification above, so the floor's only
remaining job is skipping a call certain to fail, which is a per-provider fact
rather than a policy choice. `MIN_CORRECTION_QUERY_LENGTH` is split out
separately, since whether a spelling correction is worth a round trip is a
different question from what a provider accepts.

## Test plan

- [x] `pytest` - **1083 passed**. New cases: per-domain assertions that a short
      query issues no HTTP call for books and does reach the provider for movies,
      TV and games; query-related 4xx yields an empty list; 5xx still yields 502;
      401 stays an error; the session is closed before provider entry; 24
      simultaneous searches against the configured 20-connection pool leave zero
      connections checked out at the provider barrier; a 500ms provider returns
      504 under a 50ms test deadline; an exhausted search bucket returns 429 even
      when acquiring any DB dependency would fail the test.
- [x] The per-domain floor test asserts the domains **differ**
      (`searchable == {'Movie', 'TV', 'Game'}`), so flattening them back to one
      shared constant fails the suite rather than passing silently. The previous
      tests asserted the bug as the specification and passed.
- [x] Verified against the local dev stack: `q=Go` returns 20 movies, 10 TV, 20
      games and short-circuits books in 6ms with no provider call and zero ERROR
      log lines. `q=U` behaves the same. `q=Matrix` returns results in all four.
- [x] Fired 24 concurrent authenticated searches against a 10+10 pool: **24/24
      returned 200, zero `QueuePool limit` errors** in the container logs.
- [x] Open Library went down during the demo (`SSLEOFError`), which exercised the
      real path by accident: the transport failure was correctly classified as
      genuine unavailability and returned 502 loudly, rather than being swallowed
      into an empty result.

## Checklist

- [x] Branch named `feat/…`, `fix/…`, or `chore/…`
- [x] New module has a test file in this PR (see CLAUDE.md → Testing)
- [x] Per-domain change checked against the other three domains (movies/TV/books/games)
- [ ] CI green (lint + tests) - pending on this push
- [x] No secrets committed
- [x] Docs/README updated if behavior changed (`docs/search-capacity.md`)

Closes #393. Closes #392. Closes #398.
