### PR TITLE
Add graphify-out/ and env/ to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,6 +22,13 @@ __pycache__/
 # Log files
 *.log
 
+# AI knowledge-graph output; nothing at runtime reads it
+graphify-out/
+
+# Env directory: *.env and .env.* above only match root-level files, so
+# env/prod.env (and the .template files) slip through without this entry
+env/
+
 .reports/
 
 .venv/

--- a/tests/unit/dockerfile_test.py
+++ b/tests/unit/dockerfile_test.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 DOCKERFILE = Path(__file__).parents[2] / 'Dockerfile'
+DOCKERIGNORE = Path(__file__).parents[2] / '.dockerignore'
 
 
 def test_runtime_stage_uses_builder_wheels_without_build_toolchains():
@@ -31,3 +32,16 @@ def test_runtime_healthcheck_targets_health_endpoint():
 
     assert "'/health'" in dockerfile
     assert 'HEALTHCHECK' in dockerfile
+
+
+# Paths that exist in a working checkout but must not appear in the image.
+# graphify-out/ is ~50 MB of AI tooling output; env/ holds dev/qa/prod env
+# files whose names are not caught by the *.env glob (no cross-slash match).
+IGNORED_DIRS = ['graphify-out/', 'env/']
+
+
+def test_dockerignore_excludes_large_and_sensitive_dirs():
+    """Directories that only matter locally must not leak into the image."""
+    ignore = DOCKERIGNORE.read_text()
+    for dirname in IGNORED_DIRS:
+        assert dirname in ignore, f'{dirname} missing from .dockerignore'


### PR DESCRIPTION
## Summary

- The Dockerfile ends in `COPY . .`, so anything not excluded by `.dockerignore`
  ships in the image. Two things were slipping through: `graphify-out/`, roughly
  50 MB of knowledge-graph output that nothing at runtime reads, and `env/`,
  which holds the dev, qa and prod env files.
- `env/` was the more surprising gap. The existing `*.env` and `.env.*` patterns
  only match at the root, because a glob does not cross `/`, so `env/prod.env`
  was never covered by them. Both entries are now listed with a comment
  explaining that path-matching subtlety, since the reason is not obvious from
  the patterns themselves.
- No runtime behavior changes. Env values are passed to the container at run
  time via `--env-file`, never read from a baked-in copy, so removing them from
  the build context does not affect a running container.

## Test plan

- [x] `pytest` - **1049 passed**, including the new
      `tests/unit/dockerfile_test.py::test_dockerignore_excludes_large_and_sensitive_dirs`
      asserting both entries are present.
- [x] Verified against a real build rather than the file alone:
      `docker build -t druthers-api:demo-395 .` completes clean, and
      `docker run --rm druthers-api:demo-395 ls -a /app` shows **neither**
      `env/` nor `graphify-out/`, while `app`, `alembic` and the rest land
      normally. This mattered because `COPY . .` means an over-broad exclusion
      would silently break the image.

## Checklist

- [x] Branch named `feat/…`, `fix/…`, or `chore/…`
- [x] New module has a test file in this PR (see CLAUDE.md → Testing)
- [x] Per-domain change checked against the other three domains (movies/TV/books/games) - n/a, build context only
- [ ] CI green (lint + tests) - pending on this push
- [x] No secrets committed - this PR removes env files from the image
- [x] Docs/README updated if behavior changed - n/a

Known gap, deliberately not in scope: `druthers-web` and `druthers-mcp` have not
been checked for the same `.dockerignore` pattern. Worth a follow-up issue.

Closes #395.
