### PR TITLE
fix(ci): scan dependencies the SCA gate was silently skipping

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,9 @@ jobs:
     uses: ALeonard9/.github/.github/workflows/security-reusable.yml@main
     with:
       stack: python
+      # trivy's pip analyzer only matches a file named requirements.txt;
+      # without this it scans zero dependencies and still reports green.
+      file_patterns: 'pip:requirements/.*\.txt'
       builds_image: true
       block: true            # enforced - findings resolved
       severity: "CRITICAL,HIGH"


### PR DESCRIPTION
## Summary

- trivy's pip analyzer only recognises a file literally named `requirements.txt`. This repo keeps dependencies in `requirements/{base,dev,test}.txt`, so `trivy fs` logged `0 language-specific files` and exited clean having checked no dependency at all.
- This applied to the **blocking gate**, not just the informational scan, so the required `scan / scan` check has been passing on an empty scan rather than a clean one.
- Pass `file_patterns` so the pip analyzer matches all three files.

Three lines of YAML. The real fix is in the shared workflow, which now fails any repo that declares a stack and matches zero packages, so this cannot silently regress.

## Test plan

- [x] Reproduced in CI: run 32427442660 logs `Number of language-specific files num=0`.
- [x] Locally, `TRIVY_FILE_PATTERNS='pip:requirements/.*\.txt'` takes trivy from **0 manifests to 3**, **34 packages**, **0 vulnerabilities** (so the six transitive pins in `requirements/base.txt` are still holding).
- [x] Verified the guard in the shared workflow reports 0 packages without this input and 34 with it.

## Dependency

Blocked on ALeonard9/.github#9, which defines the `file_patterns` input. Passing an input the reusable workflow does not define is a hard error, so **that PR must merge first**. Once it does, merge this promptly: the new guard fails this repo's `scan` check until this lands, and it is a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYsokjNE3FQ93esbQtm4By