### PR TITLE
fix(security): resolve all 33 open Semgrep findings, and one real secret leak behind them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/requirements/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups: # Rather than get 5 PRs for each new version, do 1 PR
       all-dependencies:
         patterns:
@@ -17,7 +19,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/deploy_cloud_run.yaml
+++ b/.github/workflows/deploy_cloud_run.yaml
@@ -27,16 +27,16 @@ jobs:
       IMAGE: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/druthers/druthers-api:${{ github.event.release.tag_name }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
         with:
           workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
           service_account: ${{ vars.GCP_DEPLOY_SA }}
 
       - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
 
       - name: Build and push image
         run: |

--- a/.github/workflows/deploy_qa.yaml
+++ b/.github/workflows/deploy_qa.yaml
@@ -27,16 +27,16 @@ jobs:
       IMAGE: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID_QA }}/druthers/druthers-api:main-${{ github.sha }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
         with:
           workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER_QA }}
           service_account: ${{ vars.GCP_DEPLOY_SA_QA }}
 
       - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
 
       - name: Build and push image
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
       with:
         python-version: "3.14"
 

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -41,26 +41,36 @@ jobs:
 
       - name: Resolve source digest
         id: src
+        env:
+          SOURCE_TAG: ${{ inputs.source_tag }}
+          TARGET: ${{ inputs.target }}
         run: |
           set -euo pipefail
-          ref="${REGISTRY}/${IMAGE_NAME}:${{ inputs.source_tag }}"
+          ref="${REGISTRY}/${IMAGE_NAME}:${SOURCE_TAG}"
           digest=$(docker buildx imagetools inspect "$ref" --format '{{.Manifest.Digest}}')
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
-          echo "Promoting ${IMAGE_NAME}@${digest} → :${{ inputs.target }}"
+          echo "Promoting ${IMAGE_NAME}@${digest} → :${TARGET}"
 
       - name: Re-tag the exact digest to the target (no rebuild)
+        env:
+          TARGET: ${{ inputs.target }}
+          SOURCE_DIGEST: ${{ steps.src.outputs.digest }}
         run: |
           set -euo pipefail
           docker buildx imagetools create \
-            --tag "${REGISTRY}/${IMAGE_NAME}:${{ inputs.target }}" \
-            --tag "${REGISTRY}/${IMAGE_NAME}:${{ inputs.target }}-${{ github.run_number }}" \
-            "${REGISTRY}/${IMAGE_NAME}@${{ steps.src.outputs.digest }}"
+            --tag "${REGISTRY}/${IMAGE_NAME}:${TARGET}" \
+            --tag "${REGISTRY}/${IMAGE_NAME}:${TARGET}-${{ github.run_number }}" \
+            "${REGISTRY}/${IMAGE_NAME}@${SOURCE_DIGEST}"
 
       - name: Record promotion
+        env:
+          SOURCE_TAG: ${{ inputs.source_tag }}
+          TARGET: ${{ inputs.target }}
+          SOURCE_DIGEST: ${{ steps.src.outputs.digest }}
         run: |
           {
-            echo "### Promoted \`${{ inputs.source_tag }}\` → \`${{ inputs.target }}\`"
+            echo "### Promoted \`${SOURCE_TAG}\` → \`${TARGET}\`"
             echo ""
-            echo "- Image: \`${IMAGE_NAME}@${{ steps.src.outputs.digest }}\`"
+            echo "- Image: \`${IMAGE_NAME}@${SOURCE_DIGEST}\`"
             echo "- Approved by: @${{ github.actor }}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -18,7 +18,7 @@ jobs:
         id-token: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
     - name: Log in to the Container registry
       uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
@@ -46,7 +46,7 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
 
     - name: Generate artifact attestation
-      uses: actions/attest-build-provenance@v4
+      uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8
       with:
         subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
         subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,9 @@ jobs:
       builds_image: true
       block: true            # enforced - findings resolved
       severity: "CRITICAL,HIGH"
-    secrets: inherit
+    # security-reusable.yml declares no `secrets:` in its workflow_call and
+    # never references `secrets.*` (it uses the auto-provided github.token),
+    # so there is nothing to pass through here.
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
       with:
         python-version: "3.14"
 
@@ -47,14 +47,14 @@ jobs:
           ./.venv/bin/pytest -q -W error
 
     - name: Upload Test Results
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: test-results
         path: .reports/junit/test-results.html
         retention-days: 60
 
     - name: Upload Coverage Report
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: coverage-report
         path: .reports/coverage

--- a/alembic/versions/8f2c1a4d9b73_tracker_unique_constraints.py
+++ b/alembic/versions/8f2c1a4d9b73_tracker_unique_constraints.py
@@ -81,6 +81,9 @@ def _survivor_order(tracker: TrackerTable) -> str:
 
 def _dedupe_tracker(tracker: TrackerTable) -> None:
     """Delete every duplicate except the deterministic preferred survivor."""
+    # nosemgrep: avoid-sqlalchemy-text
+    # table_name/fk_column come from the literal TRACKER_TABLES tuple above,
+    # never user input; this is a one-time migration cleanup, not a request path.
     op.execute(sa.text(f"""
             WITH ordered_rows AS (
                 SELECT pk,
@@ -101,6 +104,9 @@ def _dedupe_tracker(tracker: TrackerTable) -> None:
 
 def _assert_no_duplicate_groups(tracker: TrackerTable) -> None:
     """Fail the migration before DDL if cleanup left any duplicate groups."""
+    # nosemgrep: avoid-sqlalchemy-text
+    # table_name/fk_column come from the literal TRACKER_TABLES tuple above,
+    # never user input; this is a one-time migration check, not a request path.
     duplicate_groups = op.get_bind().execute(sa.text(f"""
             SELECT COUNT(*)
               FROM (

--- a/alembic/versions/ab29c4e81f70_default_privacy_overrides.py
+++ b/alembic/versions/ab29c4e81f70_default_privacy_overrides.py
@@ -65,6 +65,9 @@ def downgrade() -> None:
     """Restore concrete friends-tier shelf values before dropping the default."""
     with op.batch_alter_table('users', schema=None) as batch_op:
         for column in SHELF_TIER_COLUMNS:
+            # nosemgrep: avoid-sqlalchemy-text
+            # column is always one of the literal SHELF_TIER_COLUMNS names
+            # above, never user input; this is a one-time migration downgrade.
             batch_op.execute(
                 sa.text(
                     f'UPDATE users SET {column} = default_privacy WHERE {column} IS NULL'

--- a/alembic/versions/d3b81f4a9c67_rank_1_based_check.py
+++ b/alembic/versions/d3b81f4a9c67_rank_1_based_check.py
@@ -57,6 +57,9 @@ def upgrade() -> None:
     """Repair any non-1-based ranks, then enforce the invariant."""
     for table in TRACKER_TABLES:
         # An unplaced tracker holds no position (see module docstring).
+        # nosemgrep: sqlalchemy-execute-raw-query,formatted-sql-query
+        # table is always one of the literal TRACKER_TABLES names above, never
+        # user input; this is a one-time migration repair, not a request path.
         op.execute(f"""
             UPDATE {table}
                SET rank = NULL
@@ -65,6 +68,9 @@ def upgrade() -> None:
             """)
         # Dense 1..N per user, preserving the order the ranks already express.
         # pk breaks ties so duplicate ranks resolve deterministically.
+        # nosemgrep: sqlalchemy-execute-raw-query,formatted-sql-query
+        # table is always one of the literal TRACKER_TABLES names above, never
+        # user input; this is a one-time migration repair, not a request path.
         op.execute(f"""
             WITH renumbered AS (
                 SELECT pk,

--- a/app/auth/refresh_tokens.py
+++ b/app/auth/refresh_tokens.py
@@ -239,6 +239,9 @@ def rotate_refresh_token(db: Session, token: str) -> Tuple[DbUser, str]:
         # Outside the window this is a genuine replay of a spent token, or a
         # token revoked at sign-out. Either way the chain is no longer
         # trustworthy and everything in it dies.
+        # nosemgrep: python-logger-credential-disclosure
+        # only user_id and family_id (opaque identifiers) are logged; the
+        # token value itself is never formatted into this message.
         logger.warning(
             'Refresh token replay detected for user_id=%s family=%s; '
             'revoking the family',

--- a/app/migration/orion_import.py
+++ b/app/migration/orion_import.py
@@ -177,6 +177,9 @@ def _migrate_catalog(
     (natural_filter, values). Returns legacy_id -> target pk.
     """
     mapping: Dict[int, int] = {}
+    # nosemgrep: avoid-sqlalchemy-text
+    # table/columns are always literal strings from the call sites in this
+    # module (see run_import), never request or user-supplied input.
     rows = src.execute(
         text(f'SELECT {columns} FROM {table}')  # nosec: fixed column/table names
     ).mappings()
@@ -195,6 +198,9 @@ def _migrate_tracker(
     src, session, report, table, model, columns, transform, valid: Callable
 ):
     """Generic gerund/tracker migration keyed on (user_id, item_id)."""
+    # nosemgrep: avoid-sqlalchemy-text
+    # table/columns are always literal strings from the call sites in this
+    # module (see run_import), never request or user-supplied input.
     rows = src.execute(
         text(f'SELECT {columns} FROM {table}')  # nosec: fixed column/table names
     ).mappings()

--- a/app/services/book_search.py
+++ b/app/services/book_search.py
@@ -695,6 +695,8 @@ def _google_books_detail(googleid: str) -> Optional[dict]:
     if not api_key:
         # Once per book would be a wall of noise on a bulk run; enrich_books
         # reports the disabled fallback once, up front.
+        # nosemgrep: python-logger-credential-disclosure
+        # only the volume id is logged; the key's value never appears here.
         logger.debug('GOOGLE_BOOKS_API_KEY unset; skipping %s', googleid)
         return None
     try:

--- a/app/services/game_search.py
+++ b/app/services/game_search.py
@@ -57,9 +57,13 @@ def _access_token() -> str:
 
     client_id, client_secret = _credentials()
     try:
+        # The credentials go in the form body, never the query string.
+        # requests puts the full URL (query string included) into the message
+        # of any RequestException, so a client_secret passed as a param leaks
+        # into the log line below on every upstream error.
         response = requests.post(
             TWITCH_OAUTH_URL,
-            params={
+            data={
                 'client_id': client_id,
                 'client_secret': client_secret,
                 'grant_type': 'client_credentials',
@@ -70,8 +74,8 @@ def _access_token() -> str:
         payload = response.json()
     except (requests.RequestException, ValueError) as exc:
         # nosemgrep: python-logger-credential-disclosure
-        # exc is the request exception (status/URL), not the client secret or
-        # the issued token; neither is ever formatted into a log line.
+        # exc carries the status and URL only; the credentials travel in the
+        # form body (above) and the issued token is never logged.
         logger.error('Twitch OAuth token request failed: %s', exc)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,

--- a/app/services/game_search.py
+++ b/app/services/game_search.py
@@ -69,6 +69,9 @@ def _access_token() -> str:
         response.raise_for_status()
         payload = response.json()
     except (requests.RequestException, ValueError) as exc:
+        # nosemgrep: python-logger-credential-disclosure
+        # exc is the request exception (status/URL), not the client secret or
+        # the issued token; neither is ever formatted into a log line.
         logger.error('Twitch OAuth token request failed: %s', exc)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,

--- a/tests/unit/game_search_test.py
+++ b/tests/unit/game_search_test.py
@@ -387,3 +387,51 @@ def test_search_games_repeated_401_returns_502(mock_post, mock_settings):
         game_search.search_games('Zelda')
     assert exc.value.status_code == 502
     _reset_token_cache()
+
+
+@patch('app.services.game_search.get_settings')
+@patch('app.services.game_search.requests.post')
+def test_token_request_keeps_the_secret_out_of_the_query_string(
+    mock_post, mock_settings
+):
+    """The client secret belongs in the form body, never in the URL.
+
+    requests folds the full URL, query string included, into the message of
+    any RequestException. A secret passed as a param would therefore be
+    written verbatim to the error log on every upstream failure.
+    """
+    _reset_token_cache()
+    mock_settings.return_value = Settings(
+        twitch_client_id='cid', twitch_client_secret='secret', env='github'
+    )
+    token_resp = MagicMock()
+    token_resp.raise_for_status.return_value = None
+    token_resp.json.return_value = {'access_token': 'tok', 'expires_in': 5000000}
+    mock_post.return_value = token_resp
+
+    assert game_search._access_token() == 'tok'
+
+    _, kwargs = mock_post.call_args
+    assert kwargs['data']['client_secret'] == 'secret'
+    assert 'client_secret' not in (kwargs.get('params') or {})
+    _reset_token_cache()
+
+
+@patch('app.services.game_search.get_settings')
+@patch('app.services.game_search.requests.post')
+def test_token_failure_log_does_not_carry_the_secret(mock_post, mock_settings, caplog):
+    """A failed token request must not log the client secret."""
+    _reset_token_cache()
+    mock_settings.return_value = Settings(
+        twitch_client_id='cid', twitch_client_secret='sup3rs3cret', env='github'
+    )
+    mock_post.side_effect = game_search.requests.RequestException(
+        'Unauthorized for url: https://id.twitch.tv/oauth2/token'
+    )
+
+    with caplog.at_level('ERROR'):
+        with pytest.raises(HTTPException) as exc:
+            game_search._access_token()
+    assert exc.value.status_code == 502
+    assert 'sup3rs3cret' not in caplog.text
+    _reset_token_cache()


### PR DESCRIPTION
## Summary

Semgrep ran against this repo for the first time and opened 33 findings. This resolves all 33, plus one true positive hiding behind them.

**The Twitch client secret was reaching the error log.** `_access_token` passed `client_secret` to the OAuth endpoint as a *query parameter*, and `requests` folds the full URL, query string included, into the message of every `RequestException`. So any upstream failure (a 401, a timeout, a DNS blip) wrote the live secret verbatim into `logger.error`. Semgrep flagged the log line; the leak was one layer up, in how the request was built, which is why it reads as a false positive at the call site. The credentials now travel in the form body, which is where the `client_credentials` grant expects them anyway, so the exception message carries only the status and the bare URL.

The rest, in descending order of real risk:

- **Shell injection in `promote.yaml` (3 findings).** `inputs.source_tag`, `inputs.target` and a step output were interpolated as `${{ }}` directly into `run:` text, where a crafted tag value would execute in a job that holds GHCR push credentials. All three steps now bind them into a step-level `env:` map and reference them as quoted shell variables. Every other workflow was swept for the same pattern; nothing else was a real vector (`deploy_cloud_run.yaml` builds `IMAGE` in an `env:` block, and `promote.yaml`'s `environment: ${{ inputs.target }}` selects a GitHub Environment name, not shell).
- **`secrets: inherit` in `security.yml`** handed the caller's entire secret set to a reusable workflow that declares none. `security-reusable.yml`'s `on.workflow_call` has no `secrets:` key and never references `secrets.*`. The line was dropped, with a comment recording why.
- **11 mutable action tags** across `test.yaml`, `lint.yaml`, `publish_docker.yaml`, `deploy_qa.yaml` and `deploy_cloud_run.yaml`, pinned to full commit SHAs resolved from the GitHub API. Matches the existing no-comment pin style already used for the `docker/*` actions in this repo.
- **3 Dependabot ecosystems with no cooldown**, so a compromised release could be proposed the moment it published. Now `cooldown: { default-days: 7 }`.
- **9 raw-SQL findings** across three alembic migrations and `orion_import.py`. Every interpolated table and column name traces to a literal tuple or a literal call-site string, never runtime input. Suppressed with `nosemgrep` and a reason rather than rewriting migration history that has already been applied.
- **2 remaining logger findings** (`book_search.py` logs a volume id, `refresh_tokens.py` logs opaque user and family ids) verified as genuine false positives and suppressed with justification.

## Test plan

- [x] `pytest -q`: 1088 passed, 0 failed (up from 1086; the 2 new tests are the secret-handling guards)
- [x] Added `test_token_request_keeps_the_secret_out_of_the_query_string` (secret is in the form body, absent from query params) and `test_token_failure_log_does_not_carry_the_secret` (a failed token request logs nothing matching the secret)
- [x] Confirmed the guard actually catches the bug: reverting `data=` to `params=` fails the first test, and it passes again on restore. Not a test that would pass either way.
- [x] Full pre-commit suite passes, including the hardcoded-secrets detector, `black --skip-string-normalization` and `pylint` (10.00/10)
- [x] Every touched workflow and `dependabot.yml` parses via `yaml.safe_load` (`actionlint` not available in this environment)
- [x] Every action SHA resolved with `gh api repos/<owner>/<action>/git/ref/tags/<tag>`, not hand-written
- [ ] Verify on merge that the security workflow still runs green with `secrets: inherit` gone, and that all 33 alerts close on the next scan
- [ ] Exercise a real `promote.yaml` run: the env-var rewrite is the only change here that could break a working deploy path

## Notes for the reviewer

Two judgment calls worth a look. The `secrets: inherit` removal assumes `security-reusable.yml@main` stays secret-free; if it ever adds a `workflow_call` secret, all three druthers repos need an explicit block at the same time. And the new SHA pins here carry no `# vX.Y.Z` comment, matching this repo's existing style, while the equivalent druthers-web PR does add them; the two repos now differ cosmetically.

Separately, and deliberately **not** handled in this PR: if that Twitch error path has ever fired in production, the secret is already in the logs and rotating it is a live-credentials operation, not a code change.
