### PR TITLE
fix(security): make the 12 dead nosemgrep suppressions actually suppress

### DIFF
--- a/alembic/versions/8f2c1a4d9b73_tracker_unique_constraints.py
+++ b/alembic/versions/8f2c1a4d9b73_tracker_unique_constraints.py
@@ -81,9 +81,9 @@ def _survivor_order(tracker: TrackerTable) -> str:
 
 def _dedupe_tracker(tracker: TrackerTable) -> None:
     """Delete every duplicate except the deterministic preferred survivor."""
-    # nosemgrep: avoid-sqlalchemy-text
     # table_name/fk_column come from the literal TRACKER_TABLES tuple above,
     # never user input; this is a one-time migration cleanup, not a request path.
+    # nosemgrep: avoid-sqlalchemy-text
     op.execute(sa.text(f"""
             WITH ordered_rows AS (
                 SELECT pk,
@@ -104,9 +104,9 @@ def _dedupe_tracker(tracker: TrackerTable) -> None:
 
 def _assert_no_duplicate_groups(tracker: TrackerTable) -> None:
     """Fail the migration before DDL if cleanup left any duplicate groups."""
-    # nosemgrep: avoid-sqlalchemy-text
     # table_name/fk_column come from the literal TRACKER_TABLES tuple above,
     # never user input; this is a one-time migration check, not a request path.
+    # nosemgrep: avoid-sqlalchemy-text
     duplicate_groups = op.get_bind().execute(sa.text(f"""
             SELECT COUNT(*)
               FROM (

--- a/alembic/versions/ab29c4e81f70_default_privacy_overrides.py
+++ b/alembic/versions/ab29c4e81f70_default_privacy_overrides.py
@@ -65,10 +65,10 @@ def downgrade() -> None:
     """Restore concrete friends-tier shelf values before dropping the default."""
     with op.batch_alter_table('users', schema=None) as batch_op:
         for column in SHELF_TIER_COLUMNS:
-            # nosemgrep: avoid-sqlalchemy-text
             # column is always one of the literal SHELF_TIER_COLUMNS names
             # above, never user input; this is a one-time migration downgrade.
             batch_op.execute(
+                # nosemgrep: avoid-sqlalchemy-text
                 sa.text(
                     f'UPDATE users SET {column} = default_privacy WHERE {column} IS NULL'
                 )

--- a/alembic/versions/d3b81f4a9c67_rank_1_based_check.py
+++ b/alembic/versions/d3b81f4a9c67_rank_1_based_check.py
@@ -57,9 +57,9 @@ def upgrade() -> None:
     """Repair any non-1-based ranks, then enforce the invariant."""
     for table in TRACKER_TABLES:
         # An unplaced tracker holds no position (see module docstring).
-        # nosemgrep: sqlalchemy-execute-raw-query,formatted-sql-query
         # table is always one of the literal TRACKER_TABLES names above, never
         # user input; this is a one-time migration repair, not a request path.
+        # nosemgrep: sqlalchemy-execute-raw-query,formatted-sql-query
         op.execute(f"""
             UPDATE {table}
                SET rank = NULL
@@ -68,9 +68,9 @@ def upgrade() -> None:
             """)
         # Dense 1..N per user, preserving the order the ranks already express.
         # pk breaks ties so duplicate ranks resolve deterministically.
-        # nosemgrep: sqlalchemy-execute-raw-query,formatted-sql-query
         # table is always one of the literal TRACKER_TABLES names above, never
         # user input; this is a one-time migration repair, not a request path.
+        # nosemgrep: sqlalchemy-execute-raw-query,formatted-sql-query
         op.execute(f"""
             WITH renumbered AS (
                 SELECT pk,

--- a/app/auth/refresh_tokens.py
+++ b/app/auth/refresh_tokens.py
@@ -239,9 +239,9 @@ def rotate_refresh_token(db: Session, token: str) -> Tuple[DbUser, str]:
         # Outside the window this is a genuine replay of a spent token, or a
         # token revoked at sign-out. Either way the chain is no longer
         # trustworthy and everything in it dies.
-        # nosemgrep: python-logger-credential-disclosure
         # only user_id and family_id (opaque identifiers) are logged; the
         # token value itself is never formatted into this message.
+        # nosemgrep: python-logger-credential-disclosure
         logger.warning(
             'Refresh token replay detected for user_id=%s family=%s; '
             'revoking the family',

--- a/app/migration/orion_import.py
+++ b/app/migration/orion_import.py
@@ -177,10 +177,10 @@ def _migrate_catalog(
     (natural_filter, values). Returns legacy_id -> target pk.
     """
     mapping: Dict[int, int] = {}
-    # nosemgrep: avoid-sqlalchemy-text
     # table/columns are always literal strings from the call sites in this
     # module (see run_import), never request or user-supplied input.
     rows = src.execute(
+        # nosemgrep: avoid-sqlalchemy-text
         text(f'SELECT {columns} FROM {table}')  # nosec: fixed column/table names
     ).mappings()
     for row in rows:
@@ -198,10 +198,10 @@ def _migrate_tracker(
     src, session, report, table, model, columns, transform, valid: Callable
 ):
     """Generic gerund/tracker migration keyed on (user_id, item_id)."""
-    # nosemgrep: avoid-sqlalchemy-text
     # table/columns are always literal strings from the call sites in this
     # module (see run_import), never request or user-supplied input.
     rows = src.execute(
+        # nosemgrep: avoid-sqlalchemy-text
         text(f'SELECT {columns} FROM {table}')  # nosec: fixed column/table names
     ).mappings()
     for row in rows:

--- a/app/services/book_search.py
+++ b/app/services/book_search.py
@@ -695,8 +695,8 @@ def _google_books_detail(googleid: str) -> Optional[dict]:
     if not api_key:
         # Once per book would be a wall of noise on a bulk run; enrich_books
         # reports the disabled fallback once, up front.
-        # nosemgrep: python-logger-credential-disclosure
         # only the volume id is logged; the key's value never appears here.
+        # nosemgrep: python-logger-credential-disclosure
         logger.debug('GOOGLE_BOOKS_API_KEY unset; skipping %s', googleid)
         return None
     try:

--- a/app/services/game_search.py
+++ b/app/services/game_search.py
@@ -73,9 +73,9 @@ def _access_token() -> str:
         response.raise_for_status()
         payload = response.json()
     except (requests.RequestException, ValueError) as exc:
-        # nosemgrep: python-logger-credential-disclosure
         # exc carries the status and URL only; the credentials travel in the
         # form body (above) and the issued token is never logged.
+        # nosemgrep: python-logger-credential-disclosure
         logger.error('Twitch OAuth token request failed: %s', exc)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,


### PR DESCRIPTION
## Summary

- **Cause:** a `nosemgrep` comment only suppresses a finding when it sits on the flagged line, or on the line *immediately* above it. #404 resolved 33 findings, but 12 of its fixes wrote the suppression as a comment block with one or two lines of justification wedged between the `nosemgrep` and the code. The adjacency broke, so those 12 suppressed nothing and the alerts returned on the next scan of `main`.
- **Fix:** reordered comments at all 10 sites so the justification comes first and the `nosemgrep` sits directly on top of the flagged line. Two sites in `orion_import.py` needed it moved inside the call parentheses, because Semgrep flags the inner `text(...)` line rather than the `src.execute(` line.
- **What does not change:** comments only. No executable code, no strings, no logic, no runtime behavior. The false-positive judgment #404 made about these 12 is preserved, not revisited; spot-checking supports it (interpolated table/column names come from module-level literal tuples, and the flagged loggers format only opaque ids). Rewriting the underlying calls rather than suppressing them would be separate, larger work.
- #404's other 21 fixes were real. This only touches the 12 that silently failed.

## Test plan

- [x] **Reproduced the failure first.** Ran Semgrep locally against `main` with the same rulesets CI uses (`p/default`, `p/python`); it produced exactly 12 findings, matching the 12 open GitHub code-scanning alerts line for line.
- [x] **Confirmed the fix.** Same command over `app/` and `alembic/` after the change: **0 findings**.
- [x] `pytest -q` -> **1088 passed**, no failures, no skips.
- [x] `black --check --skip-string-normalization app alembic` -> 128 files unchanged. Full pre-commit hook set passed on commit with no reformatting.
- [x] No local dev stack verification: this change alters no runtime behavior, so there is nothing observable to demo. The 12 -> 0 Semgrep delta is the evidence.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DiAK4YvMuZMZNz6q77SXU

