### PR TITLE
feat: adopt product analytics from druthers-infra

### DIFF
--- a/.github/workflows/deploy_cloud_run.yaml
+++ b/.github/workflows/deploy_cloud_run.yaml
@@ -125,3 +125,19 @@ jobs:
             --image "$IMAGE" \
             --region ${{ vars.GCP_REGION }} \
             --project ${{ vars.GCP_PROJECT_ID }}
+
+      # Tell the druthers super repo which tag is now deployed, so its pinned
+      # submodule stops describing the previous release. Last step on purpose:
+      # the pointer should only move once the roll above has succeeded.
+      # DRUTHERS_SUPER_TOKEN is a fine-grained PAT with contents:write on
+      # ALeonard9/druthers only; GITHUB_TOKEN cannot reach another repo.
+      - name: Notify super repo of release
+        if: success()
+        continue-on-error: true   # a missed pointer is caught by staleness.yml
+        env:
+          GH_TOKEN: ${{ secrets.DRUTHERS_SUPER_TOKEN }}
+        run: |
+          gh api repos/ALeonard9/druthers/dispatches \
+            -f event_type=release-published \
+            -F "client_payload[repo]=druthers-api" \
+            -F "client_payload[ref]=${{ github.event.release.tag_name }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ parentheses, a hyphen, or a rewrite instead.
 
 ### Working as a fleet worker
 
-When dispatched by `druthers-infra/fleet`, you are one of several agents
+When dispatched by `druthers-fleet`, you are one of several agents
 working in parallel, each in its own git worktree. Additional rules apply:
 
 - **Never start the local dev stack.** Ports 5432/8000/3000 and the Docker

--- a/app/analytics/contract.py
+++ b/app/analytics/contract.py
@@ -1,0 +1,80 @@
+'''
+Privacy contract for product analytics events.
+
+Every event written to the product_events table goes through ProductEvent,
+which rejects the payload rather than sanitising it. The forbidden-key check
+is substring-based on purpose: 'display_name' and 'search_term' must fail as
+surely as 'name' and 'search' do. See docs/PRODUCT-METRICS.md.
+'''
+
+import json
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+# Privacy constraint: keys or substrings that trigger a payload rejection
+FORBIDDEN_PAYLOAD_KEYS = {
+    'email',
+    'handle',
+    'search',
+    'note',
+    'title',
+    'name',
+    'password',
+}
+
+
+@dataclass
+class ProductEvent:
+    '''One analytics event, validated at construction.'''
+
+    user_id: uuid.UUID
+    event_type: str
+    payload: Dict[str, Any] = field(default_factory=dict)
+    occurred_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def __post_init__(self):
+        self._validate_privacy()
+        self._validate_event_type()
+
+    def _validate_privacy(self):
+        '''Ensure no PII or raw text fields exist in the payload.'''
+        for key in self.payload:
+            normalized_key = key.lower()
+            for forbidden in FORBIDDEN_PAYLOAD_KEYS:
+                if forbidden in normalized_key:
+                    raise ValueError(
+                        f"Privacy violation: payload contains forbidden key '{key}'"
+                    )
+
+        # Check string values for obvious email formats just in case
+        for val in self.payload.values():
+            if isinstance(val, str) and '@' in val and '.' in val:
+                raise ValueError(
+                    'Privacy violation: payload value looks like an email address'
+                )
+
+    def _validate_event_type(self):
+        '''Reject anything outside the agreed event vocabulary.'''
+        allowed_events = {
+            'signup_completed',
+            'onboarding_started',
+            'first_item_added',
+            'fifth_item_ranked',
+            'first_share',
+            'invite_opened',
+            'friendship_established',
+            'comparison_viewed',
+            'returning_session',
+            'profile_completed',
+        }
+        if self.event_type not in allowed_events:
+            raise ValueError(f"Unknown event type: {self.event_type}")
+
+    def to_json(self) -> str:
+        '''Serialise for insertion, with UUID and timestamp made JSON-safe.'''
+        data = asdict(self)
+        data['user_id'] = str(data['user_id'])
+        data['occurred_at'] = data['occurred_at'].isoformat()
+        return json.dumps(data)

--- a/app/analytics/queries.py
+++ b/app/analytics/queries.py
@@ -1,0 +1,166 @@
+"""
+Reproducible queries for product metrics.
+These queries assume a schema matching the product_events table:
+  id UUID, user_id UUID, event_type VARCHAR, payload JSONB, occurred_at TIMESTAMP
+"""
+
+ACTIVATION_QUERY = """
+WITH signups AS (
+    SELECT user_id, date_trunc('week', occurred_at) AS signup_week
+    FROM product_events
+    WHERE event_type = 'signup_completed'
+),
+user_events AS (
+    SELECT user_id,
+           COUNT(*) FILTER (WHERE event_type = 'fifth_item_ranked') AS rank_events,
+           COUNT(*) FILTER (WHERE event_type IN ('first_share', 'profile_completed')) AS activate_events
+    FROM product_events
+    GROUP BY user_id
+)
+SELECT s.signup_week,
+       COUNT(s.user_id) AS total_signups,
+       COUNT(s.user_id) FILTER (WHERE u.rank_events > 0 AND u.activate_events > 0) AS activated_users
+FROM signups s
+LEFT JOIN user_events u ON s.user_id = u.user_id
+GROUP BY s.signup_week
+ORDER BY s.signup_week;
+"""
+
+SIGNUP_TO_ACTIVATION_CONVERSION_QUERY = """
+-- Matches ACTIVATION_QUERY but exposes the ratio explicitly.
+WITH signups AS (
+    SELECT user_id, date_trunc('week', occurred_at) AS signup_week
+    FROM product_events
+    WHERE event_type = 'signup_completed'
+),
+activations AS (
+    SELECT user_id
+    FROM product_events
+    WHERE event_type IN ('fifth_item_ranked', 'first_share', 'profile_completed')
+    GROUP BY user_id
+    HAVING COUNT(*) FILTER (WHERE event_type = 'fifth_item_ranked') > 0
+       AND COUNT(*) FILTER (WHERE event_type IN ('first_share', 'profile_completed')) > 0
+)
+SELECT
+    s.signup_week,
+    COUNT(s.user_id) AS total_signups,
+    COUNT(a.user_id) AS total_activations,
+    CASE
+        WHEN COUNT(s.user_id) = 0 THEN 0.0
+        ELSE COUNT(a.user_id)::NUMERIC / COUNT(s.user_id)
+    END AS conversion_rate
+FROM signups s
+LEFT JOIN activations a ON s.user_id = a.user_id
+GROUP BY s.signup_week
+ORDER BY s.signup_week;
+"""
+
+WEEKLY_ACTIVATION_QUERY = """
+WITH signups AS (
+    SELECT user_id, date_trunc('week', occurred_at) AS signup_week, occurred_at AS signup_time
+    FROM product_events
+    WHERE event_type = 'signup_completed'
+),
+activations AS (
+    SELECT user_id, MAX(occurred_at) AS activation_time
+    FROM product_events
+    WHERE event_type IN ('fifth_item_ranked', 'first_share', 'profile_completed')
+    GROUP BY user_id
+    HAVING COUNT(*) FILTER (WHERE event_type = 'fifth_item_ranked') > 0
+       AND COUNT(*) FILTER (WHERE event_type IN ('first_share', 'profile_completed')) > 0
+)
+SELECT
+    s.signup_week,
+    COUNT(s.user_id) AS signups,
+    COUNT(a.user_id) AS activated_within_7d
+FROM signups s
+LEFT JOIN activations a ON s.user_id = a.user_id
+    AND a.activation_time <= s.signup_time + INTERVAL '7 days'
+GROUP BY s.signup_week
+ORDER BY s.signup_week;
+"""
+
+D7_RETENTION_QUERY = """
+WITH signups AS (
+    SELECT user_id, date_trunc('week', occurred_at) AS signup_week, occurred_at::date AS signup_date
+    FROM product_events
+    WHERE event_type = 'signup_completed'
+),
+returns AS (
+    SELECT DISTINCT user_id, occurred_at::date AS return_date
+    FROM product_events
+    WHERE event_type = 'returning_session'
+)
+SELECT
+    s.signup_week,
+    COUNT(DISTINCT s.user_id) AS cohort_size,
+    COUNT(DISTINCT r.user_id) AS d7_retained
+FROM signups s
+LEFT JOIN returns r ON s.user_id = r.user_id
+    AND r.return_date >= s.signup_date + 7
+    AND r.return_date <= s.signup_date + 13
+GROUP BY s.signup_week
+ORDER BY s.signup_week;
+"""
+
+D28_RETENTION_QUERY = """
+WITH signups AS (
+    SELECT user_id, date_trunc('week', occurred_at) AS signup_week, occurred_at::date AS signup_date
+    FROM product_events
+    WHERE event_type = 'signup_completed'
+),
+returns AS (
+    SELECT DISTINCT user_id, occurred_at::date AS return_date
+    FROM product_events
+    WHERE event_type = 'returning_session'
+)
+SELECT
+    s.signup_week,
+    COUNT(DISTINCT s.user_id) AS cohort_size,
+    COUNT(DISTINCT r.user_id) AS d28_retained
+FROM signups s
+LEFT JOIN returns r ON s.user_id = r.user_id
+    AND r.return_date >= s.signup_date + 28
+    AND r.return_date <= s.signup_date + 34
+GROUP BY s.signup_week
+ORDER BY s.signup_week;
+"""
+
+SHARE_TO_SIGNUP_CONVERSION_QUERY = """
+WITH shares AS (
+    SELECT date_trunc('week', occurred_at) AS cohort_week, COUNT(*) AS total_shares
+    FROM product_events
+    WHERE event_type = 'first_share'
+    GROUP BY 1
+),
+invite_signups AS (
+    SELECT date_trunc('week', occurred_at) AS cohort_week, COUNT(DISTINCT user_id) AS total_invite_signups
+    FROM product_events
+    WHERE event_type = 'signup_completed'
+    AND payload->>'source' = 'invite'
+    GROUP BY 1
+)
+SELECT
+    COALESCE(s.cohort_week, i.cohort_week) AS week,
+    COALESCE(s.total_shares, 0) AS total_shares,
+    COALESCE(i.total_invite_signups, 0) AS total_invite_signups,
+    CASE
+        WHEN COALESCE(s.total_shares, 0) = 0 THEN 0.0
+        ELSE COALESCE(i.total_invite_signups, 0)::NUMERIC / s.total_shares
+    END AS share_conversion_rate
+FROM shares s
+FULL OUTER JOIN invite_signups i ON s.cohort_week = i.cohort_week
+ORDER BY week;
+"""
+
+WEEKLY_EVENT_COUNTS_QUERY = """
+-- Covers all other product events to ensure nothing is unmeasured (e.g. onboarding_started, invite_opened)
+SELECT
+    date_trunc('week', occurred_at) AS week,
+    event_type,
+    COUNT(*) AS event_count,
+    COUNT(DISTINCT user_id) AS unique_users
+FROM product_events
+GROUP BY 1, 2
+ORDER BY 1, 2;
+"""

--- a/docs/PRODUCT-METRICS.md
+++ b/docs/PRODUCT-METRICS.md
@@ -1,0 +1,63 @@
+# Product Metrics and Analytics Strategy
+
+## 1. Analytics Approach
+
+Druthers relies on a **privacy-first, self-hosted** analytics approach using our existing PostgreSQL database (Neon).
+
+*   **Cost:** $0 marginal cost. Piggybacks on our existing database compute and storage. Fits well within the $10/month hobby scale budget.
+*   **Retention:** Indefinite by default, but subject to aggressive data-minimization at capture (see payloads).
+*   **Deletion:** Event data is bound to a `user_id`. When an account is deleted, a cascading delete or a targeted scrub query (defined below) removes all associated analytics events, complying with our privacy promises.
+*   **Vendor Lock-In:** None. Standard SQL queries compute all metrics.
+
+## 2. Event Payloads and Privacy Contract
+
+To prevent leaking PII, **all event payloads must strictly exclude:**
+*   Emails
+*   User handles
+*   Search terms
+*   Private notes
+*   Title names (movies, books, etc.)
+
+Events are recorded in a `product_events` table:
+```sql
+CREATE TABLE product_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    event_type VARCHAR(50) NOT NULL,
+    occurred_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    payload JSONB DEFAULT '{}'::jsonb
+);
+CREATE INDEX idx_product_events_user_id ON product_events(user_id);
+CREATE INDEX idx_product_events_type_time ON product_events(event_type, occurred_at);
+```
+
+Defined event types:
+1.  `signup_completed`
+2.  `onboarding_started`
+3.  `first_item_added`
+4.  `fifth_item_ranked`
+5.  `first_share`
+6.  `invite_opened` (payload includes: `source=share_link`)
+7.  `friendship_established`
+8.  `comparison_viewed` (payload includes: `domain`)
+9.  `returning_session` (returning session marker)
+10. `profile_completed`
+
+## 3. Definitions
+
+*   **Activation:** A user is considered *activated* if they have ranked at least 5 items AND (completed their profile OR shared a list). We track activation when `fifth_item_ranked` is present alongside a `first_share` or `profile_completed` event.
+*   **Weekly Activation:** Percentage of signups in a given week that reach Activation within 7 days.
+*   **D7 Retention:** Percentage of users who have a `returning_session` event on days 7-13 after `signup_completed`.
+*   **D28 Retention:** Percentage of users who have a `returning_session` event on days 28-34 after `signup_completed`.
+*   **Share-to-Signup Conversion:** Number of `signup_completed` events resulting from an invite vs. total `first_share` events.
+*   **Signup-to-Activation Conversion:** Total activated users / Total signups.
+
+## 4. Data Deletion
+
+When a user deletes their account, the raw event data is removed via:
+```sql
+DELETE FROM product_events WHERE user_id = $1;
+```
+This is executed as part of the standard user deletion transaction.
+
+To prevent deletion from silently rewriting historical metrics (e.g., a cohort size shrinking months later), the system maintains a periodic rollup table holding aggregated metrics per cohort period (e.g., weekly totals). This rollup table contains no `user_id` or PII and is preserved after account deletion, keeping trend lines accurate while scrubbing personal data.

--- a/scripts/load_test.py
+++ b/scripts/load_test.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""
+Lightweight QA Load Testing Script for Druthers API.
+
+Exercises traffic-relevant read endpoints:
+  1. GET /v1/search/movies?q=dune
+  2. GET /v1/search/tv?q=breaking
+  3. GET /v1/search/books?q=hobbit
+  4. GET /v1/search/games?q=zelda
+  5. GET /v1/public/dadam
+  6. GET /v1/summary
+
+Usage:
+  python scripts/load_test.py --url http://localhost:8000 --concurrency 5 --duration 10
+
+Rate Limit Note:
+  Druthers API enforces rate limits on unauthenticated/authenticated endpoints
+  via `app/services/rate_limit.py`. Be mindful of concurrency levels when testing
+  against production or QA environments to avoid tripping the rate limiters.
+"""
+
+import argparse
+import concurrent.futures
+import math
+import time
+import urllib.request
+import urllib.error
+
+ENDPOINTS = [
+    '/v1/search/movies?q=dune',
+    '/v1/search/tv?q=breaking',
+    '/v1/search/books?q=hobbit',
+    '/v1/search/games?q=zelda',
+    '/v1/public/dadam',
+    '/v1/summary',
+]
+
+
+def make_request(base_url: str, path: str) -> tuple[bool, float, int]:
+    '''Issue one GET and return (success, elapsed_ms, status_code).'''
+    url = f"{base_url.rstrip('/')}{path}"
+    start = time.perf_counter()
+    status_code = 0
+    success = False
+    try:
+        req = urllib.request.Request(
+            url,
+            headers={'User-Agent': 'Druthers-LoadTest/1.0'},
+        )
+        with urllib.request.urlopen(req, timeout=10) as response:
+            status_code = response.status
+            success = 200 <= status_code < 300
+    except urllib.error.HTTPError as err:
+        status_code = err.code
+    except Exception:  # pylint: disable=broad-exception-caught
+        # A load test must survive every transport failure a rate limiter or a
+        # cold Cloud Run instance can produce; anything unhandled here would
+        # kill the worker thread and quietly shrink the concurrency.
+        status_code = 0
+
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+    return success, elapsed_ms, status_code
+
+
+def percentile(data: list[float], p: float) -> float:
+    '''Linear-interpolated percentile over unsorted samples.'''
+    if not data:
+        return 0.0
+    sorted_data = sorted(data)
+    k = (len(sorted_data) - 1) * (p / 100.0)
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return sorted_data[int(k)]
+    d0 = sorted_data[int(f)] * (c - k)
+    d1 = sorted_data[int(c)] * (k - f)
+    return d0 + d1
+
+
+def run_load_test(base_url: str, concurrency: int, duration_sec: int):
+    # pylint: disable=too-many-locals
+    # The counters, timers and result buckets are all one flat measurement
+    # loop; splitting them across helpers would hide the sequence rather than
+    # clarify it.
+    '''Drive the endpoint list for duration_sec and print a latency summary.'''
+    print('\n🚀 Starting Druthers Load Test')
+    print(f"   Target URL:  {base_url}")
+    print(f"   Concurrency: {concurrency} workers")
+    print(f"   Duration:    {duration_sec} seconds")
+    print(f"   Endpoints:   {len(ENDPOINTS)} paths\n")
+
+    latencies: list[float] = []
+    status_counts: dict[int, int] = {}
+    total_requests = 0
+    success_requests = 0
+
+    end_time = time.time() + duration_sec
+    idx = 0
+
+    def worker_task():
+        nonlocal idx
+        results = []
+        while time.time() < end_time:
+            path = ENDPOINTS[idx % len(ENDPOINTS)]
+            idx += 1
+            res = make_request(base_url, path)
+            results.append(res)
+        return results
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as executor:
+        futures = [executor.submit(worker_task) for _ in range(concurrency)]
+        for future in concurrent.futures.as_completed(futures):
+            for ok, elapsed_ms, code in future.result():
+                total_requests += 1
+                if ok:
+                    success_requests += 1
+                latencies.append(elapsed_ms)
+                status_counts[code] = status_counts.get(code, 0) + 1
+
+    if not total_requests:
+        print('❌ No requests executed.')
+        return
+
+    error_rate = ((total_requests - success_requests) / total_requests) * 100.0
+    p50 = percentile(latencies, 50)
+    p95 = percentile(latencies, 95)
+    p99 = percentile(latencies, 99)
+
+    print('📊 --- Load Test Results ---')
+    print(f"Total Requests:     {total_requests}")
+    print(f"Successful:         {success_requests}")
+    print(f"Error Rate:         {error_rate:.2f}%")
+    print(f"Status Code Breakdown: {dict(sorted(status_counts.items()))}")
+    print('Latency Percentiles:')
+    print(f"  p50 (median):     {p50:.2f} ms")
+    print(f"  p95:              {p95:.2f} ms")
+    print(f"  p99:              {p99:.2f} ms")
+    print('----------------------------\n')
+
+
+def main():
+    '''Parse arguments and run one load test.'''
+    parser = argparse.ArgumentParser(description='Druthers QA Load Test Script')
+    parser.add_argument(
+        '--url',
+        default='http://localhost:8000',
+        help='Base URL of target API (default: http://localhost:8000)',
+    )
+    parser.add_argument(
+        '--concurrency',
+        type=int,
+        default=5,
+        help='Number of concurrent workers (default: 5)',
+    )
+    parser.add_argument(
+        '--duration',
+        type=int,
+        default=10,
+        help='Duration of test in seconds (default: 10)',
+    )
+    args = parser.parse_args()
+    run_load_test(args.url, args.concurrency, args.duration)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/unit/analytics_contract_test.py
+++ b/tests/unit/analytics_contract_test.py
@@ -1,0 +1,111 @@
+'''
+This file contains unit tests for the product analytics privacy contract in
+app/analytics/contract.py, and asserts that the reproducible metric queries in
+app/analytics/queries.py stay non-empty.
+'''
+
+import uuid
+
+import pytest
+
+from app.analytics.contract import ProductEvent, FORBIDDEN_PAYLOAD_KEYS
+from app.analytics.queries import (
+    ACTIVATION_QUERY,
+    SIGNUP_TO_ACTIVATION_CONVERSION_QUERY,
+    WEEKLY_ACTIVATION_QUERY,
+    D7_RETENTION_QUERY,
+    D28_RETENTION_QUERY,
+    SHARE_TO_SIGNUP_CONVERSION_QUERY,
+    WEEKLY_EVENT_COUNTS_QUERY,
+)
+
+
+def test_valid_event():
+    '''
+    Tests that a well-formed event is accepted unchanged.
+    '''
+    uid = uuid.uuid4()
+    event = ProductEvent(
+        user_id=uid, event_type='signup_completed', payload={'source': 'organic'}
+    )
+    assert event.event_type == 'signup_completed'
+    assert event.user_id == uid
+
+
+def test_profile_completed_event():
+    '''
+    Tests that an event with an empty payload is accepted.
+    '''
+    uid = uuid.uuid4()
+    event = ProductEvent(user_id=uid, event_type='profile_completed', payload={})
+    assert event.event_type == 'profile_completed'
+
+
+def test_privacy_validation_forbids_keys():
+    '''
+    Tests that every forbidden key is caught as a substring: each is prefixed
+    with 'user_' so an exact-match check would let all of them through.
+    '''
+    uid = uuid.uuid4()
+    for forbidden in FORBIDDEN_PAYLOAD_KEYS:
+        with pytest.raises(ValueError, match='Privacy violation'):
+            ProductEvent(
+                user_id=uid,
+                event_type='first_share',
+                payload={f"user_{forbidden}": 'secret'},
+            )
+
+
+def test_privacy_validation_forbids_emails_in_values():
+    '''
+    Tests that an email-shaped value is rejected even under an allowed key,
+    where the key-name check alone would not fire.
+    '''
+    uid = uuid.uuid4()
+    with pytest.raises(ValueError, match='looks like an email'):
+        ProductEvent(
+            user_id=uid,
+            event_type='invite_opened',
+            payload={'recipient': 'adam@druthers.io'},
+        )
+
+
+def test_invalid_event_type():
+    '''
+    Tests that an event type outside the agreed vocabulary is rejected.
+    '''
+    uid = uuid.uuid4()
+    with pytest.raises(ValueError, match='Unknown event type'):
+        ProductEvent(user_id=uid, event_type='random_unsupported_event', payload={})
+
+
+def test_queries_are_defined():
+    '''
+    Tests that every exported metric query is real SQL against product_events,
+    catching a query renamed or emptied without its caller noticing.
+    '''
+    queries = [
+        ACTIVATION_QUERY,
+        SIGNUP_TO_ACTIVATION_CONVERSION_QUERY,
+        WEEKLY_ACTIVATION_QUERY,
+        D7_RETENTION_QUERY,
+        D28_RETENTION_QUERY,
+        SHARE_TO_SIGNUP_CONVERSION_QUERY,
+        WEEKLY_EVENT_COUNTS_QUERY,
+    ]
+    for q in queries:
+        assert 'SELECT' in q.upper()
+        assert 'product_events' in q
+
+    # Assert fix 1: Queries group by cohort period
+    assert 'GROUP BY' in ACTIVATION_QUERY
+    assert 'GROUP BY' in SIGNUP_TO_ACTIVATION_CONVERSION_QUERY
+    assert 'GROUP BY' in SHARE_TO_SIGNUP_CONVERSION_QUERY
+
+    # Assert fix 2: Retention windows
+    assert '+ 7' in D7_RETENTION_QUERY and '+ 13' in D7_RETENTION_QUERY
+    assert '+ 28' in D28_RETENTION_QUERY and '+ 34' in D28_RETENTION_QUERY
+
+    # Assert fix 3: Activation uses profile_completed
+    assert 'profile_completed' in ACTIVATION_QUERY
+    assert 'profile_completed' in SIGNUP_TO_ACTIVATION_CONVERSION_QUERY


### PR DESCRIPTION
## Summary

- `analytics/` lived in druthers-infra, which is infrastructure. It is application code: it validates and queries the `product_events` table in this service's database, and its privacy contract rejects payload keys against a list that only means anything next to this schema.
- Landed as `app/analytics/{contract,queries}.py` rather than a root-level package, matching every other module here, and `tests/unit/analytics_contract_test.py` so pytest collects it the way the house layout expects.
- `docs/PRODUCT-METRICS.md` specifies the contract the code enforces; `scripts/load_test.py` load tests this service.
- `deploy_cloud_run.yaml` notifies the new [druthers](https://github.com/ALeonard9/druthers) super repo of the released tag, so its pinned submodule stops describing the previous release. Last step and `continue-on-error`: a missed pointer is caught by the super repo's staleness gate, and a failed notification should not fail a deploy that already succeeded.
- **The adopted code needed real work, not a move.** It came from a repo with no pylint gate into one that has one, and failed on 20 findings: missing module, class and function docstrings, two unused `typing` imports, `.keys()` iteration, import ordering, and two f-strings with nothing interpolated. All fixed rather than suppressed.
- Two suppressions remain, both narrow and commented: `broad-exception-caught` in the load test worker, where an unhandled transport error would silently shrink concurrency instead of failing loudly, and `too-many-locals` on the measurement loop.

## Test plan

- [x] Full suite: **1094 passed**, re-run after each pre-commit rewrite (black, quote style, whitespace)
- [x] Relocated analytics test: 6 passed, covering forbidden-key substring matching, email-shaped values under allowed keys, unknown event types, and that every exported metric query is real SQL against `product_events`
- [x] `pre-commit run` clean on all touched files, including pylint
- [x] `scripts/load_test.py --help` imports and parses after the lint fixes
- [x] Test docstrings written against what each test actually asserts, not generated from the function name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xtUGSXLTyoFtKc6KkFtXg