### PR TITLE
fix: track CLAUDE.md so a fresh clone reads AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,7 +181,6 @@ database/data/*
 .testmondata
 
 # Local Claude Code artifacts (not checked in for this repo)
-CLAUDE.md
 graphify-out/
 # Fleet worker runtime artifacts
 WORKER_REPORT.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- `.gitignore` excluded `CLAUDE.md` as a "local Claude Code artifact". It is not one: it is the one-line `@AGENTS.md` pointer that makes Claude read this repo's contract at all. `druthers-web`, `druthers-mcp` and `druthers-infra` all track it; this repo was the only holdout.
- The consequence was invisible locally, because the file exists on every machine that has ever worked here. It only surfaced when the `AGENTS.md` drift check moved to the [druthers](https://github.com/ALeonard9/druthers) super repo, where CI clones each repo fresh: no `CLAUDE.md`, no import, no contract. A fleet worker in a new worktree had the same gap.
- **What does not change:** `graphify-out/` stays ignored. That one really is a local artifact.

## Test plan

- [x] `sync-rules.sh --check` now reports `ok druthers-api/AGENTS.md` and no `CLAUDE.md` drift; the only remaining drift is `druthers-ios`, which is deliberately out of scope and skipped in CI
- [x] `git ls-files CLAUDE.md` returns the file, matching the other three repos
- [x] File content verified as exactly `@AGENTS.md`, the pointer `sync-rules.sh` expects

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xtUGSXLTyoFtKc6KkFtXg