### PR TITLE
chore: reclaim the Docker space local builds leave behind

### DIFF
--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -19,11 +19,48 @@ tasks:
       - GIT_SHA=$(git rev-parse HEAD) docker compose -f dc-{{.ENV}}.yml --env-file env/{{.ENV}}.env up -d --build
 
   dd:
-    desc: "Stop druthers Docker environment"
+    desc: "Stop druthers Docker environment, and reclaim what the last build orphaned."
     vars:
       ENV: '{{default "dev" .CLI_ARGS}}'
     cmds:
       - docker compose -f dc-{{.ENV}}.yml --env-file env/{{.ENV}}.env down
+      - task: dclean
+
+  dclean:
+    desc: "Reclaim Docker space left by local builds. Safe: keeps every tagged image."
+    # `task du` rebuilds the API image on every start, deliberately (api#232,
+    # so it can never serve stale code). Each rebuild retags the name onto a
+    # new image and leaves the previous one dangling, and nothing ever removed
+    # them: nine <none> images and 5.6 GB of build cache had accumulated over
+    # about 36 hours of normal use.
+    #
+    # Scoped on purpose. `docker image prune` without -a removes only
+    # dangling images, so the pulled tool images survive - `docker system
+    # prune -a` would take semgrep with it and cost a 1.12 GB re-pull the next
+    # time `task sast` runs.
+    #
+    # Build cache is deliberately NOT touched here. An `until=` filter looked
+    # obvious and reclaimed exactly 0 bytes: this project rebuilds often
+    # enough that all 5.6 GB of cache was under 36 hours old, so any window
+    # wide enough to be safe keeps everything. Age is the wrong axis when the
+    # cache churns daily - the right control is a size ceiling that keeps the
+    # newest layers and evicts the rest, which is the BuildKit GC in
+    # ~/.docker/daemon.json. If `defaultKeepStorage` is still "20GB" there it
+    # will never fire at this project's scale; 4GB is a ceiling that actually
+    # bites. Use `task dclean:cache` for a one-off, and expect a cold rebuild.
+    cmds:
+      - docker image prune -f
+      - docker system df
+
+  dclean:cache:
+    desc: "Drop the whole BuildKit cache. Opt-in: the next build is cold."
+    # Not wired into `dd`, because unlike dangling images this has a real
+    # cost - the next `task du` rebuilds every layer from scratch. Reach for
+    # it when the daemon GC ceiling has not been lowered and the cache has run
+    # away, not as routine hygiene.
+    cmds:
+      - docker builder prune -f
+      - docker system df
 
   dr:
     desc: "Rebuild druthers Docker environment"


### PR DESCRIPTION
## Summary

- `task du` rebuilds the API image on every start, deliberately, so it can never serve stale code (#232). Each rebuild moves the tag to a new image and leaves the previous one **dangling** — and nothing ever removed them. ~36 hours of ordinary use had produced 9 `<none>` images, 14 images totalling 3.2 GB, 78% reclaimable.
- **`task dclean`** prunes dangling images and reports what's left. Wired into `task dd`, which the demo workflow already ends with, so cleanup happens where the session does.
- **Scoped deliberately.** `docker image prune` without `-a` touches only dangling images, so pulled tool images survive. `docker system prune -a` would take `semgrep/semgrep` with it and cost a **1.12 GB re-pull** on the next `task sast`.
- **`task dclean:cache`** is separate and opt-in, because dropping the build cache costs a cold rebuild. Not routine hygiene.
- **What does not change:** build cache is untouched by `dclean`. See below — that's a finding, not an omission.

### The build cache needs a machine setting, not a task

I tried the obvious thing first and it reclaimed **exactly 0 bytes**. An `until=168h` filter keeps everything here: this project rebuilds often enough that all 5.6 GB of cache was under 36 hours old (bulk of it 21–36h). **Age is the wrong axis when the cache churns daily.**

The right control is a size ceiling — and one already exists, doing nothing. `~/.docker/daemon.json` has BuildKit GC **enabled** with `defaultKeepStorage: "20GB"`. At this project's scale it has never once fired. Dropping it to `4GB` makes the cache self-manage permanently, with no task involved:

```json
{ "builder": { "gc": { "enabled": true, "defaultKeepStorage": "4GB" } } }
```

That's a per-machine setting and needs a Docker Desktop restart, so it's documented in the task comment rather than pretended to be fixed in this repo.

Note `--keep-storage` is no longer a `docker builder prune` flag on Docker 29.7.2, so the daemon policy is the only lever for cache size.

## Test plan

- [x] `task dclean` run against a live stack: 14 images → 5, 3.165 GB → 2.004 GB
- [x] Tool images verified present afterwards: `semgrep/semgrep`, `zricethezav/gitleaks`, `postgres`
- [x] Running containers stayed healthy through the prune (`m3_druthers_api_dev` healthy, `m3_druthers_db_dev` up)
- [x] `taskfile.yaml` parses; both targets appear in `task -l`
- [x] Negative result recorded: `until=168h` cache filter reclaimed 0 B, which is why cache pruning is opt-in rather than wired into `dd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xtUGSXLTyoFtKc6KkFtXg