### PR TITLE
feat: raise the QA sign-in rate limit to 50

### DIFF
--- a/.github/workflows/deploy_qa.yaml
+++ b/.github/workflows/deploy_qa.yaml
@@ -98,4 +98,15 @@ jobs:
           gcloud run deploy druthers-api \
             --image "$IMAGE" \
             --region ${{ vars.GCP_REGION }} \
-            --project ${{ vars.GCP_PROJECT_ID_QA }}
+            --project ${{ vars.GCP_PROJECT_ID_QA }} \
+            --update-env-vars RATE_LIMIT_AUTH=50
+
+      # --update-env-vars, not --set-env-vars: this deploy deliberately does
+      # not own QA's environment (that is gcp/30-deploy.sh in druthers-infra),
+      # and --set would drop every variable it does not name, including
+      # DISABLE_PASSWORD_LOGIN and GOOGLE_CLIENT_ID.
+      #
+      # It has to be here at all because this workflow otherwise only swaps
+      # the image: setting RATE_LIMIT_AUTH in druthers-infra's env.qa.sh alone
+      # would never reach QA, since the manual deploy script is not what runs
+      # on a push to main.

--- a/env/dev.env.template
+++ b/env/dev.env.template
@@ -9,6 +9,19 @@ TIME_ZONE=America/New_York
 # Auth: REQUIRED in dev/prod. Generate with: openssl rand -hex 32
 JWT_SECRET_KEY=
 
+# Sign-in attempts per IP per 5 minutes (default 10). Raise it locally if you
+# run the authenticated Playwright lane in druthers-web: it signs in once per
+# dev-cast seat plus three times for the session-refresh specs, and reruns
+# inside five minutes will otherwise 429 and look like broken assertions
+# rather than a spent budget.
+#
+# Raise it rather than setting RATE_LIMITS_ENABLED=false, which switches off
+# all six limiters and stops the limiter being exercised outside prod.
+#
+# Note: `docker compose restart` does NOT re-read this file. Use
+# `task du -- dev` (compose up -d) to pick a change up.
+RATE_LIMIT_AUTH=200
+
 # Session lifetimes (#246). The access token stays short because the refresh
 # token renews it silently; drop ACCESS_TOKEN_EXPIRE_MINUTES to 2 if you want
 # to actually watch a refresh happen locally.


### PR DESCRIPTION
## Summary

- druthers-web's authenticated Playwright lane signs in **once per dev-cast seat (6)** plus **three times for the session-refresh specs**, which cannot share a cached session because a refresh token rotates when spent. That is **9 against the default cap of 10** — one more seat or refresh spec breaks the suite, and a 429 surfaces as a broken assertion rather than a spent budget.
- **50, not unlimited.** QA is internet-facing and accepts password sign-in, so the brake stays on, just above what the suite needs. **Prod is untouched** and keeps the api's default of 10.
- Also documents the knob in `env/dev.env.template`, including that `docker compose restart` does **not** re-read the env file (`up -d` does) — which cost me a confused verification cycle.

## Why it is set here and not only in druthers-infra

`deploy_qa.yaml` is what actually runs on a push to main, and it **passes no `--set-env-vars` at all** — it only swaps the image. QA's environment persists from whenever `druthers-infra/gcp/30-deploy.sh` last set it. So a value set only in `env.qa.sh` would never reach QA on the automated path.

Both are updated: ALeonard9/druthers-infra#56 covers `env.sh` / `env.qa.sh` / `30-deploy.sh` for the manual path.

`--update-env-vars`, not `--set-env-vars`: this workflow does not own QA's environment, and `--set` would drop every variable it does not name, including `DISABLE_PASSWORD_LOGIN` and `GOOGLE_CLIENT_ID`.

## Why raise rather than exempt

Worth recording, because "just exempt the test user" is the obvious first idea and it cannot work. `auth_rate_limit` is a route **dependency** (`app/auth/authentication.py:54`), so it runs **before** the endpoint body — before credentials are checked. There is no user yet, which is the entire point: it throttles someone guessing passwords, who by definition is unauthenticated. Exempting by submitted username would let an attacker submit the exempt username.

The other five limiters (`refresh`, `search`, `catalog_add`, `friend_request`) all run after identity is known and *could* be exempted per user. This one structurally cannot.

Raising also beats `RATE_LIMITS_ENABLED=false`, which switches off all six limiters — the code path would stop being exercised outside prod, and flow-matrix row 7 would become untestable.

## Test plan

- [x] Verified locally: `RATE_LIMIT_AUTH=200` in `env/dev.env`, container recreated, `get_settings().rate_limit_auth` reads **200**.
- [x] Confirmed `compose restart` does not pick up env changes and `up -d` does — the first attempt still read 10.
- [x] Sourced both infra env files: QA resolves to `RATE_LIMIT_AUTH=50, DISABLE_PASSWORD_LOGIN=0`; prod resolves to `10, 1`.
- [x] `check yaml` and the full pre-commit/pre-push hook set pass.
- [ ] Not verified against deployed QA: takes effect on the next push to main.