### PR TITLE
feat: add a disposable dev-cast seat for destructive admin tests

### DIFF
--- a/app/migration/seed_dev.py
+++ b/app/migration/seed_dev.py
@@ -247,6 +247,38 @@ _CAST_USERS = (
         'time_zone': 'America/Chicago',
         'admin': True,
     },
+    {
+        # The disposable seat. Not a relationship position and not part of the
+        # visibility matrix: it exists so destructive admin rules can be
+        # *tested* rather than only described.
+        #
+        # Disabling an account, expiring its session and impersonating it are
+        # all one-way in a way the rest of the cast cannot absorb. Proving
+        # "an admin cannot disable another admin" by disabling ``admin-two``
+        # breaks every later run at exactly the moment the rule regresses,
+        # which is when the suite most needs to still work. So the destructive
+        # specs act on this seat instead, and nothing else reads it.
+        #
+        # Deliberately holds nothing: no canon movies, no friendships, no
+        # follows, so no other seat's assertions depend on its state. A test
+        # may leave it disabled; ``disposable`` below is what makes the next
+        # ``task seed:dev`` clear ``disabled_at`` again.
+        #
+        # ``gmail.com`` for the same reason as ``admin-two``: it authenticates
+        # through the normal app paths, which validate the email with an MX
+        # lookup, unlike this script's direct inserts.
+        'email': 'e2e-disposable@gmail.com',
+        'display_name': 'Disposable',
+        'handle': 'disposable',
+        'position': 'disposable',
+        'tiers': _cast_tiers('public'),
+        'canon_movies': 0,
+        # Its own zone, not UTC: ``stranger`` already holds UTC and the cast
+        # keeps one zone per seat, so a date rendered from the wrong seat is
+        # visibly wrong rather than plausible.
+        'time_zone': 'Pacific/Auckland',
+        'disposable': True,
+    },
 )
 
 
@@ -793,6 +825,14 @@ def _get_or_create_cast_user(session: Session, spec: dict) -> DbUser:
     user.time_zone = spec['time_zone']
     if spec.get('admin'):
         user.user_group = 'admin'
+    if spec.get('disposable'):
+        # Re-enable on every run. The destructive admin specs disable this
+        # seat on purpose, and a spec that fails midway leaves it disabled;
+        # without this the seat is single-use and the next run fails for the
+        # previous run's reason. Only the disposable seat gets this: silently
+        # re-enabling an account an operator disabled by hand would be a
+        # surprise, and for the rest of the cast a disabled seat is a bug.
+        user.disabled_at = None
     return user
 
 

--- a/docs/dev-cast.md
+++ b/docs/dev-cast.md
@@ -1,6 +1,6 @@
 # The dev cast
 
-Eight local accounts. Seven cover every relationship, visibility and
+Nine local accounts. Six cover every relationship, visibility and
 time-zone position the social features have; the eighth (`admin-two`) is
 unrelated to that matrix - it exists so admin-console rules that need a
 *second* admin (#341: an admin cannot impersonate or disable another admin)
@@ -27,6 +27,7 @@ is the seed admin from `env/dev.env` and keeps its own `ADMIN_PASSWORD`.
 | `private-user` | `private@example.com` | `change-me` | private | 6 | America/New_York |
 | `stranger` | `stranger@example.com` | `change-me` | public | 4 | UTC |
 | `admin-two` | `admin-two@gmail.com` | `change-me` | private | 0 | America/Chicago |
+| `disposable` | `e2e-disposable@gmail.com` | `change-me` | public | 0 | Pacific/Auckland |
 
 Read `$ADMIN_EMAIL` / `$ADMIN_PASSWORD` out of `env/dev.env` - they are
 per-clone, so never hardcode them into a script or a report. `admin-two`'s
@@ -43,6 +44,7 @@ account like the rest, just an admin one.
 | `public-user` | none | a stranger whose shelves are readable anyway |
 | `private-user` | none, private profile | a profile that 404s - with a stocked shelf behind it, so the 404 is the tier and not emptiness |
 | `stranger` | none | `not_enough_overlap`: a real shelf, still under the five shared titles alignment needs |
+| `disposable` | none | the seat destructive admin tests act on: disable, expire, impersonate. Holds nothing and is re-enabled by every `task seed:dev`, so a test may leave it in any state |
 | `admin-two` | none - both are `user_group='admin'` | the only seat that can demo an admin acting *on* another admin: sign in as `you` (or `admin-two`), try to disable or impersonate the other, and get refused. With one admin in the seed this rule was provable only by unit test. |
 
 **The movie counts are load-bearing.** Every title a cast member ranks is

--- a/tests/unit/seed_dev_test.py
+++ b/tests/unit/seed_dev_test.py
@@ -1,4 +1,6 @@
 # pylint: disable=missing-module-docstring, missing-function-docstring, protected-access
+from datetime import datetime, timezone
+
 import pytest
 
 from app.config import Settings, get_settings
@@ -262,7 +264,7 @@ def test_seed_cast_creates_fixed_users_and_relationships(test_client):
     result = seed_dev._seed_cast(session, target)
     session.commit()
 
-    assert result['cast_users'] == 7
+    assert result['cast_users'] == 8
     # target 8 canon + friend 8 + follower 2 + followee 1 + public 3
     # + private 6 + stranger 4 non-canon + admin-two 0.
     assert result['ranked_rows'] == 32
@@ -399,6 +401,35 @@ def test_seed_cast_stocks_the_private_users_shelf(test_client):
     )
 
 
+def test_seed_cast_re_enables_only_the_disposable_seat(test_client):
+    """
+    The destructive admin specs disable the disposable seat on purpose, and a
+    spec that fails midway leaves it disabled. Without this the seat is
+    single-use and the next run fails for the previous run's reason.
+
+    Scoped to that one seat: silently re-enabling an account an operator
+    disabled by hand would be a surprise, and for the rest of the cast a
+    disabled seat is a bug rather than leftover state.
+    """
+    session = test_client.test_db_session
+    seed_dev._seed_cast(session, test_client.first_user)
+    session.commit()
+
+    disposable = _cast_user(session, 'e2e-disposable@gmail.com')
+    ordinary = _cast_user(session, 'follower@example.com')
+    disposable.disabled_at = datetime.now(timezone.utc)
+    ordinary.disabled_at = datetime.now(timezone.utc)
+    session.commit()
+
+    seed_dev._seed_cast(session, test_client.first_user)
+    session.commit()
+
+    assert _cast_user(session, 'e2e-disposable@gmail.com').disabled_at is None
+    assert (
+        _cast_user(session, 'follower@example.com').disabled_at is not None
+    ), 'a non-disposable seat must keep whatever disabled state it was given'
+
+
 def test_seed_cast_gives_every_member_a_distinct_time_zone(test_client):
     """The spread is the point: one zone for all of them demos nothing."""
     session = test_client.test_db_session
@@ -434,12 +465,12 @@ def test_seed_cast_is_idempotent(test_client):
     second = seed_dev._seed_cast(session, target)
     session.commit()
 
-    assert second == {'cast_users': 7, 'ranked_rows': 0}
+    assert second == {'cast_users': 8, 'ranked_rows': 0}
     assert (
         session.query(DbUser)
         .filter(DbUser.email.in_([s['email'] for s in seed_dev._CAST_USERS]))
         .count()
-        == 7
+        == 8
     )
     assert session.query(DbFriendship).count() == 1
     assert session.query(DbFollow).count() == 2


### PR DESCRIPTION
## Summary

- Disabling an account, expiring its session and impersonating it are all **one-way** in a way the rest of the cast cannot absorb. Proving "an admin cannot disable another admin" (#341) by disabling `admin-two` would break every later run **at exactly the moment the rule regresses** — which is when the suite most needs to still work.
- Adds `e2e-disposable@gmail.com` (handle `disposable`) for the destructive specs to act on. It holds nothing — no canon movies, no friendships, no follows — so no other seat's assertions depend on its state.
- `_get_or_create_cast_user` re-applied tiers, time zone and the admin group every run but **not `disabled_at`**, so a disabled seat stayed disabled and this one would have been single-use. It now clears `disabled_at`, **only for a seat marked `disposable`**: silently re-enabling an account an operator disabled by hand would be a surprise, and for the rest of the cast a disabled seat is a bug rather than leftover state.

**What does not change:** the visibility matrix. This seat is not a relationship position and nothing else reads it.

## Two things the existing tests caught

Worth calling out, because both were mine and both were caught by checks rather than by me:

1. **The seat collided with `stranger` on UTC.** `test_seed_cast_gives_every_member_a_distinct_time_zone` failed immediately. The invariant is real — one zone per seat is what makes a date rendered from the wrong seat visibly wrong rather than plausible — so the seat moved to `Pacific/Auckland` rather than the test being weakened.
2. **The pre-push hook blocked the push** on the two `cast_users == 7` assertions. Updated to 8.

## Test plan

- [x] `pytest -q`: **1095 passed**.
- [x] New `test_seed_cast_re_enables_only_the_disposable_seat` asserts both halves: the disposable seat comes back, and an ordinary seat keeps whatever disabled state it was given.
- [x] Verified end to end against the local stack: disabling by hand gives `403 Account disabled`; `task seed:dev` restores sign-in with `disabled_at` back to `NULL`.
- [x] `docs/dev-cast.md` updated — nine accounts, with what the seat is for and why a test may leave it in any state.

Unblocks the destructive admin specs in ALeonard9/druthers-web#321.