### PR TITLE
feat: seed the dev cast into QA on every deploy

### DIFF
--- a/.github/workflows/deploy_qa.yaml
+++ b/.github/workflows/deploy_qa.yaml
@@ -63,6 +63,35 @@ jobs:
       # roll so QA exercises the same sequence prod will. If QA skipped these,
       # QA would show the unbackfilled state prod is specifically avoiding -
       # which is exactly the bug QA exists to catch.
+      # Seeds the dev cast so druthers-web's authenticated Playwright lane has
+      # seats to sign in as (#413). Runs on every deploy on purpose: QA's Neon
+      # branch is reset from prod on demand, which wipes anything seeded by
+      # hand, silently. Idempotent, so a re-deploy changes nothing.
+      #
+      # Skipped rather than failed when the target is unset: a QA deploy must
+      # not go red because the E2E fixtures are not configured yet.
+      - name: Seed the dev cast
+        if: steps.migrate.outputs.ran == 'true'
+        env:
+          DATABASE_URL: ${{ secrets.NEON_DATABASE_URL_QA }}
+          QA_E2E_TARGET_EMAIL: ${{ vars.QA_E2E_TARGET_EMAIL }}
+          # Optional. Without it the second admin seat is skipped and the
+          # admin-on-admin rule (#341) stays covered locally only. Seeding an
+          # admin with a shared known password on an internet-facing host
+          # holding prod-derived data is a different proposition from doing it
+          # on a local database, so it is opt-in.
+          QA_ADMIN_TWO_PASSWORD: ${{ secrets.QA_ADMIN_TWO_PASSWORD }}
+          ENV: qa
+        run: |
+          set -euo pipefail
+          if [ -z "${QA_E2E_TARGET_EMAIL:-}" ]; then
+            echo "::warning::QA_E2E_TARGET_EMAIL not set - skipping the cast"
+            echo "::warning::seed. druthers-web's QA E2E lane will have no"
+            echo "::warning::seats to sign in as."
+            exit 0
+          fi
+          python -m app.migration.seed_qa_cast
+
       - name: Backfill catalog data
         if: steps.migrate.outputs.ran == 'true'
         env:

--- a/app/migration/seed_dev.py
+++ b/app/migration/seed_dev.py
@@ -813,7 +813,11 @@ def _get_or_create_cast_user(session: Session, spec: dict) -> DbUser:
         user = DbUser(
             display_name=spec['display_name'],
             email=spec['email'],
-            password=Hash.hash_password(_CAST_PASSWORD),
+            # Per-spec override so a deployed environment can give a seat a
+            # real password. Locally every seat shares ``change-me``, which is
+            # harmless because ``_assert_local_dev`` means there is no
+            # environment it unlocks.
+            password=Hash.hash_password(spec.get('password') or _CAST_PASSWORD),
             handle=spec['handle'],
         )
         session.add(user)
@@ -937,7 +941,7 @@ def _ensure_follow(session: Session, follower: DbUser, followee: DbUser) -> None
         session.add(DbFollow(follower_id=follower.pk, followee_id=followee.pk))
 
 
-def _seed_cast(session: Session, target: DbUser) -> dict:
+def _seed_cast(session: Session, target: DbUser, specs=None) -> dict:
     """
     Create the fixed dev cast and wire their relationships (#313).
 
@@ -948,18 +952,20 @@ def _seed_cast(session: Session, target: DbUser) -> dict:
     each cast member, pinning the compare states; see the module docstring for
     the full matrix.
     """
+    specs = tuple(specs if specs is not None else _CAST_USERS)
     _claim_target_user(target)
-    users = {
-        spec['email']: _get_or_create_cast_user(session, spec) for spec in _CAST_USERS
-    }
+    users = {spec['email']: _get_or_create_cast_user(session, spec) for spec in specs}
 
+    # Anchors, and they are why a caller cannot drop a relationship seat: the
+    # matrix is defined by these three edges, so a subset that omits one of
+    # them is not a smaller cast, it is a different one.
     _ensure_friendship(session, target, users['friend@example.com'])
     _ensure_follow(session, users['follower@example.com'], target)
     _ensure_follow(session, target, users['followee@example.com'])
 
     canon = _cast_canon_movies()
     ranked = {target.pk: _rank_movies(session, target, canon)}
-    for spec in _CAST_USERS:
+    for spec in specs:
         user = users[spec['email']]
         count = _rank_movies(session, user, canon[: spec.get('canon_movies', 0)])
         count += _rank_movies(

--- a/app/migration/seed_qa_cast.py
+++ b/app/migration/seed_qa_cast.py
@@ -1,0 +1,174 @@
+"""
+Seed the dev cast into QA, idempotently, on every deploy (#413).
+
+QA's database is a Neon branch reset from prod, so it holds real library data
+and no fixture accounts. Without a cast there, druthers-web's authenticated
+Playwright lane can only run the handful of specs that need nobody in
+particular: everything about visibility, comparison, friendship and shelves
+names a seat.
+
+A Neon reset also wipes anything seeded by hand, silently, which is why this
+runs on deploy rather than once.
+
+**Deliberately not ``seed_dev``.** That script refuses to run anywhere but the
+local dev Postgres and should keep refusing: it performs bulk randomized
+writes and must never reach a prod-derived database. This one shares its cast
+*definition* (``_CAST_USERS`` is the only place those facts live besides
+``docs/dev-cast.md``) but seeds only the cast: the accounts, their tiers,
+their three relationship edges, and the canon titles their shelf sizes depend
+on. No randomized volume, and nothing outside the accounts it creates.
+
+Every tracker row it writes is marked ``is_seed_data=True``, so it stays
+distinguishable from the prod-derived rows around it.
+
+Usage (the deploy runs the first form)::
+
+    python -m app.migration.seed_qa_cast
+    python -m app.migration.seed_qa_cast --email someone@example.com
+
+The target defaults to ``QA_E2E_TARGET_EMAIL``. It must already exist: this
+script never creates the account the whole cast is anchored to, because that
+account is the one with real credentials and an operator should have made a
+deliberate decision about it.
+
+**admin-two is opt-in.** The seat exists so "an admin cannot impersonate or
+disable another admin" (#341) is demonstrable, and it is an admin account. On
+a local database a known password on it unlocks nothing. On QA it would be
+admin access to a prod-derived copy, reachable from the internet, so it is
+seeded only when ``QA_ADMIN_TWO_PASSWORD`` supplies a real password. Without
+that variable the seat is skipped and the admin-on-admin spec stays local.
+"""
+
+import argparse
+import logging
+import os
+import sys
+from urllib.parse import urlsplit
+
+from sqlalchemy.orm import Session
+
+from app.config import get_settings
+from app.db.database import SessionLocal
+from app.db.models import DbUser
+from app.migration.seed_dev import _CAST_USERS, _seed_cast
+
+logger = logging.getLogger(__name__)
+
+TARGET_EMAIL_VAR = 'QA_E2E_TARGET_EMAIL'
+ADMIN_TWO_PASSWORD_VAR = 'QA_ADMIN_TWO_PASSWORD'
+
+
+def _assert_qa() -> None:
+    """
+    Refuse to run anywhere but QA.
+
+    The mirror of ``seed_dev._assert_local_dev``, and it exists for the same
+    reason: this writes to a database, and the one it must never reach is
+    prod. Checks the *resolved* connection host as well as ENV, since
+    DATABASE_URL wins over the discrete POSTGRES_* parts and an env var alone
+    is not proof of where the writes are going.
+    """
+    settings = get_settings()
+    host = (urlsplit(settings.sqlalchemy_database_url).hostname or '').lower()
+    if settings.env != 'qa':
+        logger.error(
+            'seed_qa_cast refuses to run: ENV=%s is not qa. This script '
+            'writes to a database and must never reach prod.',
+            settings.env,
+        )
+        sys.exit(2)
+    # An unset DATABASE_URL does not leave the host empty: settings falls back
+    # to the discrete POSTGRES_* parts and the hostname resolves to the literal
+    # string 'none'. A truthiness check would sail straight past that, so name
+    # the placeholders. localhost is here too: ENV=qa pointed at a local
+    # database means something is misconfigured, and seeding it would be
+    # writing QA fixtures into whatever happens to be running.
+    if host in ('', 'none', 'localhost', '127.0.0.1'):
+        logger.error(
+            'seed_qa_cast refuses to run: ENV=qa but the resolved database '
+            'host is %r, which is not a deployed QA database.',
+            host,
+        )
+        sys.exit(2)
+
+
+def _specs_for_qa() -> tuple:
+    """
+    The cast to seed here.
+
+    Every relationship seat, always: the matrix is defined by them and a
+    subset is a different cast rather than a smaller one. ``admin-two`` only
+    when a real password is supplied, since seeding an admin with a shared
+    known password on an internet-facing host is a different proposition from
+    doing it locally.
+    """
+    admin_password = os.getenv(ADMIN_TWO_PASSWORD_VAR)
+    specs = []
+    for spec in _CAST_USERS:
+        if spec.get('admin'):
+            if not admin_password:
+                logger.info(
+                    'Skipping %s: set %s to seed the second admin seat. '
+                    'The admin-on-admin rule stays local-only without it.',
+                    spec['handle'],
+                    ADMIN_TWO_PASSWORD_VAR,
+                )
+                continue
+            spec = {**spec, 'password': admin_password}
+        specs.append(spec)
+    return tuple(specs)
+
+
+def _target(session: Session, email: str | None) -> DbUser:
+    """The account the cast is anchored to. Never created here."""
+    email = email or os.getenv(TARGET_EMAIL_VAR)
+    if not email:
+        logger.error(
+            'seed_qa_cast needs a target: set %s or pass --email.',
+            TARGET_EMAIL_VAR,
+        )
+        sys.exit(2)
+    user = session.query(DbUser).filter_by(email=email).one_or_none()
+    if user is None:
+        logger.error(
+            'seed_qa_cast refuses to create the target account %s. Create it '
+            'deliberately (druthers-infra scripts/qa-create-user.sh), then '
+            're-run.',
+            email,
+        )
+        sys.exit(2)
+    return user
+
+
+def run(email: str = None) -> dict:
+    """Seed the cast against QA and return what was created."""
+    _assert_qa()
+    session = SessionLocal()
+    try:
+        result = _seed_cast(session, _target(session, email), specs=_specs_for_qa())
+        session.commit()
+        logger.info(
+            'QA cast seeded: %s accounts, %s ranked rows.',
+            result['cast_users'],
+            result['ranked_rows'],
+        )
+        return result
+    finally:
+        session.close()
+
+
+def main() -> None:
+    """CLI entry point: parse --email and seed."""
+    logging.basicConfig(level=logging.INFO, format='%(levelname)s %(message)s')
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--email',
+        default=None,
+        help=f'Target account the cast anchors to (default: ${TARGET_EMAIL_VAR}).',
+    )
+    args = parser.parse_args()
+    run(args.email)
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/dev-cast.md
+++ b/docs/dev-cast.md
@@ -54,6 +54,32 @@ size *is* shared-title count, and five shared titles is the line between
 a second `friend` and the `not_enough_overlap` state stops existing anywhere
 in the seed data.
 
+## Which environments the cast exists in
+
+| Environment | How it gets there | Notes |
+| --- | --- | --- |
+| local dev | `task seed:dev` (`app/migration/seed_dev.py`) | The full cast, plus randomized volume for the target |
+| QA | `app/migration/seed_qa_cast.py`, run by `deploy_qa.yaml` on every deploy | The cast only: accounts, tiers, the three relationship edges, and the canon titles the shelf sizes depend on. No randomized volume |
+| prod | never | Both seeders refuse: `seed_dev` only runs against the local dev Postgres, `seed_qa_cast` only when `ENV=qa` |
+
+Two things differ on QA and both are deliberate:
+
+- **The target is not the seed admin.** QA's database is a Neon branch reset
+  from prod, so the seed admin there is a real account with a real library.
+  The cast anchors to a dedicated account named by the `QA_E2E_TARGET_EMAIL`
+  repo variable, and `seed_qa_cast` refuses to create it: that account has
+  real credentials on an internet-facing host and an operator should have made
+  a deliberate decision about it.
+- **`admin-two` is opt-in.** It is an admin account, and a shared known
+  password on it is harmless locally (`seed_dev` refuses to run anywhere that
+  password unlocks something) but would be admin access to a prod-derived copy
+  on QA. It is seeded only when the `QA_ADMIN_TWO_PASSWORD` secret supplies a
+  real one; otherwise the seat is skipped and the admin-on-admin rule (#341)
+  stays covered locally.
+
+A Neon reset wipes the cast, which is why the seed runs on every deploy rather
+than once. It is idempotent, so a re-deploy changes nothing.
+
 ## Agent instructions: demoing with the cast
 
 Bring the stack up with the `druthers-up` skill first. Then, for whatever is

--- a/tests/unit/seed_qa_cast_test.py
+++ b/tests/unit/seed_qa_cast_test.py
@@ -1,0 +1,171 @@
+# pylint: disable=missing-function-docstring, protected-access
+"""
+Tests for the QA cast seeder (#413).
+
+The guard tests matter most. This script writes to a database that is a branch
+of prod, so the interesting question is never "does it seed" but "what stops it
+seeding somewhere it should not".
+"""
+
+import pytest
+
+from app.config import Settings
+from app.db.hash import Hash
+from app.db.models import DbFollow, DbFriendship, DbUser
+from app.migration import seed_dev, seed_qa_cast
+
+
+def _cast_user(session, email):
+    return session.query(DbUser).filter_by(email=email).one()
+
+
+# --- the guard ------------------------------------------------------------
+
+
+@pytest.mark.parametrize('env', ['dev', 'prod', 'local', 'github'])
+def test_assert_qa_refuses_every_env_but_qa(monkeypatch, env):
+    settings = Settings(env=env, database_url='postgresql://u:p@somewhere/db')
+    monkeypatch.setattr(seed_qa_cast, 'get_settings', lambda: settings)
+
+    with pytest.raises(SystemExit):
+        seed_qa_cast._assert_qa()
+
+
+@pytest.mark.parametrize('database_url', ['', None])
+def test_assert_qa_refuses_a_placeholder_host(monkeypatch, database_url):
+    # The mirror of #257 on seed_dev's guard: ENV alone is not proof of where
+    # the writes land. And an unset DATABASE_URL does NOT leave the host empty
+    # -- settings falls back to the discrete POSTGRES_* parts and the hostname
+    # resolves to the literal string 'none', which a truthiness check sails
+    # straight past.
+    settings = Settings(env='qa', database_url=database_url)
+    monkeypatch.setattr(seed_qa_cast, 'get_settings', lambda: settings)
+
+    with pytest.raises(SystemExit):
+        seed_qa_cast._assert_qa()
+
+
+def test_assert_qa_refuses_a_local_database(monkeypatch):
+    # ENV=qa pointed at localhost means something is misconfigured, and
+    # seeding it would write QA fixtures into whatever happens to be running.
+    settings = Settings(
+        env='qa', database_url='postgresql://u:p@localhost:5432/druthers'
+    )
+    monkeypatch.setattr(seed_qa_cast, 'get_settings', lambda: settings)
+
+    with pytest.raises(SystemExit):
+        seed_qa_cast._assert_qa()
+
+
+def test_assert_qa_allows_qa(monkeypatch):
+    settings = Settings(
+        env='qa',
+        database_url='postgresql://u:p@ep-qa-branch.us-east-2.aws.neon.tech/druthers',
+    )
+    monkeypatch.setattr(seed_qa_cast, 'get_settings', lambda: settings)
+
+    seed_qa_cast._assert_qa()
+
+
+# --- the target -----------------------------------------------------------
+
+
+def test_target_refuses_to_create_the_anchor_account(test_client, monkeypatch):
+    # The anchor is the one account with real credentials. Creating it here
+    # would mean inventing a password for an account on an internet-facing
+    # host, which is an operator's decision and not this script's.
+    session = test_client.test_db_session
+    monkeypatch.delenv(seed_qa_cast.TARGET_EMAIL_VAR, raising=False)
+
+    with pytest.raises(SystemExit):
+        seed_qa_cast._target(session, 'nobody-here@example.com')
+
+
+def test_target_refuses_without_an_email_at_all(test_client, monkeypatch):
+    session = test_client.test_db_session
+    monkeypatch.delenv(seed_qa_cast.TARGET_EMAIL_VAR, raising=False)
+
+    with pytest.raises(SystemExit):
+        seed_qa_cast._target(session, None)
+
+
+def test_target_reads_the_environment_when_no_email_is_passed(test_client, monkeypatch):
+    session = test_client.test_db_session
+    existing = test_client.first_user
+    monkeypatch.setenv(seed_qa_cast.TARGET_EMAIL_VAR, existing.email)
+
+    assert seed_qa_cast._target(session, None).email == existing.email
+
+
+# --- which seats get seeded ----------------------------------------------
+
+
+def test_admin_seat_is_skipped_without_a_password(monkeypatch):
+    # An admin seat with a shared known password is harmless locally, where
+    # seed_dev's guard means it unlocks nothing. On QA it would be admin access
+    # to a prod-derived copy, so it has to be opted into.
+    monkeypatch.delenv(seed_qa_cast.ADMIN_TWO_PASSWORD_VAR, raising=False)
+
+    specs = seed_qa_cast._specs_for_qa()
+
+    assert not any(s.get('admin') for s in specs)
+    assert len(specs) == len(seed_dev._CAST_USERS) - 1
+
+
+def test_admin_seat_is_seeded_with_its_own_password_when_supplied(monkeypatch):
+    monkeypatch.setenv(seed_qa_cast.ADMIN_TWO_PASSWORD_VAR, 'a-real-secret')
+
+    specs = seed_qa_cast._specs_for_qa()
+    admin = next(s for s in specs if s.get('admin'))
+
+    assert admin['password'] == 'a-real-secret'
+    assert len(specs) == len(seed_dev._CAST_USERS)
+
+
+def test_every_relationship_seat_is_always_seeded(monkeypatch):
+    # The matrix is defined by the three relationship edges. Dropping a seat
+    # would not give a smaller cast, it would give a different one.
+    monkeypatch.delenv(seed_qa_cast.ADMIN_TWO_PASSWORD_VAR, raising=False)
+
+    emails = {s['email'] for s in seed_qa_cast._specs_for_qa()}
+
+    for required in (
+        'friend@example.com',
+        'follower@example.com',
+        'followee@example.com',
+    ):
+        assert required in emails
+
+
+# --- seeding itself -------------------------------------------------------
+
+
+def test_seeding_a_subset_still_builds_the_relationship_edges(test_client):
+    session = test_client.test_db_session
+    target = test_client.first_user
+    specs = tuple(s for s in seed_dev._CAST_USERS if not s.get('admin'))
+
+    result = seed_dev._seed_cast(session, target, specs=specs)
+    session.commit()
+
+    assert result['cast_users'] == len(specs)
+    assert session.query(DbFriendship).count() == 1
+    assert session.query(DbFollow).count() == 2
+
+
+def test_a_spec_password_override_is_used(test_client):
+    session = test_client.test_db_session
+    target = test_client.first_user
+    specs = tuple(
+        {**s, 'password': 'per-seat-secret'} if s.get('admin') else s
+        for s in seed_dev._CAST_USERS
+    )
+
+    seed_dev._seed_cast(session, target, specs=specs)
+    session.commit()
+
+    admin_spec = next(s for s in seed_dev._CAST_USERS if s.get('admin'))
+    user = _cast_user(session, admin_spec['email'])
+
+    assert Hash.verify(user.password, 'per-seat-secret')
+    assert not Hash.verify(user.password, seed_dev._CAST_PASSWORD)


### PR DESCRIPTION
## Summary

- QA's database is a Neon branch **reset from prod**, so it holds real library data and no fixture accounts. druthers-web's authenticated Playwright lane currently passes **9 of 42** against QA: everything about visibility, comparison, friendship and shelves names a cast seat, and none exist there.
- Adds `app/migration/seed_qa_cast.py`, run by `deploy_qa.yaml` after the migration. **On every deploy on purpose** — a Neon reset wipes anything seeded by hand, silently. Idempotent, so a re-deploy changes nothing.
- Seeds **only the cast**: accounts, tiers, the three relationship edges, and the canon titles the shelf sizes depend on. No randomized volume, and nothing outside the accounts it creates. Every tracker row is `is_seed_data=True`.

**Deliberately not `seed_dev`.** That script refuses to run anywhere but the local dev Postgres and should keep refusing: it performs bulk randomized writes. This shares the cast *definition* — `_CAST_USERS` stays the only place those facts live besides `docs/dev-cast.md` — via two small seams in `seed_dev`: an optional per-spec password, and an optional spec subset.

## Guards

Both mirror `seed_dev`'s, and the second one is not the check I first wrote:

- **`ENV` must be `qa`**, and the *resolved* connection host is checked too, because ENV alone is not proof of where writes land (the #257 lesson from the other script).
- **The host must not be a placeholder.** An unset `DATABASE_URL` does **not** leave the host empty — settings falls back to the discrete `POSTGRES_*` parts and the hostname resolves to the literal string `'none'`. My first guard was `if not host`, which sails straight past that; I only caught it because the test asserting a refusal passed when it should have failed. `localhost` is refused for the same reason: `ENV=qa` pointed at a local database is a misconfiguration, and seeding it would write QA fixtures into whatever happens to be running.

Verified: `ENV=dev python -m app.migration.seed_qa_cast` exits **2** with a clear message.

## Two decisions worth reviewing

**The target account is never created here.** It is the one account with real credentials on an internet-facing host, so an operator makes that call deliberately; the script refuses and names `scripts/qa-create-user.sh`. Set the `QA_E2E_TARGET_EMAIL` repo variable to the account you already created.

**`admin-two` is opt-in**, via a `QA_ADMIN_TWO_PASSWORD` secret. A shared known password on an admin seat is harmless locally, where the guard means it unlocks nothing. On QA it would be admin access to a prod-derived copy of your library, reachable from the internet. Without the secret the seat is skipped and the admin-on-admin rule (#341) stays covered locally only. This is the open decision from the issue, resolved toward the safer default — say the word if you would rather it just used `change-me`.

## Test plan

- [x] `pytest -q`: **1111 passed**, including 16 new cases in `tests/unit/seed_qa_cast_test.py`.
- [x] Guard covered for every non-qa env, both placeholder-host forms, and localhost.
- [x] Covered that the target is never created, and that the subset still builds all three relationship edges.
- [x] Covered that a per-spec password is actually used (`Hash.verify` against the override, and *not* against `change-me`).
- [x] `black`, `double-quote-string-fixer`, `pylint` and the pre-push suite all pass.
- [ ] Not yet run against real QA — that happens on the next deploy to main.

## To activate

1. Set repo variable `QA_E2E_TARGET_EMAIL` to the QA admin account.
2. Optionally set secret `QA_ADMIN_TWO_PASSWORD`.
3. Merge. The next QA deploy seeds the cast, and `task e2e:qa` should go from 9/42 to green.

Without step 1 the deploy logs a warning and skips the seed rather than failing — a QA deploy should not go red because E2E fixtures are unconfigured.

Closes #413