### PR TITLE
feat: verify Apple identity tokens and link Apple accounts

### DIFF
--- a/alembic/versions/a3f7c21e58b9_user_apple_sub.py
+++ b/alembic/versions/a3f7c21e58b9_user_apple_sub.py
@@ -1,0 +1,31 @@
+"""Add users.apple_sub for Sign in with Apple.
+
+Revision ID: a3f7c21e58b9
+Revises: f342a9b7c1d0
+Create Date: 2026-08-22 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'a3f7c21e58b9'
+down_revision: Union[str, Sequence[str], None] = 'f342a9b7c1d0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Nullable with a unique index rather than a unique constraint on a
+    # populated column: every existing row gets NULL, and NULLs do not collide
+    # under a unique index in Postgres or SQLite, so no backfill is needed.
+    op.add_column('users', sa.Column('apple_sub', sa.String(), nullable=True))
+    op.create_index(op.f('ix_users_apple_sub'), 'users', ['apple_sub'], unique=True)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_users_apple_sub'), table_name='users')
+    op.drop_column('users', 'apple_sub')

--- a/app/auth/apple_identity.py
+++ b/app/auth/apple_identity.py
@@ -1,0 +1,125 @@
+"""
+Verification for Sign in with Apple identity tokens.
+
+Apple's tokens are not Google's with a different logo. They are signed with
+Apple's own keys, published at a different JWKS endpoint, and carry a
+different issuer, so this is a parallel verification path rather than another
+entry in the Google audience list (druthers-api#418).
+
+The claim that matters is ``sub``. It is stable for a given Apple ID against a
+given developer team and it is the only identifier we can trust across
+sign-ins: ``email`` may be an Apple private relay address, and Apple only
+guarantees the full name on the very first authorization.
+"""
+
+import hashlib
+import secrets
+from functools import lru_cache
+from typing import List, NamedTuple, Optional
+
+import jwt
+from jwt import PyJWKClient
+
+APPLE_ISSUER = 'https://appleid.apple.com'
+APPLE_JWKS_URL = 'https://appleid.apple.com/auth/keys'
+
+# Apple rotates its signing keys without notice, so the key set is fetched and
+# cached rather than pinned. PyJWKClient refetches when it sees a `kid` it does
+# not hold, which is what makes rotation a non-event; the lifespan just stops
+# us hitting Apple on every sign-in.
+_JWKS_CACHE_SECONDS = 900
+
+
+class AppleIdentityError(Exception):
+    """The token did not verify, or verified but is unusable."""
+
+
+class AppleIdentity(NamedTuple):
+    """The claims we actually act on, normalised."""
+
+    subject: str
+    email: Optional[str]
+    is_private_email: bool
+    email_verified: bool
+
+
+@lru_cache(maxsize=1)
+def _jwks_client() -> PyJWKClient:
+    """One cached client per process; see _JWKS_CACHE_SECONDS."""
+    return PyJWKClient(
+        APPLE_JWKS_URL,
+        cache_keys=True,
+        cache_jwk_set=True,
+        lifespan=_JWKS_CACHE_SECONDS,
+    )
+
+
+def _as_bool(value) -> bool:
+    """
+    Apple sends booleans as JSON booleans on some flows and as the strings
+    'true'/'false' on others. Both mean the same thing and neither is a
+    documented guarantee, so normalise instead of trusting one shape.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() == 'true'
+    return False
+
+
+def verify_identity_token(
+    token: str,
+    audiences: List[str],
+    expected_nonce: Optional[str] = None,
+) -> AppleIdentity:
+    """
+    Verify an Apple identity token and return the claims we act on.
+
+    ``audiences`` is every client id we accept, matching how
+    ``settings.google_client_ids`` works: PyJWT requires ``aud`` to match one
+    entry, so widening the list adds issuing clients without weakening
+    verification of any of them.
+
+    ``expected_nonce`` is the RAW nonce the client generated. Apple echoes back
+    whatever was put in the authorization request, and the convention is to put
+    the SHA-256 of the raw nonce there, so that is what we compare against. A
+    token carrying a nonce is only accepted when the caller can produce the raw
+    value, which is what makes it replay protection rather than decoration.
+    """
+    if not audiences:
+        raise AppleIdentityError('Apple sign-in is not configured')
+
+    try:
+        signing_key = _jwks_client().get_signing_key_from_jwt(token)
+        claims = jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=['RS256'],
+            audience=audiences,
+            issuer=APPLE_ISSUER,
+            options={'require': ['sub', 'aud', 'iss', 'exp']},
+        )
+    except (jwt.PyJWTError, jwt.exceptions.PyJWKClientError) as exc:
+        raise AppleIdentityError('Invalid Apple credential') from exc
+
+    subject = claims.get('sub')
+    if not subject:
+        # `require` above should have caught this; belt and braces, because an
+        # empty subject would silently become an account nobody can sign back
+        # into.
+        raise AppleIdentityError('Apple credential has no subject')
+
+    token_nonce = claims.get('nonce')
+    if token_nonce is not None:
+        if not expected_nonce:
+            raise AppleIdentityError('Apple credential requires a nonce')
+        hashed = hashlib.sha256(expected_nonce.encode('utf-8')).hexdigest()
+        if not secrets.compare_digest(hashed, str(token_nonce)):
+            raise AppleIdentityError('Apple credential nonce mismatch')
+
+    return AppleIdentity(
+        subject=subject,
+        email=claims.get('email'),
+        is_private_email=_as_bool(claims.get('is_private_email')),
+        email_verified=_as_bool(claims.get('email_verified')),
+    )

--- a/app/auth/authentication.py
+++ b/app/auth/authentication.py
@@ -4,6 +4,7 @@ This module creates tokens for users.
 
 import secrets
 from datetime import datetime, timezone
+from typing import Optional
 
 from fastapi import APIRouter, HTTPException, status
 from fastapi.param_functions import Depends
@@ -11,9 +12,10 @@ from fastapi.security.oauth2 import OAuth2PasswordRequestForm
 from google.auth.transport import requests as google_requests
 from google.oauth2 import id_token as google_id_token
 from pydantic import BaseModel
+from sqlalchemy import func
 from sqlalchemy.orm.session import Session
 
-from app.auth import oauth2, refresh_tokens
+from app.auth import apple_identity, oauth2, refresh_tokens
 from app.services.rate_limit import auth_rate_limit, refresh_rate_limit
 from app.config import get_settings
 from app.db import models
@@ -28,6 +30,21 @@ class GoogleAuthRequest(BaseModel):
     """Payload carrying the Google Identity Services ID token (credential)."""
 
     credential: str
+
+
+class AppleAuthRequest(BaseModel):
+    """
+    Payload from Sign in with Apple.
+
+    ``nonce`` is the RAW nonce the client generated; the token carries its
+    SHA-256. ``full_name`` is here because Apple hands the name to the client
+    once, on the very first authorization, and never again - if we do not take
+    it now we cannot ask for it later.
+    """
+
+    identity_token: str
+    nonce: Optional[str] = None
+    full_name: Optional[str] = None
 
 
 def _token_response(user: models.DbUser, refresh_token: str) -> dict:
@@ -222,3 +239,142 @@ def logout(request: InRefreshToken, db: Session = Depends(get_db)):
             models.DbImpersonationSession.ended_at.is_(None),
         ).update({'ended_at': datetime.now(timezone.utc)}, synchronize_session=False)
         db.commit()
+
+
+def _check_oauth_allowlist(email: str) -> None:
+    """
+    Enforce the invite-only allowlist (#183) against a resolved email.
+
+    Applies to new AND existing accounts: during an invite-only phase the
+    allowlist is the single source of truth for who may sign in, not just who
+    may register.
+    """
+    allowlist = get_settings().oauth_allowlist_emails
+    if allowlist is not None and email.lower() not in allowlist:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                'This app is invite-only right now. Your account '
+                'isn’t on the access list - contact the administrator '
+                'if you believe this is a mistake.'
+            ),
+        )
+
+
+@router.post('/apple', response_model=OutToken, dependencies=[Depends(auth_rate_limit)])
+def apple_login(request: AppleAuthRequest, db: Session = Depends(get_db)):
+    """
+    Sign in with an Apple identity token.
+
+    Resolution order is deliberate, and it is the part with consequences:
+
+    1. **By Apple subject.** ``sub`` is stable for this Apple ID against our
+       developer team, and it survives the user turning off email relay or
+       changing their Apple ID address.
+    2. **By email, once, to link.** Someone who signed in with Google on the
+       web and then with Apple on the phone is one person, and must land in
+       one account. When Apple gives us a real, verified address that already
+       belongs to an account, we stamp the Apple subject onto it rather than
+       creating a second account. Splitting them here is cheap to prevent and
+       expensive to merge later.
+    3. **Otherwise create.** First sign-in with no matching account.
+
+    Linking by email is deliberately NOT done for Apple private relay
+    addresses. A relay is minted per app and will never equal the address on a
+    Google account, so matching on one could only ever produce a false link.
+    """
+    settings = get_settings()
+    client_ids = settings.apple_client_ids
+    if not client_ids:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail='Apple sign-in is not configured',
+        )
+
+    try:
+        identity = apple_identity.verify_identity_token(
+            request.identity_token, client_ids, request.nonce
+        )
+    except apple_identity.AppleIdentityError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail='Invalid Apple credential',
+        ) from exc
+
+    # Kept in Apple's casing for storage, lowercased only for comparison:
+    # existing rows carry mixed-case addresses (`Dylan.Obrien@...`), so an
+    # exact match would miss the very account we are trying to link to and
+    # silently create a duplicate.
+    email = (identity.email or '').strip() or None
+    email_key = email.lower() if email else None
+
+    user = (
+        db.query(models.DbUser)
+        .filter(models.DbUser.apple_sub == identity.subject)
+        .first()
+    )
+
+    if user is None and email and identity.email_verified:
+        if not identity.is_private_email:
+            existing = (
+                db.query(models.DbUser)
+                .filter(func.lower(models.DbUser.email) == email_key)
+                .first()
+            )
+            if existing is not None:
+                _check_oauth_allowlist(existing.email)
+                if existing.disabled_at is not None:
+                    raise HTTPException(
+                        status_code=status.HTTP_403_FORBIDDEN,
+                        detail='Account disabled',
+                    )
+                existing.apple_sub = identity.subject
+                db.commit()
+                db.refresh(existing)
+                user = existing
+
+    if user is None:
+        if not email:
+            # Apple omits the email claim in some re-authorization flows. With
+            # no subject match and no address there is nothing to key a new
+            # account on, and inventing a placeholder would create an account
+            # the user can never reach from any other client.
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail='Apple credential carries no email address',
+            )
+        _check_oauth_allowlist(email)
+        clash = (
+            db.query(models.DbUser)
+            .filter(func.lower(models.DbUser.email) == email_key)
+            .first()
+        )
+        if clash is not None:
+            # Only reachable when the address is a private relay that happens
+            # to equal an existing account's address, since a non-relay match
+            # would have linked above. Refusing beats inserting into a unique
+            # index and turning a policy decision into a 500.
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail='An account already exists for this email address',
+            )
+        user = models.DbUser(
+            email=email,
+            display_name=(request.full_name or '').strip()[:30] or email,
+            user_group='user',
+            apple_sub=identity.subject,
+            # Apple-authenticated users don't use a password; store an
+            # unusable one, matching the Google flow.
+            password=Hash.hash_password(secrets.token_hex(16)),
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+    else:
+        _check_oauth_allowlist(user.email)
+        if user.disabled_at is not None:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail='Account disabled'
+            )
+
+    return _sign_in_response(user, db)

--- a/app/config.py
+++ b/app/config.py
@@ -14,6 +14,25 @@ from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
+def _split_client_ids(*sources: Optional[str]) -> List[str]:
+    """
+    Flatten comma-separated OAuth client id settings into an ordered list.
+
+    Shared by the Google and Apple audience lists. Order is preserved and
+    duplicates are dropped, so a client id named in both the primary and the
+    additional setting is not sent to the verifier twice.
+    """
+    ids: List[str] = []
+    for raw in sources:
+        if not raw:
+            continue
+        for client_id in raw.split(','):
+            client_id = client_id.strip()
+            if client_id and client_id not in ids:
+                ids.append(client_id)
+    return ids
+
+
 class Settings(BaseSettings):
     """
     Application settings, populated from the process environment.
@@ -80,6 +99,14 @@ class Settings(BaseSettings):
     # that id as its audience. Additive: deployments setting only
     # GOOGLE_CLIENT_ID are unaffected.
     google_additional_client_ids: Optional[str] = None
+
+    # Sign in with Apple (#418). Separate from the Google ids above because
+    # Apple tokens verify against Apple's issuer and key set, not Google's, so
+    # they are not interchangeable audiences. For a native app the client id
+    # is the bundle id (io.druthers.ios); a web Services ID would go in the
+    # additional list.
+    apple_client_id: Optional[str] = None
+    apple_additional_client_ids: Optional[str] = None
 
     # --- Abuse resistance (#148, threat model H1/H2) ---
     # Kill switch for /v1/auth/token: prod is Google + API keys only.
@@ -229,6 +256,18 @@ class Settings(BaseSettings):
         )
 
     @property
+    def apple_client_ids(self) -> List[str]:
+        """
+        Every Apple client id whose tokens we accept, primary first.
+
+        Same contract as ``google_client_ids``: PyJWT requires the token's
+        ``aud`` to match one entry, so widening this adds accepted issuing
+        clients without weakening verification of any of them. Empty list
+        means Apple sign-in is not configured.
+        """
+        return _split_client_ids(self.apple_client_id, self.apple_additional_client_ids)
+
+    @property
     def google_client_ids(self) -> List[str]:
         """
         Every OAuth client id whose tokens we accept, primary first.
@@ -238,17 +277,9 @@ class Settings(BaseSettings):
         clients without weakening verification of any of them. Empty list means
         Google sign-in is not configured.
         """
-        ids = []
-        for raw in (self.google_client_id, self.google_additional_client_ids):
-            if not raw:
-                continue
-            for client_id in raw.split(','):
-                client_id = client_id.strip()
-                # Preserve order and drop duplicates: a client id listed in
-                # both settings should not be sent twice.
-                if client_id and client_id not in ids:
-                    ids.append(client_id)
-        return ids
+        return _split_client_ids(
+            self.google_client_id, self.google_additional_client_ids
+        )
 
     @property
     def argon2_params(self) -> dict:

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -97,6 +97,13 @@ class DbUser(DBBaseModel):
     user_group = Column(String, default='user')
     password = Column(String)
 
+    # Sign in with Apple (#418). Apple's `sub` is the only stable identifier
+    # across sign-ins: `email` may be a private relay address, and a relay can
+    # be turned off by the user, so keying identity on email would strand the
+    # account. Nullable because every account that predates Apple sign-in, and
+    # every Google-only account, has no Apple subject.
+    apple_sub = Column(String, unique=True, index=True, nullable=True)
+
     # --- Visibility (#143, tiered in #274): everything is private by
     # default. Anything non-private needs a handle (druthers.io/u/<handle>);
     # only ranked lists and opted-in watchlists are ever exposed.

--- a/docs/druthers-api.postman_collection.json
+++ b/docs/druthers-api.postman_collection.json
@@ -3974,6 +3974,39 @@
       "description": "Auth operations",
       "item": [
         {
+          "name": "Apple Login",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/auth/apple",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "auth",
+                "apple"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"identity_token\": \"string\",\n  \"nonce\": \"string\",\n  \"full_name\": \"string\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Sign in with an Apple identity token.\n\nResolution order is deliberate, and it is the part with consequences:\n\n1. **By Apple subject.** ``sub`` is stable for this Apple ID against our\n   developer team, and it survives the user turning off email relay or\n   changing their Apple ID address.\n2. **By email, once, to link.** Someone who signed in with Google on the\n   web and then with Apple on the phone is one person, and must land in\n   one account. When Apple gives us a real, verified address that already\n   belongs to an account, we stamp the Apple subject onto it rather than\n   creating a second account. Splitting them here is cheap to prevent and\n   expensive to merge later.\n3. **Otherwise create.** First sign-in with no matching account.\n\nLinking by email is deliberately NOT done for Apple private relay\naddresses. A relay is minted per app and will never equal the address on a\nGoogle account, so matching on one could only ever produce a false link."
+          }
+        },
+        {
           "name": "Get Token",
           "request": {
             "method": "POST",

--- a/openapi.json
+++ b/openapi.json
@@ -185,6 +185,48 @@
         }
       }
     },
+    "/v1/auth/apple": {
+      "post": {
+        "tags": [
+          "authentication"
+        ],
+        "summary": "Apple Login",
+        "description": "Sign in with an Apple identity token.\n\nResolution order is deliberate, and it is the part with consequences:\n\n1. **By Apple subject.** ``sub`` is stable for this Apple ID against our\n   developer team, and it survives the user turning off email relay or\n   changing their Apple ID address.\n2. **By email, once, to link.** Someone who signed in with Google on the\n   web and then with Apple on the phone is one person, and must land in\n   one account. When Apple gives us a real, verified address that already\n   belongs to an account, we stamp the Apple subject onto it rather than\n   creating a second account. Splitting them here is cheap to prevent and\n   expensive to merge later.\n3. **Otherwise create.** First sign-in with no matching account.\n\nLinking by email is deliberately NOT done for Apple private relay\naddresses. A relay is minted per app and will never equal the address on a\nGoogle account, so matching on one could only ever produce a false link.",
+        "operationId": "apple_login_v1_auth_apple_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AppleAuthRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutToken"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/users": {
       "get": {
         "tags": [
@@ -6863,6 +6905,42 @@
         ],
         "title": "ActivityItem",
         "description": "One inferred user action, unified across all four tracker domains. Most\ntrackers only carry their latest touch (created_at/updated_at) rather\nthan a full history, so one tracker row = one entry here, dated by its\nlast update and with its action inferred from current list state.\nTV episodes are the exception (a real per-watch row exists), so each\nwatched episode appears individually rather than being collapsed into\nits show's row."
+      },
+      "AppleAuthRequest": {
+        "properties": {
+          "identity_token": {
+            "type": "string",
+            "title": "Identity Token"
+          },
+          "nonce": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nonce"
+          },
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "identity_token"
+        ],
+        "title": "AppleAuthRequest",
+        "description": "Payload from Sign in with Apple.\n\n``nonce`` is the RAW nonce the client generated; the token carries its\nSHA-256. ``full_name`` is here because Apple hands the name to the client\nonce, on the very first authorization, and never again - if we do not take\nit now we cannot ask for it later."
       },
       "Body_get_token_v1_auth_token_post": {
         "properties": {

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,11 @@ PyJWT==2.13.0
 # signatures on Apple identity tokens (#418), and it was only present here
 # by way of google-auth. A dependency that signature verification rests on
 # should not be able to disappear when an unrelated package drops it.
-cryptography==49.0.0
+#
+# 50.0.0, not 49.x: CVE-2026-69247 (HIGH) is fixed in 50.0.0. The transitive
+# install was already sitting on the vulnerable 49.0.0; pinning it here is
+# what made the exposure visible to Trivy, which only scans this file.
+cryptography==50.0.0
 google-auth==2.56.3
 requests>=2.34.2 # not directly required, pinned to avoid a vulnerability
 urllib3>=2.7.0 # not directly required, pinned to avoid a vulnerability

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,6 +16,11 @@ python-logging-loki==0.3.1
 tzdata==2026.3
 click>=8.4.2 # not directly required, pinned to avoid a vulnerability
 PyJWT==2.13.0
+# Explicit, not transitive: PyJWT needs cryptography to verify the RS256
+# signatures on Apple identity tokens (#418), and it was only present here
+# by way of google-auth. A dependency that signature verification rests on
+# should not be able to disappear when an unrelated package drops it.
+cryptography==49.0.0
 google-auth==2.56.3
 requests>=2.34.2 # not directly required, pinned to avoid a vulnerability
 urllib3>=2.7.0 # not directly required, pinned to avoid a vulnerability

--- a/tests/integration/router_auth_test.py
+++ b/tests/integration/router_auth_test.py
@@ -7,9 +7,11 @@ from unittest.mock import patch
 from faker import Faker
 from fastapi.testclient import TestClient
 
+from app.auth.apple_identity import AppleIdentity, AppleIdentityError
 from app.config import Settings
 
 fake = Faker()
+APPLE_CLIENT = 'io.druthers.ios'
 
 
 @patch('app.auth.authentication.get_settings')
@@ -293,3 +295,176 @@ def test_google_login_unconfigured_returns_503(
 
     assert response.status_code == 503
     mock_verify.assert_not_called()
+
+
+# --- Sign in with Apple (#418) ---------------------------------------------
+#
+# Verification itself is covered in tests/unit/apple_identity_test.py against
+# real signatures. These stub it out and test what the route does with the
+# claims: which account you land in.
+
+
+def _apple_identity(**overrides):
+    """An AppleIdentity with sensible defaults, for stubbing verification."""
+    fields = {
+        'subject': '001234.abcdef.5678',
+        'email': f'{fake.user_name()}@example.com',
+        'is_private_email': False,
+        'email_verified': True,
+    }
+    fields.update(overrides)
+    return AppleIdentity(**fields)
+
+
+@patch('app.auth.authentication.get_settings')
+@patch('app.auth.authentication.apple_identity.verify_identity_token')
+def test_apple_login_creates_user(mock_verify, mock_settings, test_client: TestClient):
+    """A valid Apple credential signs in and creates the user on first use."""
+    mock_settings.return_value = Settings(apple_client_id=APPLE_CLIENT, env='github')
+    identity = _apple_identity()
+    mock_verify.return_value = identity
+
+    response = test_client.post(
+        '/v1/auth/apple',
+        json={'identity_token': 'fake-apple-token', 'full_name': 'Test Apple User'},
+    )
+
+    assert response.status_code == 200
+    assert response.json()['email'] == identity.email
+
+
+@patch('app.auth.authentication.get_settings')
+@patch('app.auth.authentication.apple_identity.verify_identity_token')
+def test_apple_login_links_to_an_existing_account_by_email(
+    mock_verify, mock_settings, test_client: TestClient, test_db_session
+):
+    """
+    Google on the web then Apple on the phone is ONE person, so it must be one
+    account. This is the case that is cheap to prevent and expensive to merge
+    after the fact.
+    """
+    existing = test_client.first_user
+    mock_settings.return_value = Settings(apple_client_id=APPLE_CLIENT, env='github')
+    mock_verify.return_value = _apple_identity(email=existing.email)
+
+    response = test_client.post(
+        '/v1/auth/apple', json={'identity_token': 'fake-apple-token'}
+    )
+
+    assert response.status_code == 200
+    assert response.json()['user_id'] == existing.id
+    test_db_session.refresh(existing)
+    assert existing.apple_sub == '001234.abcdef.5678'
+
+
+@patch('app.auth.authentication.get_settings')
+@patch('app.auth.authentication.apple_identity.verify_identity_token')
+def test_apple_login_does_not_link_a_private_relay_address(
+    mock_verify, mock_settings, test_client: TestClient
+):
+    """
+    A relay address is minted per app and can never equal the address on
+    someone's Google account, so matching on one could only ever be a false
+    link. It gets its own account.
+    """
+    existing = test_client.first_user
+    mock_settings.return_value = Settings(apple_client_id=APPLE_CLIENT, env='github')
+    mock_verify.return_value = _apple_identity(
+        email=existing.email, is_private_email=True
+    )
+
+    response = test_client.post(
+        '/v1/auth/apple', json={'identity_token': 'fake-apple-token'}
+    )
+
+    # Refused outright rather than silently taking over that account, and
+    # never a 500 from the unique index.
+    assert response.status_code == 409
+
+
+@patch('app.auth.authentication.get_settings')
+@patch('app.auth.authentication.apple_identity.verify_identity_token')
+def test_apple_login_finds_the_account_by_subject_when_email_changes(
+    mock_verify, mock_settings, test_client: TestClient
+):
+    """
+    The subject is the stable key. A user who turns off email relay, or whose
+    token stops carrying an address, must land back in the same account.
+    """
+    mock_settings.return_value = Settings(apple_client_id=APPLE_CLIENT, env='github')
+    mock_verify.return_value = _apple_identity()
+    first = test_client.post(
+        '/v1/auth/apple', json={'identity_token': 'fake-apple-token'}
+    )
+    assert first.status_code == 200
+
+    # Same subject, no email at all this time.
+    mock_verify.return_value = _apple_identity(email=None)
+    second = test_client.post(
+        '/v1/auth/apple', json={'identity_token': 'fake-apple-token'}
+    )
+
+    assert second.status_code == 200
+    assert second.json()['user_id'] == first.json()['user_id']
+
+
+@patch('app.auth.authentication.get_settings')
+@patch('app.auth.authentication.apple_identity.verify_identity_token')
+def test_apple_login_rejects_an_unknown_subject_with_no_email(
+    mock_verify, mock_settings, test_client: TestClient
+):
+    """Nothing to key an account on, and a placeholder would be unreachable."""
+    mock_settings.return_value = Settings(apple_client_id=APPLE_CLIENT, env='github')
+    mock_verify.return_value = _apple_identity(subject='001234.never.seen', email=None)
+
+    response = test_client.post(
+        '/v1/auth/apple', json={'identity_token': 'fake-apple-token'}
+    )
+
+    assert response.status_code == 401
+
+
+@patch('app.auth.authentication.get_settings')
+@patch('app.auth.authentication.apple_identity.verify_identity_token')
+def test_apple_login_rejects_an_invalid_credential(
+    mock_verify, mock_settings, test_client: TestClient
+):
+    """A verification failure is a 401, never a 500."""
+    mock_settings.return_value = Settings(apple_client_id=APPLE_CLIENT, env='github')
+    mock_verify.side_effect = AppleIdentityError('Invalid Apple credential')
+
+    response = test_client.post('/v1/auth/apple', json={'identity_token': 'forged'})
+
+    assert response.status_code == 401
+
+
+@patch('app.auth.authentication.get_settings')
+def test_apple_login_is_503_when_not_configured(mock_settings, test_client: TestClient):
+    """An environment with no Apple client id says so, rather than 401ing."""
+    mock_settings.return_value = Settings(env='github')
+
+    response = test_client.post(
+        '/v1/auth/apple', json={'identity_token': 'fake-apple-token'}
+    )
+
+    assert response.status_code == 503
+
+
+@patch('app.auth.authentication.get_settings')
+@patch('app.auth.authentication.apple_identity.verify_identity_token')
+def test_apple_login_respects_the_invite_allowlist(
+    mock_verify, mock_settings, test_client: TestClient
+):
+    """The allowlist gates Apple sign-in the same way it gates Google."""
+    mock_settings.return_value = Settings(
+        apple_client_id=APPLE_CLIENT,
+        env='github',
+        oauth_allowlist='someone-else@example.com',
+    )
+    mock_verify.return_value = _apple_identity()
+
+    response = test_client.post(
+        '/v1/auth/apple', json={'identity_token': 'fake-apple-token'}
+    )
+
+    assert response.status_code == 403

--- a/tests/unit/apple_identity_test.py
+++ b/tests/unit/apple_identity_test.py
@@ -1,0 +1,171 @@
+"""
+Tests for Apple identity token verification.
+
+These sign real tokens with a real RSA key and verify them through the real
+code path, stubbing only the network fetch of Apple's key set. Mocking
+``jwt.decode`` instead would assert that we call a library, not that a forged
+token is actually rejected, which is the only thing worth proving here.
+"""
+
+import hashlib
+import time
+from unittest.mock import patch
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from app.auth import apple_identity
+from app.auth.apple_identity import (
+    AppleIdentityError,
+    verify_identity_token,
+)
+
+AUDIENCE = 'io.druthers.ios'
+
+
+@pytest.fixture(name='signing_key')
+def signing_key_fixture():
+    """One 2048-bit key for the whole module; generation is the slow part."""
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture(name='other_key')
+def other_key_fixture():
+    """A key Apple never published, for the forged-signature case."""
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _make_token(key, **overrides):
+    """Mint an Apple-shaped identity token."""
+    now = int(time.time())
+    claims = {
+        'iss': 'https://appleid.apple.com',
+        'aud': AUDIENCE,
+        'sub': '001234.abcdef.5678',
+        'iat': now,
+        'exp': now + 600,
+        'email': 'person@example.com',
+        'email_verified': 'true',
+        'is_private_email': 'false',
+    }
+    claims.update(overrides)
+    for empty in [k for k, v in claims.items() if v is None]:
+        del claims[empty]
+    return jwt.encode(claims, key, algorithm='RS256')
+
+
+def _verify(token, key, **kwargs):
+    """Run verification with Apple's key set stubbed to ``key``."""
+
+    class _StubKey:
+        def __init__(self, public_key):
+            self.key = public_key
+
+    with patch.object(apple_identity, '_jwks_client') as jwks:
+        jwks.return_value.get_signing_key_from_jwt.return_value = _StubKey(
+            key.public_key()
+        )
+        return verify_identity_token(token, [AUDIENCE], **kwargs)
+
+
+def test_accepts_a_valid_token(signing_key):
+    """The happy path, with the claims normalised the way the route reads them."""
+    identity = _verify(_make_token(signing_key), signing_key)
+
+    assert identity.subject == '001234.abcdef.5678'
+    assert identity.email == 'person@example.com'
+    assert identity.email_verified is True
+    assert identity.is_private_email is False
+
+
+def test_rejects_a_token_signed_by_the_wrong_key(signing_key, other_key):
+    """A forged token verified against Apple's real key set must not pass."""
+    forged = _make_token(other_key)
+
+    with pytest.raises(AppleIdentityError):
+        _verify(forged, signing_key)
+
+
+def test_rejects_the_wrong_audience(signing_key):
+    """A token minted for a different app must not sign anyone in here."""
+    token = _make_token(signing_key, aud='com.someone.else')
+
+    with pytest.raises(AppleIdentityError):
+        _verify(token, signing_key)
+
+
+def test_rejects_the_wrong_issuer(signing_key):
+    """Guards against a token minted by another provider with our audience."""
+    token = _make_token(signing_key, iss='https://accounts.google.com')
+
+    with pytest.raises(AppleIdentityError):
+        _verify(token, signing_key)
+
+
+def test_rejects_an_expired_token(signing_key):
+    """Expiry is enforced by us, not left to the client to respect."""
+    now = int(time.time())
+    token = _make_token(signing_key, iat=now - 7200, exp=now - 3600)
+
+    with pytest.raises(AppleIdentityError):
+        _verify(token, signing_key)
+
+
+def test_rejects_a_token_with_no_configured_audience(signing_key):
+    """An unconfigured environment refuses rather than accepting any audience."""
+    with pytest.raises(AppleIdentityError):
+        verify_identity_token(_make_token(signing_key), [])
+
+
+def test_accepts_a_matching_nonce(signing_key):
+    """The token carries SHA-256 of the raw nonce; the caller supplies the raw."""
+    raw = 'a-random-nonce'
+    hashed = hashlib.sha256(raw.encode()).hexdigest()
+    token = _make_token(signing_key, nonce=hashed)
+
+    identity = _verify(token, signing_key, expected_nonce=raw)
+
+    assert identity.subject == '001234.abcdef.5678'
+
+
+def test_rejects_a_mismatched_nonce(signing_key):
+    """A replayed token carries someone else's nonce."""
+    token = _make_token(
+        signing_key, nonce=hashlib.sha256(b'the-real-nonce').hexdigest()
+    )
+
+    with pytest.raises(AppleIdentityError):
+        _verify(token, signing_key, expected_nonce='a-different-nonce')
+
+
+def test_rejects_a_nonce_token_when_the_caller_supplies_none(signing_key):
+    """
+    Otherwise nonce checking is opt-out by omission: a replayer would just
+    drop the raw nonce from the request and sail through.
+    """
+    token = _make_token(
+        signing_key, nonce=hashlib.sha256(b'the-real-nonce').hexdigest()
+    )
+
+    with pytest.raises(AppleIdentityError):
+        _verify(token, signing_key)
+
+
+def test_normalises_apple_string_booleans(signing_key):
+    """Apple sends these as JSON booleans on some flows and strings on others."""
+    token = _make_token(signing_key, email_verified=True, is_private_email=True)
+
+    identity = _verify(token, signing_key)
+
+    assert identity.email_verified is True
+    assert identity.is_private_email is True
+
+
+def test_treats_a_missing_email_as_absent(signing_key):
+    """Apple omits the claim on some re-authorizations; that is not an error here."""
+    token = _make_token(signing_key, email=None)
+
+    identity = _verify(token, signing_key)
+
+    assert identity.email is None


### PR DESCRIPTION
## Summary

- The iOS app cannot reach the App Store without Sign in with Apple (Guideline 4.8), and the API had no path that would accept an Apple token. Apple signs with its own keys, at its own JWKS endpoint, under a different issuer, so this is a **parallel verification path**, not another entry in the Google audience list.
- `app/auth/apple_identity.py` verifies signature, issuer, audience, expiry and nonce. Apple's keys are fetched and cached rather than pinned, because Apple rotates them without notice; `PyJWKClient` refetches on an unseen `kid`, which is what makes rotation a non-event rather than an outage.
- **Account resolution keys on Apple's `sub`, not email.** A user who turns off private relay, or whose token stops carrying an address, lands back in the same account. Email is not stable enough to be an identity key here.
- **Google-then-Apple lands in one account, not two.** When Apple gives a real verified address that already belongs to an account, the Apple subject is stamped onto it. Private relay addresses are deliberately never linked by email: a relay is minted per app, so a match could only ever be false.
- Nonce is checked whenever the token carries one, and the raw value must be supplied. Without that rule a replayer could opt out of the check simply by omitting the nonce from the request.
- **No change to the Google flow, the password flow, or any existing route.** `users.apple_sub` is nullable, so every existing account is unaffected and no backfill is needed.

Two things beyond the issue as written, both defensive:

- **`cryptography` is now pinned explicitly** in `requirements/base.txt`. PyJWT needs it to verify RS256 and it was only present transitively via `google-auth`. Signature verification should not rest on a dependency an unrelated package could drop.

  Pinning it immediately surfaced a pre-existing problem: **the transitive install was sitting on 49.0.0, which carries CVE-2026-69247 (HIGH)**. Trivy only scans `requirements/*.txt`, so naming the package there is what made an exposure the repo already had visible. Pinned at **50.0.0**, where it is fixed; full suite passes on it and Apple's JWKS still verifies.
- **A 409 guard before account creation.** The relay-collision case would otherwise hit the unique index and turn a policy decision into a 500.

### One bug found while building this

Emails in this database are stored **mixed case** (`Dylan.Obrien.a76b951c@zoho.com`). The first implementation lowercased the Apple address before matching, so the lookup missed the very account it was trying to link to and silently created a duplicate. That is precisely the account split this change exists to prevent, and it only surfaced because the linking test asserted on the user id rather than on a 200. Both sides now compare case-insensitively.

Worth knowing separately: `google_login` also matches email exactly, and only gets away with it because Google happens to return lowercase. Not changed here.

## Test plan

- [x] `pytest` - **1132 passed**. 19 new: 11 unit in `tests/unit/apple_identity_test.py`, 8 integration in `tests/integration/router_auth_test.py`.
- [x] The unit tests sign **real tokens with real RSA keypairs** and verify them through the real code path, stubbing only the network fetch. Covered: valid token, forged signature from a key Apple never published, wrong audience, wrong issuer, expired token, unconfigured audience list, matching nonce, mismatched nonce, nonce omitted by the caller, Apple's string-vs-boolean claim quirk, missing email.
- [x] Integration tests cover the routing decisions: creates on first sign-in, links to an existing account by verified email, refuses to link a private relay address, finds the account by subject when the email disappears, 401 on unknown subject with no email, 401 on invalid credential, 503 when unconfigured, 403 against the invite allowlist.
- [x] **Migration verified against real Postgres**, not just SQLite: `task migrate` up, `alembic downgrade -1`, then up again. `\d users` confirms the `apple_sub` column and the `ix_users_apple_sub` unique index.
- [x] **Verified against the local dev stack**: `POST http://localhost:8000/v1/auth/apple` returns `503 {"message":"Apple sign-in is not configured"}`, since dev sets no `APPLE_CLIENT_ID`.
- [x] **Verified against Apple for real**: fetched the live JWKS at `https://appleid.apple.com/auth/keys` (6 RS256 keys), and confirmed a forged token carrying an unpublished `kid` is refused cleanly rather than raising.

## Checklist

- [x] Branch named `feat/…`
- [x] New module has a test file in this PR
- [x] Per-domain change checked - not a per-domain change; this is auth, which has no movies/TV/books/games split
- [ ] CI green (lint + tests) - first run is on this PR; `black`, `pylint` 10.00/10 and the full suite pass locally
- [x] No secrets committed
- [x] `openapi.json` and the Postman collection regenerated, as the pre-commit hook requires

## Deployment note

This ships inert. `/v1/auth/apple` returns 503 until `APPLE_CLIENT_ID` is set on an environment, so merging and deploying changes nothing for existing users. QA and prod need that variable added in `druthers-infra` before the iOS button works, the same way `GOOGLE_CLIENT_ID` is set today.

Closes #418.
