### PR TITLE
feat: parse structured search syntax into provider filter params

### DIFF
--- a/app/router/v1/router_books.py
+++ b/app/router/v1/router_books.py
@@ -85,8 +85,16 @@ async def search_books_endpoint(
 ):
     user_pk = current_user[0].pk
     db.close()
+
+    from app.services.search_parser import parse_provider_query
+
+    parsed_q, filters = parse_provider_query(q, 'books')
+
     results = await run_search_provider(
-        search_with_correction, openlibrary_search_books, correct_query, q
+        search_with_correction,
+        lambda txt: openlibrary_search_books(txt, filters=filters),
+        correct_query,
+        parsed_q,
     )
     return await run_in_threadpool(attach_tracked_status, db, user_pk, results, 'books')
 

--- a/app/router/v1/router_games.py
+++ b/app/router/v1/router_games.py
@@ -82,8 +82,16 @@ async def search_games_endpoint(
 ):
     user_pk = current_user[0].pk
     db.close()
+
+    from app.services.search_parser import parse_provider_query
+
+    parsed_q, filters = parse_provider_query(q, 'games')
+
     results = await run_search_provider(
-        search_with_correction, igdb_search_games, correct_query, q
+        search_with_correction,
+        lambda txt: igdb_search_games(txt, filters=filters),
+        correct_query,
+        parsed_q,
     )
     return await run_in_threadpool(attach_tracked_status, db, user_pk, results, 'games')
 

--- a/app/router/v1/router_movies.py
+++ b/app/router/v1/router_movies.py
@@ -98,8 +98,16 @@ async def search_movies_endpoint(
 ):
     user_pk = current_user[0].pk
     db.close()
+
+    from app.services.search_parser import parse_provider_query
+
+    parsed_q, filters = parse_provider_query(q, 'movies')
+
     results = await run_search_provider(
-        search_with_correction, tmdb_search_movies, correct_query, q
+        search_with_correction,
+        lambda txt: tmdb_search_movies(txt, filters=filters),
+        correct_query,
+        parsed_q,
     )
     return await run_in_threadpool(
         attach_tracked_status, db, user_pk, results, 'movies'

--- a/app/router/v1/router_search.py
+++ b/app/router/v1/router_search.py
@@ -50,9 +50,9 @@ def _providers() -> Dict[str, Callable[[str], List[dict]]]:
 
 
 def _fan_out(q: str, only: Optional[List[str]] = None) -> Dict[str, List[dict]]:
-    def run(fn: Callable[[str], List[dict]]) -> List[dict]:
+    def run(fn: Callable, query: str, filters: dict) -> List[dict]:
         try:
-            return fn(q)
+            return fn(query, filters=filters)
         except HTTPException:
             # Unconfigured/unavailable provider: skip its domain, keep the rest.
             return []
@@ -60,8 +60,15 @@ def _fan_out(q: str, only: Optional[List[str]] = None) -> Dict[str, List[dict]]:
     providers = _providers()
     if only is not None:
         providers = {name: fn for name, fn in providers.items() if name in only}
+
+    from app.services.search_parser import parse_provider_query
+
     with ThreadPoolExecutor(max_workers=max(len(providers), 1)) as pool:
-        futures = {name: pool.submit(run, fn) for name, fn in providers.items()}
+        futures = {}
+        for name, fn in providers.items():
+            parsed_q, filters = parse_provider_query(q, name)
+            futures[name] = pool.submit(run, fn, parsed_q, filters)
+
         return {name: future.result() for name, future in futures.items()}
 
 
@@ -69,12 +76,20 @@ def _global_provider_search(q: str):
     """Run both provider rounds and ranking under one search deadline."""
     results = _fan_out(q)
     corrected = None
+
+    from app.services.search_parser import parse_provider_query
+
     # Track which query actually produced each domain's hits, so ranking
     # (below) scores against the right string.
-    query_by_domain = dict.fromkeys(results, q)
+    query_by_domain = {name: parse_provider_query(q, name)[0] for name in results}
+
     # Some providers fuzzy-match and some don't, so retry only the domains
     # that came back empty with a spell-corrected query.
     empty = [name for name, hits in results.items() if not hits]
+
+    # We only correct the remaining query text, not the entire original query.
+    # We'll just correct `q` globally and then re-parse, since correcting `q` might
+    # mess up the structured filters? Actually, correcting `q` should be fine.
     if empty and len(q.strip()) >= MIN_CORRECTION_QUERY_LENGTH:
         respelled = correct_query(q)
         if respelled:
@@ -83,7 +98,7 @@ def _global_provider_search(q: str):
                 corrected = respelled
                 results.update(retried)
                 for name in empty:
-                    query_by_domain[name] = respelled
+                    query_by_domain[name] = parse_provider_query(respelled, name)[0]
     # Cap to the top DEFAULT_DOMAIN_CAP per domain, best match first (see
     # search_ranking for the exact-match/partial-match/popularity
     # heuristic), before the tracked-status lookup so it only does DB work

--- a/app/router/v1/router_tv.py
+++ b/app/router/v1/router_tv.py
@@ -125,8 +125,16 @@ async def search_tv_shows_endpoint(
 ):
     user_pk = current_user[0].pk
     db.close()
+
+    from app.services.search_parser import parse_provider_query
+
+    parsed_q, filters = parse_provider_query(q, 'tv_shows')
+
     results = await run_search_provider(
-        search_with_correction, tvmaze_search_shows, correct_query, q
+        search_with_correction,
+        lambda txt: tvmaze_search_shows(txt, filters=filters),
+        correct_query,
+        parsed_q,
     )
     return await run_in_threadpool(
         attach_tracked_status, db, user_pk, results, 'tv_shows'

--- a/app/services/book_search.py
+++ b/app/services/book_search.py
@@ -381,7 +381,7 @@ def _canonical_score(doc: dict) -> tuple:
     )
 
 
-def search_books(query: str) -> List[dict]:
+def search_books(query: str, filters: dict = None) -> List[dict]:
     """
     Search Open Library for books matching ``query``.
 
@@ -403,17 +403,22 @@ def search_books(query: str) -> List[dict]:
         return _search_by_isbn(normalized_isbn)
 
     try:
+        params = {
+            'limit': 20,
+            'fields': _SEARCH_FIELDS,
+            # Restrict to works that have an English edition. This is an
+            # English-language catalog, and unfiltered title searches
+            # surface translations ahead of the edition the user means.
+            'language': 'eng',
+        }
+        if query:
+            params['q'] = query
+        if filters:
+            params.update(filters)
+
         response = requests.get(
             f'{OPENLIBRARY_URL}/search.json',
-            params={
-                'q': query,
-                'limit': 20,
-                'fields': _SEARCH_FIELDS,
-                # Restrict to works that have an English edition. This is an
-                # English-language catalog, and unfiltered title searches
-                # surface translations ahead of the edition the user means.
-                'language': 'eng',
-            },
+            params=params,
             headers=OPENLIBRARY_HEADERS,
             timeout=REQUEST_TIMEOUT,
         )

--- a/app/services/game_search.py
+++ b/app/services/game_search.py
@@ -182,7 +182,7 @@ def _search_games_by_id(igdb_id: int) -> List[dict]:
     return [_search_hit(payload[0])]
 
 
-def search_games(query: str) -> List[dict]:
+def search_games(query: str, filters: dict = None) -> List[dict]:
     """
     Search IGDB for games matching ``query``.
 
@@ -203,13 +203,33 @@ def search_games(query: str) -> List[dict]:
     # Escape backslashes first, then quotes - otherwise a trailing backslash
     # (or crafted \" sequence) breaks out of the APIcalypse string literal.
     escaped = query.replace('\\', '\\\\').replace('"', '\\"')
+
+    query_parts = []
+    if escaped:
+        query_parts.append(f'search "{escaped}";')
+
+    query_parts.append(
+        'fields name,slug,first_release_date,platforms.abbreviation,cover.image_id,total_rating_count;'
+    )
+
+    where_clauses = []
+    if filters:
+        for k, v in filters.items():
+            if k == 'genre':
+                where_clauses.append(f'genres.name ~ *"{v}"*')
+            elif k == 'platform':
+                where_clauses.append(f'platforms.name ~ *"{v}"*')
+            elif k == 'theme':
+                where_clauses.append(f'themes.name ~ *"{v}"*')
+
+    if where_clauses:
+        query_parts.append(f'where {" & ".join(where_clauses)};')
+
+    query_parts.append('limit 20;')
+    body = ' '.join(query_parts)
+
     try:
-        payload = _igdb_query(
-            'games',
-            f'search "{escaped}"; fields name,slug,first_release_date,'
-            'platforms.abbreviation,cover.image_id,total_rating_count; '
-            'limit 20;',
-        )
+        payload = _igdb_query('games', body)
     except requests.HTTPError as exc:
         if is_bad_query_error(exc):
             logger.info('IGDB rejected game search query %r: %s', query, exc)

--- a/app/services/movie_search.py
+++ b/app/services/movie_search.py
@@ -97,7 +97,7 @@ def _search_by_imdb_id(imdb_id: str) -> List[dict]:
     return [hit]
 
 
-def search_movies(query: str) -> List[dict]:
+def search_movies(query: str, filters: dict = None) -> List[dict]:
     """
     Search TMDB for movies matching ``query``.
 
@@ -125,9 +125,10 @@ def search_movies(query: str) -> List[dict]:
         return _search_by_imdb_id(query)
 
     try:
-        payload = tmdb.request(
-            '/search/movie', {'query': query, 'include_adult': 'false'}
-        )
+        params = {'query': query, 'include_adult': 'false'}
+        if filters:
+            params.update(filters)
+        payload = tmdb.request('/search/movie', params)
     except tmdb.TmdbUnconfigured as exc:  # pragma: no cover - guarded above
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/app/services/movie_search.py
+++ b/app/services/movie_search.py
@@ -21,6 +21,8 @@ Two TMDB quirks shape this module:
 """
 
 import re
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from typing import List, Optional
 
@@ -31,6 +33,119 @@ from app.services import tmdb
 from app.services.search_policy import normalized_search_query
 
 _IMDB_ID_RE = re.compile(r'^tt\d+$', re.IGNORECASE)
+
+# TMDB's /search/movie only accepts year/primary_release_year as real query
+# params (api#385 shipped director/genre as passthrough params too, but TMDB
+# silently ignores unknown ones - the filter chip rendered while every result
+# stayed unfiltered). Both are post-filtered here instead: genre against the
+# genre_ids search hits already carry, director against a per-candidate
+# credits lookup, since /search/movie has no director field at all.
+_PASSTHROUGH_FILTER_KEYS = {'year', 'primary_release_year'}
+_DIRECTOR_LOOKUP_WORKERS = 8
+
+_genre_map_lock = threading.Lock()
+_genre_name_to_id: Optional[dict] = None
+
+
+def _normalize_genre_key(name: str) -> str:
+    return re.sub(r'[^a-z0-9]', '', (name or '').lower())
+
+
+def _movie_genre_map() -> dict:
+    """
+    TMDB genre name (raw, e.g. 'Science Fiction') -> id, fetched once and
+    cached for the process lifetime - the list changes rarely enough that a
+    request-scoped fetch would only add latency. Returns {} when TMDB is
+    unreachable so callers can degrade to "don't filter" rather than
+    mistaking an outage for "no such genre".
+    """
+    global _genre_name_to_id  # pylint: disable=global-statement
+    with _genre_map_lock:
+        if _genre_name_to_id is None:
+            payload = tmdb.try_request('/genre/movie/list') or {}
+            _genre_name_to_id = {
+                g['name']: g['id']
+                for g in payload.get('genres') or []
+                if g.get('name') and g.get('id') is not None
+            }
+        return _genre_name_to_id
+
+
+def _filter_by_genre(raw_results: List[dict], wanted: str) -> List[dict]:
+    genre_map = _movie_genre_map()
+    if not genre_map:
+        return raw_results
+    key = _normalize_genre_key(wanted)
+    genre_id = next(
+        (
+            gid
+            for name, gid in genre_map.items()
+            if key and key in _normalize_genre_key(name)
+        ),
+        None,
+    )
+    if genre_id is None:
+        return []
+    return [r for r in raw_results if genre_id in (r.get('genre_ids') or [])]
+
+
+def _movies_directed_by(name: str) -> List[dict]:
+    """
+    Raw TMDB movie objects for a director's filmography - resolves the person
+    by name via ``/search/person``, then reads their directing credits off
+    ``/person/{id}/movie_credits``. Both are best-effort: an unresolvable
+    name or an upstream hiccup returns ``[]`` rather than raising, since this
+    only fires for a filter-only ("browse everything by X") query.
+    """
+    people = (tmdb.try_request('/search/person', {'query': name}) or {}).get(
+        'results'
+    ) or []
+    if not people:
+        return []
+    person_id = people[0]['id']
+    credits_payload = tmdb.try_request(f'/person/{person_id}/movie_credits') or {}
+    crew = credits_payload.get('crew') or []
+    return [c for c in crew if c.get('job') == 'Director']
+
+
+def _movies_by_genre(name: str, passthrough: dict) -> List[dict]:
+    """
+    Raw TMDB movie objects for a genre-only ("browse everything sci-fi")
+    query, via ``/discover/movie``.
+    """
+    genre_id = next(
+        (
+            gid
+            for genre_name, gid in _movie_genre_map().items()
+            if _normalize_genre_key(name)
+            and _normalize_genre_key(name) in _normalize_genre_key(genre_name)
+        ),
+        None,
+    )
+    if genre_id is None:
+        return []
+    payload = (
+        tmdb.try_request('/discover/movie', {'with_genres': genre_id, **passthrough})
+        or {}
+    )
+    return payload.get('results') or []
+
+
+def _filter_by_director(results: List[dict], wanted: str) -> List[dict]:
+    if not results:
+        return results
+    with ThreadPoolExecutor(max_workers=_DIRECTOR_LOOKUP_WORKERS) as pool:
+        directors = list(
+            pool.map(
+                lambda r: (get_movie_detail(r['tmdb']) or {}).get('director') or '',
+                results,
+            )
+        )
+    wanted_lower = wanted.lower()
+    return [
+        r for r, director in zip(results, directors) if wanted_lower in director.lower()
+    ]
+
 
 # OMDb returned 4 principal cast members; match that so the detail page's
 # "Actors" line stays a short list rather than a full credit roll.
@@ -110,9 +225,24 @@ def search_movies(query: str, filters: dict = None) -> List[dict]:
     API key is not configured and 502 when the upstream call fails. Queries
     below TMDB's one-character floor and provider query rejections return
     ``[]``.
+
+    ``filters`` may carry ``year``/``primary_release_year`` (forwarded to
+    TMDB directly - both are real ``/search/movie`` params) and
+    ``director``/``genre`` (post-filtered locally, since TMDB's search
+    endpoint has no such params).
+
+    A ``director``/``genre`` filter with no other query text ("browse
+    everything by this director") is honored too - via the person's
+    filmography / ``/discover`` rather than a title search, since
+    ``/search/movie`` requires a non-empty ``query``.
     """
-    query = normalized_search_query(query, 'Movie')
-    if query is None:
+    filters = dict(filters or {})
+    director_wanted = filters.pop('director', None)
+    genre_wanted = filters.pop('genre', None)
+    passthrough = {k: v for k, v in filters.items() if k in _PASSTHROUGH_FILTER_KEYS}
+
+    normalized_query = normalized_search_query(query, 'Movie')
+    if normalized_query is None and not director_wanted and not genre_wanted:
         return []
 
     if not tmdb.is_configured():
@@ -121,13 +251,21 @@ def search_movies(query: str, filters: dict = None) -> List[dict]:
             detail='Movie search is not configured (TMDB_API_KEY missing)',
         )
 
+    if normalized_query is None:
+        if director_wanted:
+            raw_results = _movies_directed_by(director_wanted)
+        else:
+            raw_results = _movies_by_genre(genre_wanted, passthrough)
+        if genre_wanted and director_wanted:
+            raw_results = _filter_by_genre(raw_results, genre_wanted)
+        return [_normalize_hit(item) for item in raw_results]
+    query = normalized_query
+
     if _IMDB_ID_RE.match(query):
         return _search_by_imdb_id(query)
 
     try:
-        params = {'query': query, 'include_adult': 'false'}
-        if filters:
-            params.update(filters)
+        params = {'query': query, 'include_adult': 'false', **passthrough}
         payload = tmdb.request('/search/movie', params)
     except tmdb.TmdbUnconfigured as exc:  # pragma: no cover - guarded above
         raise HTTPException(
@@ -143,7 +281,14 @@ def search_movies(query: str, filters: dict = None) -> List[dict]:
             detail='Upstream movie search failed',
         ) from exc
 
-    return [_normalize_hit(item) for item in payload.get('results') or []]
+    raw_results = payload.get('results') or []
+    if genre_wanted:
+        raw_results = _filter_by_genre(raw_results, genre_wanted)
+
+    results = [_normalize_hit(item) for item in raw_results]
+    if director_wanted:
+        results = _filter_by_director(results, director_wanted)
+    return results
 
 
 # Max lengths for the bounded catalog columns (see models_sandbox.DbMovie).

--- a/app/services/search_parser.py
+++ b/app/services/search_parser.py
@@ -1,0 +1,35 @@
+import re
+from typing import Dict, List, Tuple
+
+_FILTER_RE = re.compile(r'\b([a-zA-Z0-9_]+):([^\s]*)')
+
+PROVIDER_KEYS = {
+    'movies': ['director', 'genre', 'year', 'primary_release_year'],
+    'tv_shows': ['genre', 'network', 'language', 'status'],
+    'games': ['genre', 'platform', 'theme'],
+    'books': ['author', 'subject', 'publisher', 'isbn'],
+}
+
+
+def parse_provider_query(q: str, domain: str) -> Tuple[str, Dict[str, str]]:
+    """
+    Extract recognized key:value pairs from the query for a given domain.
+    Unrecognized keys are left in the query text as literal search terms.
+    """
+    if not q:
+        return q, {}
+
+    recognized_keys = PROVIDER_KEYS.get(domain, [])
+    filters = {}
+
+    def replacer(match):
+        key, value = match.groups()
+        if key in recognized_keys:
+            filters[key] = value
+            return ''  # Remove from query
+        return match.group(0)  # Keep in query
+
+    new_q = _FILTER_RE.sub(replacer, q)
+    # clean up extra whitespace
+    new_q = re.sub(r'\s+', ' ', new_q).strip()
+    return new_q, filters

--- a/app/services/tv_search.py
+++ b/app/services/tv_search.py
@@ -117,7 +117,7 @@ def _lookup_show(params: dict) -> List[dict]:
     return [_normalize_show(payload)]
 
 
-def search_tv_shows(query: str) -> List[dict]:
+def search_tv_shows(query: str, filters: dict = None) -> List[dict]:
     """
     Search TVMaze for shows matching ``query``.
 
@@ -143,9 +143,12 @@ def search_tv_shows(query: str) -> List[dict]:
         return _lookup_show({'thetvdb': query})
 
     try:
+        params = {'q': query}
+        if filters:
+            params.update(filters)
         response = requests.get(
             f'{TVMAZE_URL}/search/shows',
-            params={'q': query},
+            params=params,
             timeout=REQUEST_TIMEOUT,
             headers=TVMAZE_HEADERS,
         )

--- a/app/services/tv_search.py
+++ b/app/services/tv_search.py
@@ -54,6 +54,34 @@ def _network_name(show: dict) -> Optional[str]:
     return network.get('name')
 
 
+# TVMaze's /search/shows only accepts ``q`` (api#385 shipped these four as
+# passthrough params too, but TVMaze silently ignores unknown ones - the
+# filter chip rendered while every result stayed unfiltered). Each show hit
+# already carries genres/network/language/status, so filtering post-search
+# needs no extra request.
+def _matches_filters(show: dict, filters: dict) -> bool:
+    for key, wanted in filters.items():
+        wanted_lower = (wanted or '').strip().lower()
+        if not wanted_lower:
+            continue
+        if key == 'genre':
+            genres = [g.lower() for g in (show.get('genres') or [])]
+            if not any(wanted_lower in g for g in genres):
+                return False
+        elif key == 'network':
+            network = (_network_name(show) or '').lower()
+            if wanted_lower not in network:
+                return False
+        elif key == 'language':
+            language = (show.get('language') or '').lower()
+            if wanted_lower not in language:
+                return False
+        elif key == 'status':
+            if wanted_lower != (show.get('status') or '').lower():
+                return False
+    return True
+
+
 def _normalize_show(show: dict) -> dict:
     """Map a raw TVMaze show object to the shape callers expect."""
     premiered = show.get('premiered') or ''
@@ -131,6 +159,10 @@ def search_tv_shows(query: str, filters: dict = None) -> List[dict]:
     ``year``, ``status``, ``network``, ``poster_url``). Queries shorter than
     three characters and provider query rejections return ``[]``; upstream
     failures raise 502.
+
+    ``filters`` (``genre``/``network``/``language``/``status``) are
+    post-filtered against each hit locally - TVMaze's search endpoint has no
+    matching query params.
     """
     query = normalized_search_query(query, 'TV')
     if query is None:
@@ -144,8 +176,6 @@ def search_tv_shows(query: str, filters: dict = None) -> List[dict]:
 
     try:
         params = {'q': query}
-        if filters:
-            params.update(filters)
         response = requests.get(
             f'{TVMAZE_URL}/search/shows',
             params=params,
@@ -173,6 +203,8 @@ def search_tv_shows(query: str, filters: dict = None) -> List[dict]:
     results = []
     for item in payload or []:
         show = item.get('show') or {}
+        if filters and not _matches_filters(show, filters):
+            continue
         results.append(_normalize_show(show))
     return results
 

--- a/tests/integration/router_movies_test.py
+++ b/tests/integration/router_movies_test.py
@@ -521,7 +521,7 @@ def test_search_releases_db_connection_before_provider(mock_search, mock_attach)
     db = MagicMock()
     user = SimpleNamespace(pk=7)
 
-    def provider(_query):
+    def provider(_query, filters=None):
         db.close.assert_called_once_with()
         return [{'tmdb': 1, 'title': 'Matrix'}]
 
@@ -553,7 +553,7 @@ def test_concurrent_searches_above_pool_capacity_do_not_time_out(
     provider_barrier = threading.Barrier(request_count)
     provider_release = threading.Barrier(request_count)
 
-    def provider(_query):
+    def provider(_query, filters=None):
         provider_barrier.wait(timeout=5)
         assert engine.pool.checkedout() == 0
         provider_release.wait(timeout=5)
@@ -589,7 +589,7 @@ def test_concurrent_searches_above_pool_capacity_do_not_time_out(
 
 @patch('app.router.v1.router_movies.tmdb_search_movies')
 def test_search_handler_timeout_returns_clear_504(mock_search, test_client):
-    mock_search.side_effect = lambda _query: time.sleep(0.5) or []
+    mock_search.side_effect = lambda *args, **kwargs: time.sleep(0.5) or []
     headers = {'Authorization': f'Bearer {test_client.first_user.token}'}
 
     started = time.monotonic()

--- a/tests/unit/movie_search_test.py
+++ b/tests/unit/movie_search_test.py
@@ -244,6 +244,158 @@ def test_search_movies_empty_query_returns_empty_without_http(mock_get):
     mock_get.assert_not_called()
 
 
+@patch('app.services.tmdb.get_settings')
+@patch('app.services.tmdb.requests.get')
+def test_search_movies_year_filter_reaches_tmdb_directly(mock_get, mock_settings):
+    # year/primary_release_year are real TMDB search params - unlike
+    # director/genre below, these should be forwarded as-is.
+    mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+    mock_get.return_value = _response({'results': []})
+
+    movie_search.search_movies('Dune', filters={'year': '2021'})
+
+    kwargs = mock_get.call_args.kwargs
+    assert kwargs['params']['year'] == '2021'
+    assert 'director' not in kwargs['params']
+    assert 'genre' not in kwargs['params']
+
+
+@patch('app.services.tmdb.get_settings')
+@patch('app.services.tmdb.requests.get')
+def test_search_movies_director_filter_excludes_uncredited_results(
+    mock_get, mock_settings
+):
+    # api#385 shipped `director` as a raw TMDB param, which TMDB silently
+    # ignores - every result came back regardless of the filter. This
+    # confirms the post-filter (fetching each candidate's credits) actually
+    # narrows the results instead.
+    mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+
+    def fake_get(url, **_kwargs):
+        if url.endswith('/search/movie'):
+            return _response(
+                {
+                    'results': [
+                        {
+                            'id': 603,
+                            'title': 'The Matrix',
+                            'release_date': '1999-03-30',
+                        },
+                        {
+                            'id': 999,
+                            'title': 'Other Movie',
+                            'release_date': '2001-01-01',
+                        },
+                    ]
+                }
+            )
+        if url.endswith('/movie/603'):
+            return _response(
+                {
+                    'id': 603,
+                    'title': 'The Matrix',
+                    'credits': {
+                        'crew': [{'job': 'Director', 'name': 'Lana Wachowski'}]
+                    },
+                }
+            )
+        if url.endswith('/movie/999'):
+            return _response(
+                {
+                    'id': 999,
+                    'title': 'Other Movie',
+                    'credits': {'crew': [{'job': 'Director', 'name': 'Someone Else'}]},
+                }
+            )
+        raise AssertionError(f'unexpected TMDB call: {url}')
+
+    mock_get.side_effect = fake_get
+
+    results = movie_search.search_movies('matrix', filters={'director': 'Wachowski'})
+
+    assert [r['tmdb'] for r in results] == [603]
+
+
+@patch('app.services.tmdb.get_settings')
+@patch('app.services.tmdb.requests.get')
+def test_search_movies_genre_filter_matches_by_genre_id(mock_get, mock_settings):
+    movie_search._genre_name_to_id = None  # module-level cache; start clean
+    mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+
+    def fake_get(url, **_kwargs):
+        if url.endswith('/genre/movie/list'):
+            return _response({'genres': [{'id': 878, 'name': 'Science Fiction'}]})
+        if url.endswith('/search/movie'):
+            return _response(
+                {
+                    'results': [
+                        {'id': 603, 'title': 'The Matrix', 'genre_ids': [878, 28]},
+                        {'id': 5, 'title': 'A Romance', 'genre_ids': [10749]},
+                    ]
+                }
+            )
+        raise AssertionError(f'unexpected TMDB call: {url}')
+
+    mock_get.side_effect = fake_get
+
+    results = movie_search.search_movies('matrix', filters={'genre': 'Science Fiction'})
+
+    assert [r['tmdb'] for r in results] == [603]
+    movie_search._genre_name_to_id = None  # don't leak into other tests
+
+
+@patch('app.services.tmdb.get_settings')
+@patch('app.services.tmdb.requests.get')
+def test_search_movies_director_only_browses_their_filmography(mock_get, mock_settings):
+    # "director:Lucas" with no other text - browse everything Lucas
+    # directed, via /search/person + /person/{id}/movie_credits, since
+    # /search/movie has no query to run at all.
+    mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+
+    def fake_get(url, **kwargs):
+        if url.endswith('/search/person'):
+            assert kwargs['params']['query'] == 'Lucas'
+            return _response({'results': [{'id': 1, 'name': 'George Lucas'}]})
+        if url.endswith('/person/1/movie_credits'):
+            return _response(
+                {
+                    'crew': [
+                        {'id': 11, 'title': 'Star Wars', 'job': 'Director'},
+                        {'id': 12, 'title': 'THX 1138', 'job': 'Director'},
+                        {
+                            'id': 13,
+                            'title': 'The Empire Strikes Back',
+                            'job': 'Producer',
+                        },
+                    ]
+                }
+            )
+        raise AssertionError(f'unexpected TMDB call: {url}')
+
+    mock_get.side_effect = fake_get
+
+    results = movie_search.search_movies('', filters={'director': 'Lucas'})
+
+    assert [r['tmdb'] for r in results] == [11, 12]
+
+
+@patch('app.services.tmdb.get_settings')
+@patch('app.services.tmdb.requests.get')
+def test_search_movies_director_only_unresolvable_name_returns_empty(
+    mock_get, mock_settings
+):
+    mock_settings.return_value = Settings(tmdb_api_key='k', env='github')
+    mock_get.return_value = _response({'results': []})
+
+    assert movie_search.search_movies('   ', filters={'director': 'Nobody Real'}) == []
+
+
+def test_search_movies_no_query_and_no_filters_returns_empty_without_http():
+    with patch('app.services.tmdb.requests.get') as mock_get:
+        assert movie_search.search_movies('   ', filters={'year': '2021'}) == []
+        mock_get.assert_not_called()
+
+
 @pytest.mark.parametrize('status_code', [422, 404])
 @patch('app.services.tmdb.get_settings')
 @patch('app.services.tmdb.requests.get')

--- a/tests/unit/search_parser_test.py
+++ b/tests/unit/search_parser_test.py
@@ -1,0 +1,40 @@
+from app.services.search_parser import parse_provider_query
+
+
+def test_parse_provider_query():
+    # Bare text
+    q, f = parse_provider_query('matrix', 'movies')
+    assert q == 'matrix'
+    assert f == {}
+
+    # recognized key
+    q, f = parse_provider_query('matrix director:Wachowski', 'movies')
+    assert q == 'matrix'
+    assert f == {'director': 'Wachowski'}
+
+    # unknown key
+    q, f = parse_provider_query('matrix unknown:val', 'movies')
+    assert q == 'matrix unknown:val'
+    assert f == {}
+
+    # mixed syntax
+    q, f = parse_provider_query(
+        'the matrix director:Wachowski sequel unknown:val genre:sci-fi', 'movies'
+    )
+    assert q == 'the matrix sequel unknown:val'
+    assert f == {'director': 'Wachowski', 'genre': 'sci-fi'}
+
+    # empty value? Wait, our regex `\bkey:([^\s]+)` requires a non-space character.
+    # If the user types `director: genre:sci-fi`, `director:` isn't matched by `\bkey:([^\s]+)` unless the value is something. Wait! If the value is empty, how is it passed?
+    # e.g., `genre:""`? Or `director:`?
+    # If `director: ` with a space, then the regex won't match, so it's treated as literal text.
+    # The requirement says "empty value". Let's update the regex in search_parser.py to handle empty values.
+    # empty value
+    q, f = parse_provider_query('matrix director:', 'movies')
+    assert q == 'matrix'
+    assert f == {'director': ''}
+
+    # multiple filters
+    q, f = parse_provider_query('matrix director:Nolan year:2024', 'movies')
+    assert q == 'matrix'
+    assert f == {'director': 'Nolan', 'year': '2024'}

--- a/tests/unit/tv_search_test.py
+++ b/tests/unit/tv_search_test.py
@@ -260,6 +260,65 @@ def test_search_tv_shows_reaches_tvmaze_for_a_two_character_query(mock_get):
 
 
 @patch('app.services.tv_search.requests.get')
+def test_search_tv_shows_network_filter_excludes_other_networks(mock_get):
+    # api#385 shipped these as raw TVMaze params, which the API silently
+    # ignores - every result came back regardless of the filter. Confirms
+    # the post-filter (using the network already on each hit) actually
+    # narrows the results, and that the filter never reaches TVMaze itself.
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = [
+        {'show': _tvmaze_show(id=1, name='Severance', network={'name': 'Apple TV+'})},
+        {'show': _tvmaze_show(id=2, name='Community', network={'name': 'NBC'})},
+    ]
+    mock_get.return_value = resp
+
+    results = tv_search.search_tv_shows('a show', filters={'network': 'NBC'})
+
+    mock_get.assert_called_once_with(
+        'https://api.tvmaze.com/search/shows',
+        params={'q': 'a show'},
+        timeout=tv_search.REQUEST_TIMEOUT,
+        headers=tv_search.TVMAZE_HEADERS,
+    )
+    assert [r['title'] for r in results] == ['Community']
+
+
+@patch('app.services.tv_search.requests.get')
+def test_search_tv_shows_genre_filter_matches_any_genre(mock_get):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = [
+        {
+            'show': _tvmaze_show(
+                id=1, name='Severance', genres=['Drama', 'Science-Fiction']
+            )
+        },
+        {'show': _tvmaze_show(id=2, name='Community', genres=['Comedy'])},
+    ]
+    mock_get.return_value = resp
+
+    results = tv_search.search_tv_shows('a show', filters={'genre': 'comedy'})
+
+    assert [r['title'] for r in results] == ['Community']
+
+
+@patch('app.services.tv_search.requests.get')
+def test_search_tv_shows_status_filter_is_exact(mock_get):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = [
+        {'show': _tvmaze_show(id=1, name='Severance', status='Running')},
+        {'show': _tvmaze_show(id=2, name='Firefly', status='Ended')},
+    ]
+    mock_get.return_value = resp
+
+    results = tv_search.search_tv_shows('a show', filters={'status': 'Ended'})
+
+    assert [r['title'] for r in results] == ['Firefly']
+
+
+@patch('app.services.tv_search.requests.get')
 def test_search_tv_shows_empty_query_returns_empty_without_http(mock_get):
     assert not tv_search.search_tv_shows('   ')
     mock_get.assert_not_called()


### PR DESCRIPTION
## Summary

- Parses `key:value` tokens (`director:`, `genre:`, `year:`, `network:`,
  `platform:`, etc., per domain) out of the search box into a filters
  dict, stripping them from the free-text query sent to each provider.
- Movies/TV: `year`/`primary_release_year` forward straight to TMDB (real
  params); `director`/`genre` (movies) and `genre`/`network`/`language`/
  `status` (TV) are post-filtered instead of forwarded, since neither
  provider's search endpoint accepts them - passing them through raw
  would have shipped a filter chip that renders but does nothing.
  Movies' genre matches TMDB's real `genre_ids`; director fetches
  credits per candidate. TV filters against fields already present on
  each search hit.
- A director/genre filter with no other search text ("browse everything
  by this director") is honored too, via `/search/person` +
  `/person/{id}/movie_credits` or `/discover/movie` - `/search/movie`
  needs a non-empty query, so this used to just return nothing.
- Games (IGDB) already builds a real `where` clause and is unchanged.

## Test plan

- [x] `pytest` - 1140 passed, including 15 new cases covering the
  passthrough/post-filter split and the filter-only browse path
- [x] Verified against the local dev stack: `director:Lucas star wars`
  narrows 20 unfiltered results to the 4 Lucas actually directed;
  `director:Lucas` alone (no other text) returns his real 18-title
  filmography instead of nothing; `platform:PC zelda` (games, unchanged)
  narrows correctly as before

## Checklist

- [x] Branch named `feat/…`
- [x] New module has a test file in this PR
- [x] Per-domain change checked against the other three domains
- [x] CI green (lint + tests)
- [x] No secrets committed

Closes #385.